### PR TITLE
Copy license texts from txt files of a designated folder

### DIFF
--- a/cdxev/__main__.py
+++ b/cdxev/__main__.py
@@ -186,6 +186,13 @@ def create_amend_parser(
         help="Path to the SBOM file.",
         type=Path,
     )
+    parser.add_argument(
+        "--license-path",
+        metavar="<license-path>",
+        help="Path to the SBOM file.",
+        type=str,
+        default="",
+    )
     add_output_argument(parser)
 
     parser.set_defaults(cmd_handler=invoke_amend)
@@ -207,7 +214,7 @@ def create_merge_parser(
     parser.add_argument(
         "--from-folder",
         metavar="<from-folder>",
-        help="Path to a folder with sboms to be merged",
+        help="Path to a folder with txt-files containing license texts to be copied in the SBOM",
         type=Path,
     )
     add_output_argument(parser)
@@ -447,7 +454,7 @@ def create_build_public_bom_parser(
 
 def invoke_amend(args: argparse.Namespace) -> int:
     sbom, _ = read_sbom(args.input)
-    amend(sbom)
+    amend(sbom, args.license_path)
     write_sbom(sbom, args.output)
     return _STATUS_OK
 

--- a/cdxev/amend/command.py
+++ b/cdxev/amend/command.py
@@ -2,7 +2,7 @@ import logging
 
 from cdxev.auxiliary.sbomFunctions import walk_components
 
-from .operations import Operation
+from .operations import Operation, ReplaceLicenseNameWithId
 
 __operations: list[Operation] = []
 logger = logging.getLogger(__name__)
@@ -17,12 +17,16 @@ def register_operation(operation: Operation) -> None:
     __operations.append(operation)
 
 
-def run(sbom: dict) -> None:
+def run(sbom: dict, path_to_license_folder: str = "") -> None:
     """
     Runs the amend command on an SBOM. The SBOM is modified in-place.
 
     :param dict sbom: The SBOM model.
+    :param str path_to_license_folder: Path to a folder with license texts
     """
+    for operation in __operations:
+        if type(operation) is ReplaceLicenseNameWithId:
+            operation.change_path_to_license_folder(path_to_license_folder)
     _prepare(sbom)
     _metadata(sbom)
     walk_components(sbom, _do_amend, skip_meta=True)

--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -128,7 +128,9 @@ class InferSupplier(Operation):
     scheme.
     """
 
-    def handle_component(self, component: dict) -> None:
+    def handle_component(
+        self, component: dict, path_to_license_folder: str = ""
+    ) -> None:
         if (
             ("supplier" in component)
             or ("publisher" in component)
@@ -178,10 +180,22 @@ class ReplaceLicenseNameWithId(Operation):
     )
     list_of_license_names = json.loads(list_of_license_names_string)
 
+    def __init__(self) -> None:
+        self.path_to_license_folder = ""
+
+    def change_path_to_license_folder(self, path_to_license_folder: str) -> None:
+        self.path_to_license_folder = path_to_license_folder
+
     def handle_metadata(self, metadata: dict) -> None:
         if "component" not in metadata:
             return
-        replace_license_name_with_id(metadata["component"], self.list_of_license_names)
+        replace_license_name_with_id(
+            metadata["component"],
+            self.list_of_license_names,
+            self.path_to_license_folder,
+        )
 
     def handle_component(self, component: dict) -> None:
-        replace_license_name_with_id(component, self.list_of_license_names)
+        replace_license_name_with_id(
+            component, self.list_of_license_names, self.path_to_license_folder
+        )

--- a/cdxev/amend/replace_license_name_with_id.py
+++ b/cdxev/amend/replace_license_name_with_id.py
@@ -4,6 +4,7 @@
 ##################################################
 
 from typing import Sequence
+import os
 
 
 def find_license_id(license_name: str, license_namelist: Sequence[dict]) -> str:
@@ -35,7 +36,9 @@ def find_license_id(license_name: str, license_namelist: Sequence[dict]) -> str:
     return license_id
 
 
-def replace_license_name_with_id(component: dict, license_name_id_list: list) -> dict:
+def replace_license_name_with_id(
+    component: dict, license_name_id_list: list, path_to_license_folder: str = ""
+) -> dict:
     """
     Adds the id of a license to a component and removes te name, if the name
     is in the list of licenses provided
@@ -70,4 +73,19 @@ def replace_license_name_with_id(component: dict, license_name_id_list: list) ->
         if id_found:
             current_license["id"] = id_found
             current_license.pop("name")
+        elif path_to_license_folder:
+            license_text = get_license_text_from_folder(
+                current_license.get("name", ""), path_to_license_folder
+            )
+            current_license["text"] = license_text
     return component
+
+
+def get_license_text_from_folder(license_name: str, path_to_license_folder: str) -> str:
+    file_name = license_name + ".txt"
+    for licenses_text_file in os.listdir(path_to_license_folder):
+        if licenses_text_file == file_name:
+            with open(os.path.join(path_to_license_folder, file_name)) as f:
+                license_text = f.read()
+            return license_text
+    return ""

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -20,6 +20,20 @@ Currently, the command adds or modifies the following pieces of information:
   * *externalReferences* of type *vcs*
 * Generates a *bom-ref* for components which don't have one, yet. The *bom-ref* will be a GUID.
 
+### Copy license texts from files
+
+The programm can copy the text describing a license from specific file in the SBOM, if a license name is given and no id can be assigned.  
+
+This is done by submitting the path to a folder containing txt-files with the license text via the command `--license-path`.
+If a license with name X and no matching id is found, the program will search in the provided folder for the file X.txt and copy its context in the `text` field.
+The txt-files in the folder must follow the naming convention name.txt, for example MIT.txt.
+
+    cdx-ev amend bom.json" --license-path=C:\Documents\licenses
+
+If a `text` field already exists, its content will be replaced.
+
+
+
 ## merge
 
 This command requires at least two input files, but can accept an arbitrary number.

--- a/tests/auxiliary/licenses/license_name.txt
+++ b/tests/auxiliary/licenses/license_name.txt
@@ -1,0 +1,1 @@
+The text describing a license.

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -357,6 +357,74 @@ class GetLicenseTextFromFile(unittest.TestCase):
         )
         self.assertEqual(license_text, "The text describing a license.")
 
+    def test_replace_license_text(self) -> None:
+        path_to_license_folder = "tests/auxiliary/licenses"
+        with open(
+            (path_to_folder_with_test_sboms + "example_list_with_license_names.json"),
+            "r",
+            encoding="utf-8-sig",
+        ) as my_file:
+            list_of_license_names = json.load(my_file)
+        component = {
+            "type": "library",
+            "bom-ref": "pkg:nuget/some name@1.3.3",
+            "publisher": "some publisher",
+            "name": "some name",
+            "version": "1.3.2",
+            "cpe": "",
+            "description": "some description",
+            "scope": "required",
+            "hashes": [{"alg": "SHA-512", "content": "5F6996E38A31861449A493B938"}],
+            "licenses": [{"license": {"name": "license_name", "text": "other text"}}],
+            "copyright": "Copyright 2000-2021 some name Contributors",
+            "purl": "pkg:nuget/some name@1.3.2",
+        }
+        ntl.replace_license_name_with_id(
+            component, list_of_license_names, path_to_license_folder
+        )
+        print(component)
+        self.assertEqual(
+            component["licenses"][0]["license"]["text"],  # type: ignore
+            "The text describing a license.",
+        )
+
+    def test_add_license_text(self) -> None:
+        path_to_license_folder = "tests/auxiliary/licenses"
+        with open(
+            (path_to_folder_with_test_sboms + "example_list_with_license_names.json"),
+            "r",
+            encoding="utf-8-sig",
+        ) as my_file:
+            list_of_license_names = json.load(my_file)
+        component = {
+            "type": "library",
+            "bom-ref": "pkg:nuget/some name@1.3.3",
+            "publisher": "some publisher",
+            "name": "some name",
+            "version": "1.3.2",
+            "cpe": "",
+            "description": "some description",
+            "scope": "required",
+            "hashes": [{"alg": "SHA-512", "content": "5F6996E38A31861449A493B938"}],
+            "licenses": [
+                {
+                    "license": {
+                        "name": "license_name",
+                    }
+                }
+            ],
+            "copyright": "Copyright 2000-2021 some name Contributors",
+            "purl": "pkg:nuget/some name@1.3.2",
+        }
+        ntl.replace_license_name_with_id(
+            component, list_of_license_names, path_to_license_folder
+        )
+        print(component)
+        self.assertEqual(
+            component["licenses"][0]["license"]["text"],  # type: ignore
+            "The text describing a license.",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -349,5 +349,14 @@ class TestReplaceLicenseNameWithIdFunctions(unittest.TestCase):
         self.assertTrue(compare_sboms(sbom, sbom_with_id))
 
 
+class GetLicenseTextFromFile(unittest.TestCase):
+    def test_get_license_text_from_folder(self) -> None:
+        path_to_license_folder = "tests/auxiliary/licenses"
+        license_text = ntl.get_license_text_from_folder(
+            "license_name", path_to_license_folder
+        )
+        self.assertEqual(license_text, "The text describing a license.")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -91,6 +91,22 @@ class TestAmendCommand(unittest.TestCase):
             result = main()
             self.assertEqual(result, _STATUS_OK)
 
+    @unittest.mock.patch("cdxev.__main__.read_sbom")
+    def test_get_amend_license_from_folder(self, mock_read: unittest.mock.Mock) -> None:
+        path = pathlib.Path(__file__).parent.resolve()
+        with unittest.mock.patch(
+            "sys.argv",
+            [
+                "",
+                "amend",
+                "fake_bom.cdx.json",
+                str(("--license-path=" + path.as_posix() + "/auxiliary/licenses")),
+            ],
+        ):
+            mock_read.return_value = ({}, "json")
+            result = main()
+            self.assertEqual(result, _STATUS_OK)
+
 
 class TestMergeCommand(unittest.TestCase):
     @unittest.mock.patch("cdxev.__main__.read_sbom")


### PR DESCRIPTION
Copy license texts from a specific txtx file in a designated folder, if no id for a name is found.