### PR TITLE
feat: amend adds supplier if only publisher or author are given

### DIFF
--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -131,18 +131,12 @@ class InferSupplier(Operation):
     def handle_component(
         self, component: dict, path_to_license_folder: str = ""
     ) -> None:
-        if (
-            ("supplier" in component)
-        ):
+        if "supplier" in component:
             return
-        if (
-            ("publisher" in component)
-        ):
+        if "publisher" in component:
             component["supplier"] = component["publisher"]
             return
-        if (
-            ("author" in component)
-        ):
+        if "author" in component:
             component["supplier"] = component["author"]
             return
 

--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -135,10 +135,10 @@ class InferSupplier(Operation):
         if "supplier" in component:
             return
         if "publisher" in component:
-            component["supplier"] = component["publisher"]
+            component["supplier"] = {"name": component["publisher"]}
             return
         if "author" in component:
-            component["supplier"] = component["author"]
+            component["supplier"] = {"name": component["author"]}
             return
 
         if "externalReferences" in component:

--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -133,9 +133,17 @@ class InferSupplier(Operation):
     ) -> None:
         if (
             ("supplier" in component)
-            or ("publisher" in component)
-            or ("author" in component)
         ):
+            return
+        if (
+            ("publisher" in component)
+        ):
+            component["supplier"] = component["publisher"]
+            return
+        if (
+            ("author" in component)
+        ):
+            component["supplier"] = component["author"]
             return
 
         if "externalReferences" in component:

--- a/cdxev/auxiliary/schema/bom-1.3-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.3-custom.schema.json
@@ -224,6 +224,7 @@
         "name": {
           "type": "string",
           "title": "Name",
+          "minLength": 1,
           "description": "The name of the organization",
           "examples": [
             "Example Inc."

--- a/cdxev/auxiliary/schema/bom-1.4-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.4-custom.schema.json
@@ -262,6 +262,7 @@
         "name": {
           "type": "string",
           "title": "Name",
+          "minLength": 1,
           "description": "The name of the organization",
           "examples": [
             "Example Inc."

--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -361,6 +361,7 @@
         "name": {
           "type": "string",
           "title": "Name",
+          "minLength": 1,
           "description": "The name of the organization",
           "examples": [
             "Example Inc."

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -14,7 +14,7 @@ Currently, the command adds or modifies the following pieces of information:
 
 * If the SBOM metadata doesn't specify an *author* from the SBOM, it will be set to `{"name": "automated"}`.
 * The *compositions* array will be overwritten with a new one which specifies a single *incomplete* aggregate. This aggregate contains all components, including the metadata component.
-* If a component does not have an *supplier*, the tool will try to infer the supplier from the fields (in order of precedence):
+* If a component does not have a *supplier*, the tool will try to infer the supplier from the fields (in order of precedence):
   * *publisher*
   * *author*
 * If a component does not have an *author*, *publisher* or *supplier*, the tool will try to infer the supplier from (in order of precedence):

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -14,6 +14,9 @@ Currently, the command adds or modifies the following pieces of information:
 
 * If the SBOM metadata doesn't specify an *author* from the SBOM, it will be set to `{"name": "automated"}`.
 * The *compositions* array will be overwritten with a new one which specifies a single *incomplete* aggregate. This aggregate contains all components, including the metadata component.
+* If a component does not have an *supplier*, the tool will try to infer the supplier from the fields (in order of precedence):
+  * *publisher*
+  * *author*
 * If a component does not have an *author*, *publisher* or *supplier*, the tool will try to infer the supplier from (in order of precedence):
   * *externalReferences* of type *website*
   * *externalReferences* of type *issue-tracker*

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -148,8 +148,7 @@ class InferSupplierTestCase(AmendTestCase):
 
     def test_author_already_present(self) -> None:
         component = {"author": "x"}
-        expected = copy.deepcopy(component)
-        expected["supplier"] = "x"
+        expected = {"author": "x", "supplier": {"name": "x"}}
         self.operation.handle_component(component)
         self.assertDictEqual(expected, component)
 
@@ -159,7 +158,7 @@ class InferSupplierTestCase(AmendTestCase):
         self.operation.handle_component(component)
         self.assertDictEqual(expected, component)
 
-    def test_publisher_already_present(self) -> None:
+    def test_publisher_is_preferred_to_author(self) -> None:
         component = {"author": "x", "publisher": "y"}
         expected = copy.deepcopy(component)
         expected["supplier"] = "y"

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -160,8 +160,7 @@ class InferSupplierTestCase(AmendTestCase):
 
     def test_publisher_is_preferred_to_author(self) -> None:
         component = {"author": "x", "publisher": "y"}
-        expected = copy.deepcopy(component)
-        expected["supplier"] = "y"
+        expected = {"author": "x", "publisher": "y", "supplier": {"name": "y"}}
         self.operation.handle_component(component)
         self.assertDictEqual(expected, component)
 

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -58,8 +58,7 @@ class CommandIntegrationTestCase(AmendTestCase):
     def test_suppliers(self) -> None:
         run_amend(self.sbom_fixture)
         components = self.sbom_fixture["components"]
-
-        self.assertNotIn("supplier", components[0])
+        self.assertIn("supplier", components[0])
         self.assertDictEqual(
             {
                 "name": "Some Vendor Inc.",
@@ -150,6 +149,7 @@ class InferSupplierTestCase(AmendTestCase):
     def test_author_already_present(self) -> None:
         component = {"author": "x"}
         expected = copy.deepcopy(component)
+        expected["supplier"] = "x"
         self.operation.handle_component(component)
         self.assertDictEqual(expected, component)
 
@@ -162,6 +162,7 @@ class InferSupplierTestCase(AmendTestCase):
     def test_publisher_already_present(self) -> None:
         component = {"author": "x", "publisher": "y"}
         expected = copy.deepcopy(component)
+        expected["supplier"] = "y"
         self.operation.handle_component(component)
         self.assertDictEqual(expected, component)
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -432,7 +432,6 @@ class TestValidateComponents(unittest.TestCase):
             sbom = get_test_sbom()
             sbom["specVersion"] = spec_version
             sbom["components"][0]["supplier"] = {"name": ""}
-            sbom["components"][0]["copyright"] = "FE"
             issues = validate_test(sbom)
             self.assertEqual(
                 search_for_word_issues("'name' should be non-empty", issues), True

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -427,6 +427,17 @@ class TestValidateComponents(unittest.TestCase):
                 search_for_word_issues("'version' should be non-empty", issues), True
             )
 
+    def test_supplier_empty(self) -> None:
+        for spec_version in list_of_spec_versions:
+            sbom = get_test_sbom()
+            sbom["specVersion"] = spec_version
+            sbom["components"][0]["supplier"] = {"name": ""}
+            sbom["components"][0]["copyright"] = "FE"
+            issues = validate_test(sbom)
+            self.assertEqual(
+                search_for_word_issues("'name' should be non-empty", issues), True
+            )
+
 
 class TestValidateDependencies(unittest.TestCase):
     def test_dependencies_missing(self) -> None:


### PR DESCRIPTION
The amend function now adds the supplier field to components, if only publisher or author are given.