### PR TITLE
refactor: expiration_field _no_longer_mandatory_in_spec_1.5

### DIFF
--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -1032,7 +1032,7 @@
               "description": "The timestamp indicating when the current license expires (if applicable)."
             }
           },
-        "required": ["licenseTypes","licensor","licensee","expiration"]
+        "required": ["licenseTypes","licensor","licensee"]
         },
         "properties": {
           "type": "array",

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -558,27 +558,6 @@ class TestValidateUseSchema15(unittest.TestCase):
             issues = validate_test(sbom)
             self.assertEqual(search_for_word_issues("licensee", issues), True)
 
-    def test_no_expiration(self) -> None:
-        for spec_version in list_of_spec_versions_containing_licensing:
-            sbom = get_test_sbom()
-            sbom["specVersion"] = spec_version
-            sbom["components"][0]["licenses"] = [
-                {
-                    "license": {
-                        "name": "some_name",
-                        "url": "https://spdx.org/licenses/GPL-2.0-only.html",
-                        "text": {"content": "some text"},
-                        "licensing": {
-                            "licenseTypes": ["other"],
-                            "licensor": {"individual": {"name": "Something"}},
-                            "licensee": {"organization": {"name": "Acme.ing"}},
-                        },
-                    }
-                }
-            ]
-            issues = validate_test(sbom)
-            self.assertEqual(issues, ["no issue"])
-
     def test_no_licenseTypes(self) -> None:
         for spec_version in list_of_spec_versions_containing_licensing:
             sbom = get_test_sbom()
@@ -722,6 +701,15 @@ class TestValidateUseSchema15(unittest.TestCase):
             self.assertEqual(
                 search_for_word_issues("'content' must not be empty", issues), True
             )
+
+    def test_no_components_no_dependencies(self) -> None:
+        for spec_version in list_of_specVersions:
+            sbom = get_test_sbom()
+            sbom["specVersion"] = spec_version
+            sbom.pop("components")
+            sbom.pop("dependencies")
+            issues = validate_test(sbom)
+            self.assertEqual(issues, ["no issue"])
 
 
 class TestValidateUseSchemaType(unittest.TestCase):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -723,17 +723,6 @@ class TestValidateUseSchema15(unittest.TestCase):
                 search_for_word_issues("'content' must not be empty", issues), True
             )
 
-    def test_no_components_no_dependencies(
-        self,
-    ) -> None:
-        for spec_version in list_of_specVersions:
-            sbom = get_test_sbom()
-            sbom["specVersion"] = spec_version
-            sbom.pop("components")
-            sbom.pop("dependencies")
-            issues = validate_test(sbom)
-            self.assertEqual(issues, ["no issue"])
-
 
 class TestValidateUseSchemaType(unittest.TestCase):
     @unittest.skipUnless("CI" in os.environ, "running only in CI")

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -702,7 +702,9 @@ class TestValidateUseSchema15(unittest.TestCase):
                 search_for_word_issues("'content' must not be empty", issues), True
             )
 
-    def test_no_components_no_dependencies(self) -> None:
+    def test_no_components_no_dependencies(
+        self,
+    ) -> None:
         for spec_version in list_of_specVersions:
             sbom = get_test_sbom()
             sbom["specVersion"] = spec_version

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -577,7 +577,7 @@ class TestValidateUseSchema15(unittest.TestCase):
                 }
             ]
             issues = validate_test(sbom)
-            self.assertEqual(search_for_word_issues("expiration", issues), True)
+            self.assertEqual(issues, ["no issue"])
 
     def test_no_licenseTypes(self) -> None:
         for spec_version in list_of_spec_versions_containing_licensing:


### PR DESCRIPTION
The expiration field is no longer madatory as pertaining to issue 5940264