### PR TITLE
Refactor filename generation and validation

### DIFF
--- a/cdxev/auxiliary/filename_gen.py
+++ b/cdxev/auxiliary/filename_gen.py
@@ -1,0 +1,111 @@
+import typing as t
+from datetime import datetime, timezone
+import logging
+import re
+
+from dateutil.parser import isoparse
+
+
+logger = logging.getLogger(__name__)
+
+
+def generate_filename(sbom: dict) -> str:
+    """
+    Generates a filename for the given SBOM.
+
+    If the SBOM doesn't contain any of the required metadata to generate a unique filename,
+    it will default to ``bom.json``.
+
+    :param dict sbom: The SBOM to generate a filename for.
+
+    :return: The filename.
+    """
+    name = sbom.get("metadata", {}).get("component", {}).get("name")
+    version = sbom.get("metadata", {}).get("component", {}).get("version")
+    timestamp_str: t.Union[str, None] = sbom.get("metadata", {}).get("timestamp")
+
+    if not name and not version and not timestamp_str:
+        return "bom.json"
+
+    try:
+        timestamp = isoparse(timestamp_str)  # type: ignore # because type errors are caught below
+    except (ValueError, TypeError):
+        logger.info(
+            "SBOM has no or an unparsable timestamp. Using current time in filename."
+        )
+        timestamp = datetime.now(timezone.utc)
+
+    name = name or "unknown"
+    timestamp_str = _timestamp_to_utc_str(timestamp)
+
+    components = [name]
+    if version:
+        components.append(version)
+
+    components.append(timestamp_str)
+
+    return "_".join(components) + ".cdx.json"
+
+
+def generate_validation_pattern(sbom: dict) -> str:
+    """
+    Creates a regular expression which can be used to validate the filename of the given SBOM.
+
+    The pattern allows the following variants of the filename:
+
+    * ``bom.json`` is always an allowed name.
+    * ``<name>_[<version>_][<hash>_<timestamp>|<hash>|<timestamp>].cdx.json``, where
+      * ``<name>`` == ``metadata.component.name``, if it exists, otherwise ``unknown``.
+      * ``<version>`` MUST be present, if and only if ``metadata.component.version`` exists.
+      * ``<hash>`` is ``metadata.component.hashes[x].content`` for
+
+    :param dict sbom: The SBOM whose filename to validate.
+
+    :return: A regular expression.
+    """
+    regex = "bom\\.json|"
+
+    name = sbom.get("metadata", {}).get("component", {}).get("name", "unknown")
+    regex += re.escape(name) + "_"
+
+    version = sbom.get("metadata", {}).get("component", {}).get("version")
+    if version:
+        regex += re.escape(version) + "_"
+
+    timestamp = sbom.get("metadata", {}).get("timestamp")
+    if timestamp:
+        try:
+            timestamp_regex = _timestamp_to_utc_str(isoparse(timestamp))
+        except:
+            timestamp_regex = "[0-9]{8}T[0-9]{6}"
+    else:
+        timestamp_regex = "[0-9]{8}T[0-9]{6}"
+
+    hashes = [
+        hash["content"]
+        for hash in sbom.get("metadata", {}).get("component", {}).get("hashes", [])
+    ]
+    hashes = "(" + "|".join(hashes) + ")"
+
+    if not hashes:
+        regex += timestamp_regex
+    else:
+        regex += f"({hashes}|{hashes}_{timestamp_regex}|{timestamp_regex})"
+
+    regex += "\\.cdx\\.json"
+
+    return regex
+
+
+def _timestamp_to_utc_str(timestamp: datetime) -> str:
+    """
+    Converts a timestamp to the string format used in filenames.
+
+    The timestamp will be converted to UTC if it isn't already.
+
+    :param datetime timestamp: The timestamp to convert.
+
+    :return: The string representation for use in the filename.
+    """
+    timestamp = timestamp.astimezone(timezone.utc)
+    return timestamp.strftime("%Y%m%dT%H%M%S")

--- a/cdxev/auxiliary/filename_gen.py
+++ b/cdxev/auxiliary/filename_gen.py
@@ -86,7 +86,7 @@ def generate_validation_pattern(sbom: dict) -> str:
     ]
     hashes_regex = "(" + "|".join(hashes) + ")"
 
-    if not hashes_regex:
+    if not hashes:
         regex += timestamp_regex
     else:
         regex += f"({hashes_regex}|{hashes_regex}_{timestamp_regex}|{timestamp_regex})"

--- a/cdxev/auxiliary/filename_gen.py
+++ b/cdxev/auxiliary/filename_gen.py
@@ -59,7 +59,7 @@ def generate_validation_pattern(sbom: dict) -> str:
     * ``<name>_[<version>_][<hash>_<timestamp>|<hash>|<timestamp>].cdx.json``, where
       * ``<name>`` == ``metadata.component.name``, if it exists, otherwise ``unknown``.
       * ``<version>`` MUST be present, if and only if ``metadata.component.version`` exists.
-      * ``<hash>`` is ``metadata.component.hashes[x].content`` for
+      * ``<hash>`` == ``metadata.component.hashes[x].content`` for any index x.
 
     :param dict sbom: The SBOM whose filename to validate.
 

--- a/cdxev/auxiliary/filename_gen.py
+++ b/cdxev/auxiliary/filename_gen.py
@@ -124,7 +124,7 @@ def _sanitize(s: str) -> str:
     * Filter out any characters which aren't alphanumeric, spaces, dashes, periods or underscores.
     * Strip any leading or trailing non-alphanumeric characters.
 
-    :param str value: The original string.
+    :param str s: The original string.
 
     :return: A representation safe for use as a filename.
     """

--- a/cdxev/auxiliary/filename_gen.py
+++ b/cdxev/auxiliary/filename_gen.py
@@ -1,10 +1,9 @@
-import typing as t
-from datetime import datetime, timezone
 import logging
 import re
+import typing as t
+from datetime import datetime, timezone
 
 from dateutil.parser import isoparse
-
 
 logger = logging.getLogger(__name__)
 

--- a/cdxev/auxiliary/filename_gen.py
+++ b/cdxev/auxiliary/filename_gen.py
@@ -84,12 +84,12 @@ def generate_validation_pattern(sbom: dict) -> str:
         hash["content"]
         for hash in sbom.get("metadata", {}).get("component", {}).get("hashes", [])
     ]
-    hashes = "(" + "|".join(hashes) + ")"
+    hashes_regex = "(" + "|".join(hashes) + ")"
 
-    if not hashes:
+    if not hashes_regex:
         regex += timestamp_regex
     else:
-        regex += f"({hashes}|{hashes}_{timestamp_regex}|{timestamp_regex})"
+        regex += f"({hashes_regex}|{hashes_regex}_{timestamp_regex}|{timestamp_regex})"
 
     regex += "\\.cdx\\.json"
 

--- a/cdxev/validator/helper.py
+++ b/cdxev/validator/helper.py
@@ -1,6 +1,4 @@
 import json
-import re
-from datetime import datetime
 from importlib import resources
 from pathlib import Path
 
@@ -51,70 +49,6 @@ def load_spdx_schema() -> dict:
     )
     with path_to_embedded_schema.open() as f:
         return json.load(f)
-
-
-def validate_filename(sbom: dict, file: Path, filename_regex: str) -> bool:
-    if filename_regex:
-        valid_filename = re.search(filename_regex, file.name)
-    else:
-        try:
-            iso_timestamp = datetime.fromisoformat(
-                sbom.get("metadata", {}).get("timestamp", "").replace("Z", "+00:00")
-            ).strftime("%Y%m%dT%H%M%S")
-        except ValueError:
-            return False
-        name_of_component = (
-            sbom.get("metadata", {}).get("component", {}).get("name", "")
-        )
-        version_of_component = (
-            sbom.get("metadata", {}).get("component", {}).get("version", "")
-        )
-        hashes_of_component = (
-            sbom.get("metadata", {}).get("component", {}).get("hashes", [])
-        )
-        if not name_of_component or not version_of_component:
-            return False
-
-        component_hash = (
-            "([a-fA-F0-9]{32}|"
-            + "[a-fA-F0-9]{40}|"
-            + "[a-fA-F0-9]{64}|"
-            + "[a-fA-F0-9]{96}|"
-            + "[a-fA-F0-9]{128}"
-        )
-        if len(hashes_of_component) > 0:
-            filename_splitted = file.name.replace(".cdx.json", "").split("_")
-            for hash in hashes_of_component:
-                component_first_hash = [
-                    filename_part
-                    for filename_part in filename_splitted
-                    if hash["content"].startswith(filename_part)
-                ]
-            if component_first_hash:
-                component_hash = "(" + component_first_hash[0]
-            # if hash in file name is not one of the hashes in metadata, file name can not be valid
-            else:
-                return False
-        valid_filename = re.search(
-            "^"
-            + re.escape(name_of_component)
-            + "_"
-            + re.escape(version_of_component)
-            + "_("
-            + component_hash
-            + ")_"
-            + iso_timestamp
-            + ")|"
-            + component_hash
-            + "|"
-            + iso_timestamp
-            + ")(.cdx.json)$|^bom.json$",
-            file.name,
-        )
-    if valid_filename is not None:
-        return True
-    else:
-        return False
 
 
 def get_external_schema(schema_path: Path) -> tuple[dict, Path]:

--- a/cdxev/validator/validate.py
+++ b/cdxev/validator/validate.py
@@ -8,7 +8,8 @@ from referencing.jsonschema import DRAFT202012
 
 from cdxev.log import LogMessage
 from cdxev.validator.customreports import GitLabCQReporter, WarningsNgReporter
-from cdxev.validator.helper import load_spdx_schema, open_schema, validate_filename
+from cdxev.validator.helper import load_spdx_schema, open_schema
+from cdxev.auxiliary.filename_gen import generate_validation_pattern
 
 logger = logging.getLogger(__name__)
 
@@ -28,12 +29,15 @@ def validate_sbom(
         sbom_schema, used_schema_path = open_schema(
             sbom, file, schema_type, schema_path
         )
-        valid_filename = validate_filename(sbom, file, filename_regex)
-        if not valid_filename:
-            message = (
-                "SBOM has the mistake: file name is not according to the given regex"
+
+        if not filename_regex:
+            filename_regex = generate_validation_pattern(sbom)
+        if re.fullmatch(filename_regex, file.name) is None:
+            errors.append(
+                f"SBOM has the mistake: \
+                        filename doesn't match regular expression {filename_regex}"
             )
-            errors.append(message)
+
         schema = Resource(
             sbom_schema, specification=DRAFT202012
         )  # type: ignore[call-arg, var-annotated]

--- a/cdxev/validator/validate.py
+++ b/cdxev/validator/validate.py
@@ -6,10 +6,10 @@ from jsonschema import Draft7Validator, FormatChecker
 from referencing import Registry, Resource
 from referencing.jsonschema import DRAFT202012
 
+from cdxev.auxiliary.filename_gen import generate_validation_pattern
 from cdxev.log import LogMessage
 from cdxev.validator.customreports import GitLabCQReporter, WarningsNgReporter
 from cdxev.validator.helper import load_spdx_schema, open_schema
-from cdxev.auxiliary.filename_gen import generate_validation_pattern
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_filename_gen.py
+++ b/tests/test_filename_gen.py
@@ -92,6 +92,14 @@ class FilenameGeneratorTestCase(unittest.TestCase):
         pattern = fn.generate_validation_pattern(self.sbom)
         self.assertIsNotNone(re.fullmatch(pattern, filename))
 
+    def test_name_with_path_separator(self):
+        self.sbom["metadata"]["component"]["name"] = "Te\\st"
+        filename = fn.generate_filename(self.sbom)
+        self.assertEqual("Test_1.0_20000101T123045.cdx.json", filename)
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNotNone(re.fullmatch(pattern, filename))
+
     def test_version_with_underscore(self):
         self.sbom["metadata"]["component"]["version"] = "1.0_build1"
         filename = fn.generate_filename(self.sbom)

--- a/tests/test_filename_gen.py
+++ b/tests/test_filename_gen.py
@@ -1,9 +1,9 @@
-import unittest
-import re
 import datetime as dt
+import re
+import unittest
+from unittest.mock import patch
 
 import cdxev.auxiliary.filename_gen as fn
-from unittest.mock import patch
 
 
 class FilenameGeneratorTestCase(unittest.TestCase):

--- a/tests/test_filename_gen.py
+++ b/tests/test_filename_gen.py
@@ -1,0 +1,126 @@
+import unittest
+import re
+import datetime as dt
+
+import cdxev.auxiliary.filename_gen as fn
+from unittest.mock import patch
+
+
+class FilenameGeneratorTestCase(unittest.TestCase):
+    def setUp(self):
+        self.sbom = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.4",
+            "version": 1,
+            "metadata": {
+                "timestamp": "2000-01-01T12:30:45Z",
+                "component": {
+                    "name": "Test",
+                    "version": "1.0",
+                    "hashes": [
+                        {"alg": "SHA-512", "content": "abcdefg"},
+                        {"alg": "MD5", "content": "1234567890"},
+                    ],
+                },
+            },
+        }
+
+    def test_empty(self):
+        del self.sbom["metadata"]
+        filename = fn.generate_filename(self.sbom)
+        self.assertEqual("bom.json", filename)
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNotNone(re.fullmatch(pattern, filename))
+
+    def test_normal(self):
+        filename = fn.generate_filename(self.sbom)
+        self.assertEqual("Test_1.0_20000101T123045.cdx.json", filename)
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNotNone(re.fullmatch(pattern, filename))
+
+    def test_no_name(self):
+        del self.sbom["metadata"]["component"]["name"]
+        filename = fn.generate_filename(self.sbom)
+        self.assertEqual("unknown_1.0_20000101T123045.cdx.json", filename)
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNotNone(re.fullmatch(pattern, filename))
+
+    def test_no_version(self):
+        del self.sbom["metadata"]["component"]["version"]
+        filename = fn.generate_filename(self.sbom)
+        self.assertEqual("Test_20000101T123045.cdx.json", filename)
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNotNone(re.fullmatch(pattern, filename))
+
+    @patch(f"{fn.__name__}.datetime", wraps=dt.datetime)
+    def test_no_timestamp(self, mock_dt):
+        mock_dt.now.return_value = dt.datetime(
+            1999, 1, 1, 10, 11, 12, tzinfo=dt.timezone.utc
+        )
+
+        del self.sbom["metadata"]["timestamp"]
+        filename = fn.generate_filename(self.sbom)
+        self.assertEqual("Test_1.0_19990101T101112.cdx.json", filename)
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNotNone(re.fullmatch(pattern, filename))
+
+    @patch(f"{fn.__name__}.datetime", wraps=dt.datetime)
+    @patch(f"{fn.__name__}.logger")
+    def test_invalid_timestamp(self, mock_logger, mock_dt):
+        mock_dt.now.return_value = dt.datetime(
+            1999, 1, 1, 10, 11, 12, tzinfo=dt.timezone.utc
+        )
+
+        self.sbom["metadata"]["timestamp"] = "foo"
+        filename = fn.generate_filename(self.sbom)
+        self.assertEqual("Test_1.0_19990101T101112.cdx.json", filename)
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNotNone(re.fullmatch(pattern, filename))
+        mock_logger.info.assert_called_once()
+
+    def test_name_with_underscore(self):
+        self.sbom["metadata"]["component"]["name"] = "Te_ST"
+        filename = fn.generate_filename(self.sbom)
+        self.assertEqual("Te_ST_1.0_20000101T123045.cdx.json", filename)
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNotNone(re.fullmatch(pattern, filename))
+
+    def test_version_with_underscore(self):
+        self.sbom["metadata"]["component"]["version"] = "1.0_build1"
+        filename = fn.generate_filename(self.sbom)
+        self.assertEqual("Test_1.0_build1_20000101T123045.cdx.json", filename)
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNotNone(re.fullmatch(pattern, filename))
+
+    def test_validate_hash_and_timestamp(self):
+        filename = "Test_1.0_abcdefg_20000101T123045.cdx.json"
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNotNone(re.fullmatch(pattern, filename))
+
+    def test_validate_only_hash(self):
+        filename = "Test_1.0_abcdefg.cdx.json"
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNotNone(re.fullmatch(pattern, filename))
+
+    def test_validate_non_existant_hash(self):
+        filename = "Test_1.0_abcdefg.cdx.json"
+        del self.sbom["metadata"]["component"]["hashes"]
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNone(re.fullmatch(pattern, filename))
+
+    def test_validate_wrong_extension_fails(self):
+        filename = "Test_1.0_abcdefg.json"
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNone(re.fullmatch(pattern, filename))

--- a/tests/test_filename_gen.py
+++ b/tests/test_filename_gen.py
@@ -70,6 +70,43 @@ class FilenameGeneratorTestCase(unittest.TestCase):
         self.assertIsNotNone(re.fullmatch(pattern, filename))
 
     @patch(f"{fn.__name__}.datetime", wraps=dt.datetime)
+    def test_only_name(self, mock_dt):
+        mock_dt.now.return_value = dt.datetime(
+            1999, 1, 1, 10, 11, 12, tzinfo=dt.timezone.utc
+        )
+
+        del self.sbom["metadata"]["timestamp"]
+        del self.sbom["metadata"]["component"]["version"]
+        filename = fn.generate_filename(self.sbom)
+        self.assertEqual("Test_19990101T101112.cdx.json", filename)
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNotNone(re.fullmatch(pattern, filename))
+
+    @patch(f"{fn.__name__}.datetime", wraps=dt.datetime)
+    def test_only_version(self, mock_dt):
+        mock_dt.now.return_value = dt.datetime(
+            1999, 1, 1, 10, 11, 12, tzinfo=dt.timezone.utc
+        )
+
+        del self.sbom["metadata"]["timestamp"]
+        del self.sbom["metadata"]["component"]["name"]
+        filename = fn.generate_filename(self.sbom)
+        self.assertEqual("unknown_1.0_19990101T101112.cdx.json", filename)
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNotNone(re.fullmatch(pattern, filename))
+
+    def test_only_timestamp(self):
+        del self.sbom["metadata"]["component"]["name"]
+        del self.sbom["metadata"]["component"]["version"]
+        filename = fn.generate_filename(self.sbom)
+        self.assertEqual("unknown_20000101T123045.cdx.json", filename)
+
+        pattern = fn.generate_validation_pattern(self.sbom)
+        self.assertIsNotNone(re.fullmatch(pattern, filename))
+
+    @patch(f"{fn.__name__}.datetime", wraps=dt.datetime)
     @patch(f"{fn.__name__}.logger")
     def test_invalid_timestamp(self, mock_logger, mock_dt):
         mock_dt.now.return_value = dt.datetime(

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -114,61 +114,6 @@ class OutputTestCase(unittest.TestCase):
             out.update_version(sbom)
             self.assertDictEqual(expected_sbom, sbom)
 
-    def test_generate_empty_filename(self):
-        sbom = self.minimal_sbom
-
-        filename = out.generate_output_filename(sbom)
-
-        self.assertEqual("bom.json", filename)
-
-    def test_generate_filename_from_timestamp(self):
-        sbom = self.minimal_sbom
-        tz = dt.timezone(dt.timedelta(hours=10))
-        timestamp = dt.datetime(2000, 1, 2, 13, 14, 15, 200, tz)
-        sbom["metadata"] = {"timestamp": str(timestamp)}
-
-        filename = out.generate_output_filename(sbom)
-
-        self.assertEqual("unknown_20000102T031415.cdx.json", filename)
-
-    @patch(f"{out.__name__}.datetime", wraps=dt.datetime)
-    @patch(f"{out.__name__}.logger")
-    def test_generate_filename_from_invalid_timestamp(self, mock_logger, mock_dt):
-        sbom = self.minimal_sbom
-        timestamp = dt.datetime(2000, 1, 2, 13, 14, 15, 200, dt.timezone.utc)
-        mock_dt.now.return_value = timestamp
-
-        sbom["metadata"] = {"timestamp": "bla"}
-
-        filename = out.generate_output_filename(sbom)
-
-        self.assertEqual("unknown_20000102T131415.cdx.json", filename)
-        mock_logger.info.assert_called_once()
-
-    @patch(f"{out.__name__}.datetime", wraps=dt.datetime)
-    def test_generate_filename_from_name(self, mock_dt):
-        timestamp = dt.datetime(2000, 1, 2, 13, 14, 15, 200, dt.timezone.utc)
-        mock_dt.now.return_value = timestamp
-
-        sbom = self.minimal_sbom
-        sbom["metadata"] = {"component": {"name": "foobar"}}
-
-        filename = out.generate_output_filename(sbom)
-
-        self.assertEqual("foobar_20000102T131415.cdx.json", filename)
-
-    @patch(f"{out.__name__}.datetime", wraps=dt.datetime)
-    def test_generate_filename_from_name_and_version(self, mock_dt):
-        timestamp = dt.datetime(2000, 1, 2, 13, 14, 15, 200, dt.timezone.utc)
-        mock_dt.now.return_value = timestamp
-
-        sbom = self.minimal_sbom
-        sbom["metadata"] = {"component": {"name": "foobar", "version": "1.2.3"}}
-
-        filename = out.generate_output_filename(sbom)
-
-        self.assertEqual("foobar_1.2.3_20000102T131415.cdx.json", filename)
-
     @patch(f"{out.__name__}.update_timestamp")
     @patch(f"{out.__name__}.update_serial_number")
     @patch(f"{out.__name__}.update_tools")

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -73,7 +73,7 @@ class TestValidateInit(unittest.TestCase):
         filename_regex = "(myfancybom.json)"
         sbom = get_test_sbom()
         issues = validate_test(sbom, filename_regex=filename_regex)
-        self.assertTrue(search_for_word_issues("file name is not according to", issues))
+        self.assertTrue(search_for_word_issues("filename doesn't match", issues))
 
     def test_right_hash_filename(self) -> None:
         sbom = get_test_sbom()
@@ -84,7 +84,7 @@ class TestValidateInit(unittest.TestCase):
         sbom = get_test_sbom()
         sbom["metadata"]["component"]["hashes"][0]["content"] = "1337"
         issues = validate_test(sbom)
-        self.assertTrue(search_for_word_issues("file name is not according to", issues))
+        self.assertTrue(search_for_word_issues("filename doesn't match", issues))
 
     @unittest.skipUnless("CI" in os.environ, "running only in CI")
     def test_custom_schema(self) -> None:


### PR DESCRIPTION
This PR overhauls filename validation so it no longer fails to validate names generated by the tool itself.

In order to avoid similar situations in the future, generation and validation routines are moved into a dedicated module where they live side-by-side and can be changed together.

Unit tests have also been rewritten and moved to a new file. There are two categories of tests for this module:
- Tests which generate a name for an SBOM and validate it immediately. These are intended to find discrepancies between generation and validation.
- Tests which only validate names. These are intended to test the correctness of the validator when faced with names **not** generated by the tool itself.

This was a little more work as expected, especially because during coding I stumbled across a number of edge cases which aren't clearly defined and I wasn't sure how to approach them.  
As a result, I cannot fully rule out breaking changes introduced by this PR, in the sense that some filenames might no longer validate which used to be valid before.
During review, please pay close attention to the tests. They reflect all the special cases I considered and if there's something missing, please let me know.

Closes #99 