### PR TITLE
Introduce pre-commit

### DIFF
--- a/.github/workflows/dependabot-pre-commit.yaml
+++ b/.github/workflows/dependabot-pre-commit.yaml
@@ -1,0 +1,39 @@
+name: Dependabot pre-commit updater
+on: pull_request
+
+permissions:
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/checkout@v4
+        with:
+          # Check out HEAD of source branch. Without this option, the merge commit would be checked out.
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Update .pre-commit-config.yaml
+        id: update-pre-commit
+        run: |
+          # Reduces the output of the metadata step above to a simpler JSON format:
+          # { "<package-1-name>": "<new-version>", ... }
+          export updates=$(yq --null-input 'env(updates) | .[] as $item ireduce ({}; .[$item | .dependencyName] = ($item | .newVersion))' -o json)
+
+          # Goes through the dependencies of the mypy hook in pre-commit config and if any of them have
+          # been updated in this PR, replace the version number with the new version
+          yq --inplace 'env(updates) as $up | (.repos[].hooks[] | select(.id == "mypy").additional_dependencies[] | select(split(">=") | .[0] as $pkg | $up | has ($pkg))) |= (split(">=") | .[0] as $pkg | $pkg + "==" + $up[$pkg])' .pre-commit-config.yaml
+
+          # Commit the changes
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .pre-commit-config.yaml
+          git commit -m "Update additional dependencies for mypy pre-commit hook"
+          git push
+        env:
+          updates: ${{ steps.metadata.outputs.updated-dependencies-json }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+﻿# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+default_language_version:
+    python: python3.11
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: "24.1.1"
+    hooks:
+    -   id: black
+-   repo: https://github.com/PyCQA/flake8
+    rev: "7.0.0"
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: "v1.8.0"
+    hooks:
+    -   id: mypy
+        additional_dependencies:
+        -   types-python-dateutil==2.8.19.20240106
+        -   typing-extensions==4.9.0
+        -   types-jsonschema==4.21.0.20240118
+        files: "cdxev/"
+-   repo: https://github.com/PyCQA/bandit
+    rev: "1.7.7"
+    hooks:
+    -   id: bandit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,11 +22,13 @@ repos:
     rev: "v1.8.0"
     hooks:
     -   id: mypy
+        # List type stub dependencies explicitly, as --install-types should be avoided as per
+        # https://github.com/pre-commit/mirrors-mypy/blob/main/README.md
         additional_dependencies:
         -   types-python-dateutil==2.8.19.20240106
         -   typing-extensions==4.9.0
         -   types-jsonschema==4.21.0.20240118
-        files: "cdxev/"
+        files: "^cdxev/.*\\.py$"
 -   repo: https://github.com/PyCQA/bandit
     rev: "1.7.7"
     hooks:

--- a/cdxev/merge.py
+++ b/cdxev/merge.py
@@ -20,7 +20,7 @@ from cdxev.log import LogMessage
 logger = logging.getLogger(__name__)
 
 
-def merge_components(governing_sbom: dict, sbom_to_be_merged: dict):
+def merge_components(governing_sbom: dict, sbom_to_be_merged: dict) -> t.List[dict]:
     """
     Function that gets two lists of components and merges them unique into one.
 

--- a/cdxev/merge.py
+++ b/cdxev/merge.py
@@ -20,7 +20,7 @@ from cdxev.log import LogMessage
 logger = logging.getLogger(__name__)
 
 
-def merge_components(governing_sbom: dict, sbom_to_be_merged: dict) -> t.List[dict]:
+def merge_components(governing_sbom: dict, sbom_to_be_merged: dict):
     """
     Function that gets two lists of components and merges them unique into one.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -108,6 +108,17 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "cfgv"
+version = "3.4.0"
+description = "Validate configuration and produce human readable error messages."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
+    {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
+]
+
+[[package]]
 name = "click"
 version = "8.1.7"
 description = "Composable command line interface toolkit"
@@ -197,6 +208,17 @@ files = [
 toml = ["tomli"]
 
 [[package]]
+name = "distlib"
+version = "0.3.8"
+description = "Distribution utilities"
+optional = false
+python-versions = "*"
+files = [
+    {file = "distlib-0.3.8-py2.py3-none-any.whl", hash = "sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784"},
+    {file = "distlib-0.3.8.tar.gz", hash = "sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64"},
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.0"
 description = "Backport of PEP 654 (exception groups)"
@@ -209,6 +231,22 @@ files = [
 
 [package.extras]
 test = ["pytest (>=6)"]
+
+[[package]]
+name = "filelock"
+version = "3.13.1"
+description = "A platform independent file lock."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "filelock-3.13.1-py3-none-any.whl", hash = "sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c"},
+    {file = "filelock-3.13.1.tar.gz", hash = "sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e"},
+]
+
+[package.extras]
+docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.24)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
+typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
 name = "flake8"
@@ -236,6 +274,20 @@ files = [
     {file = "fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"},
     {file = "fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f"},
 ]
+
+[[package]]
+name = "identify"
+version = "2.5.33"
+description = "File identification library for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "identify-2.5.33-py2.py3-none-any.whl", hash = "sha256:d40ce5fcd762817627670da8a7d8d8e65f24342d14539c59488dc603bf662e34"},
+    {file = "identify-2.5.33.tar.gz", hash = "sha256:161558f9fe4559e1557e1bff323e8631f6a0e4837f7497767c1782832f16b62d"},
+]
+
+[package.extras]
+license = ["ukkonen"]
 
 [[package]]
 name = "idna"
@@ -446,6 +498,20 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.8.0"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+files = [
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
 name = "packaging"
 version = "23.2"
 description = "Core utilities for Python packages"
@@ -521,6 +587,24 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pre-commit"
+version = "3.6.0"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pre_commit-3.6.0-py2.py3-none-any.whl", hash = "sha256:c255039ef399049a5544b6ce13d135caba8f2c28c3b4033277a788f434308376"},
+    {file = "pre_commit-3.6.0.tar.gz", hash = "sha256:d30bad9abf165f7785c15a21a1f46da7d0677cb00ee7ff4c579fd38922efe15d"},
+]
+
+[package.dependencies]
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+nodeenv = ">=0.11.1"
+pyyaml = ">=5.1"
+virtualenv = ">=20.10.0"
 
 [[package]]
 name = "pycodestyle"
@@ -822,6 +906,22 @@ files = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "69.0.3"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "setuptools-69.0.3-py3-none-any.whl", hash = "sha256:385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05"},
+    {file = "setuptools-69.0.3.tar.gz", hash = "sha256:be1af57fc409f93647f2e8e4573a142ed38724b8cdd389706a867bb4efcf1e78"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -917,6 +1017,26 @@ files = [
 
 [package.extras]
 dev = ["flake8", "flake8-annotations", "flake8-bandit", "flake8-bugbear", "flake8-commas", "flake8-comprehensions", "flake8-continuation", "flake8-datetimez", "flake8-docstrings", "flake8-import-order", "flake8-literal", "flake8-modern-annotations", "flake8-noqa", "flake8-pyproject", "flake8-requirements", "flake8-typechecking-import", "flake8-use-fstring", "mypy", "pep8-naming", "types-PyYAML"]
+
+[[package]]
+name = "virtualenv"
+version = "20.25.0"
+description = "Virtual Python Environment builder"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "virtualenv-20.25.0-py3-none-any.whl", hash = "sha256:4238949c5ffe6876362d9c0180fc6c3a824a7b12b80604eeb8085f2ed7460de3"},
+    {file = "virtualenv-20.25.0.tar.gz", hash = "sha256:bf51c0d9c7dd63ea8e44086fa1e4fb1093a31e963b86959257378aef020e1f1b"},
+]
+
+[package.dependencies]
+distlib = ">=0.3.7,<1"
+filelock = ">=3.12.2,<4"
+platformdirs = ">=3.9.1,<5"
+
+[package.extras]
+docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
+test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
 [[package]]
 name = "webcolors"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,7 @@ upload_to_release = false
 build_command = "pip install poetry && poetry build"
 
 [tool.mypy]
-files = ["cdxev/*"]
-exclude = ["tests/*"]
+packages = "cdxev"
 disallow_untyped_defs = true
 no_error_summary = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ toml = "0.10.2"
 typing-extensions = "4.9.0"
 bandit = "1.7.7"
 isort = "5.13.2"
+pre-commit = "3.6.0"
 
 [build-system]
 requires = ["poetry-core"]
@@ -63,4 +64,3 @@ source = ["cdxev"]
 
 [tool.coverage.report]
 omit = ["*__init__.py*"]
-


### PR DESCRIPTION
Hi guys. Take this PR as a suggestion. Since I've been working on #108 - after a long absence from this project, during which I've forgotten all the tools we used to use - I've noticed how much I missed pre-commit hooks here which simply run all the required linters and formatters for me before I can commit and push bad code.  
Obviously, any problems are caught by the actions so they don't get merged into `main` but personally I still prefer catching them as early as possible, i.e., before committing.

This PR adds a dev dependency on [pre-commit](https://pre-commit.com/) and a configuration file which runs all the same tools on every commit which are also used in `.github/workflows/tests.yml` - with the notable exception of pytest because IMO individual commits should be allowed to fail tests ... and also because there is no pre-commit hook for it.  
Three additional hooks are included because they come by default (but could be removed if unwanted):

- `trailing-whitespace` trims trailing whitespace from lines
- `end-of-file-fixer` makes sure every file ends on a newline
- `check-yaml` syntax-checks any yaml files

Of course, there are some minor trade-offs involved here, which you should be aware of:

- Hooks don't work automatically. Every developer must run `pre-commit install` once after `poetry install` to make them work.
  I see this as a positive, really. It's an opt-in system. If you don't want to use the hooks, just don't run that command.
- It takes a few seconds on every commit for the hooks to run. The delay isn't bad but its there and could be annoying for people who do micro-commits.

So please try it out and decide for yourselves whether you think this is a benefit or not. To do so, follow these steps:

1. Check out this branch locally
2. `poetry install`
3. `pre-commit install` (make sure your local venv is active, obviously, or prefix it with `poetry run`
4. `pre-commit run --all-files`
   This step is for you to see the effect. It runs all hooks an all files in the repository and is not normally required. In normal use, hooks are executed on staged files, when you do a commit. 
   You will see that `trailing-whitespace` and `end-of-file-fixer` fix some files. That's not surprising as up to now there is no system in place to avoid violations of these two rules.

For a second test:

1. Change a type annotation somewhere in a python file which should make mypy complain.
2. Add some whitespace to the end of a line in another file. 
3. `git add`
4. `git commit -m "test"`
   You'll get messages about the errors found (whitespace gets fixed automatically, type annotation doesn't) and the commit will fail.

Very importantly, please also make some experiments using the same tools you normally use for working with git. Pre-commit works very well in a terminal, but I think it could be better integrated into VS Code, for example.

#### About `dependabot-pre-commit.yml`

There is a small technicality which prompted me to add a new github workflow. Pre-commit hooks are run in their own isolated python environments where our project dependencies aren't installed. For mypy this means, that some type stubs are missing and the [`--install-types` command-line switch shouldn't be used](https://github.com/pre-commit/mirrors-mypy/blob/main/README.md).

`.pre-commit-config.yaml` allows us to explicitly specify dependencies which get added to the mypy environment **but** that introduces the burden to keep the versions of these type stubs synchronized with `pyproject.toml`.  
Because my goal is not to cause you guys more work, I've added this workflow which *hopefully* updates `.pre-commit-config.yaml` whenever dependabot updates any of the type packages.

I've had no way to test this workflow locally, so I can't really vouch for its correctness.

#### About 9ca9f3f2d68c793465fe8f1ca2811abec630fe5c

This commit isn't directly related to pre-commit. I only noticed during testing of the hooks that the mypy configuration section in `pyproject.toml` wasn't correct.

The `exclude` field wasn't a regex as expected by mypy and wasn't required anyways.  
The `files` field was overly inclusive. Since all our code is organized in a neat package, we can replace this with `packages`  which is simpler (there are no glob patterns to consider).
Again, I can't test Github Actions locally, so I hope these changes don't cause any trouble. I guess I'll see as soon as I create this PR :wink: