### PR TITLE
fix: Catch error caused by empty-set logic in pattern

### DIFF
--- a/cdxev/auxiliary/schema/bom-1.3-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.3-custom.schema.json
@@ -585,6 +585,7 @@
           },
           "then": {
             "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
+            "required": ["supplier"],
             "dependencies": {
               "supplier": {"properties": {"supplier": {"required": ["name"]}}}
             }

--- a/cdxev/auxiliary/schema/bom-1.3-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.3-custom.schema.json
@@ -250,8 +250,7 @@
             "$ref": "#/definitions/organizationalContact"
           }
         }
-      },
-      "additionalProperties": false
+      }
     },
     "organizationalContact": {
       "type": "object",
@@ -522,6 +521,9 @@
           }
         }
       },
+      "dependencies": {
+        "supplier": {"properties": {"supplier": {"required": ["name"]}}}
+      },
       "allOf": [
         {
           "anyOf": [
@@ -572,15 +574,22 @@
           }
         },
         {
-          "if": {
-            "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
-            "required": ["supplier"]
+          "if":{ 
+            "dependencies": {
+              "supplier": {"properties": {"supplier": {"required": ["name"]}}}
+            }
           },
           "then": {
-            "properties": { "copyright": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },
-            "required": ["copyright"]
+            "if": {
+              "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
+              "required": ["supplier"]
+            },
+            "then": {
+              "properties": { "copyright": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },
+              "required": ["copyright"]
+            }
           }
-        },
+        },                    
         {
           "if": {
             "properties": { "author": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },

--- a/cdxev/auxiliary/schema/bom-1.3-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.3-custom.schema.json
@@ -249,9 +249,26 @@
           "items": {
             "$ref": "#/definitions/organizationalContact"
           }
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        {
+            "required": [
+                "name"
+            ]
         },
-        "additionalProperties": false
+        {
+            "required": [
+                "url"
+            ]
+        },
+        {
+          "required": [
+              "contact"
+          ]
       }
+    ]
     },
     "organizationalContact": {
       "type": "object",
@@ -568,24 +585,22 @@
           },
           "then": {
             "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
-            "required": ["supplier"]
+            "dependencies": {
+              "supplier": {"properties": {"supplier": {"required": ["name"]}}}
+            }
           }
         },
         {
-          "if":{ 
+          "if": {
+            "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
+            "required": ["supplier"],
             "dependencies": {
               "supplier": {"properties": {"supplier": {"required": ["name"]}}}
             }
           },
           "then": {
-            "if": {
-              "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
-              "required": ["supplier"]
-            },
-            "then": {
-              "properties": { "copyright": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },
-              "required": ["copyright"]
-            }
+            "properties": { "copyright": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },
+            "required": ["copyright"]
           }
         },
         {

--- a/cdxev/auxiliary/schema/bom-1.3-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.3-custom.schema.json
@@ -522,9 +522,6 @@
           }
         }
       },
-      "dependencies": {
-        "supplier": {"properties": {"supplier": {"required": ["name"]}}}
-      },
       "allOf": [
         {
           "anyOf": [

--- a/cdxev/auxiliary/schema/bom-1.3-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.3-custom.schema.json
@@ -249,7 +249,8 @@
           "items": {
             "$ref": "#/definitions/organizationalContact"
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "organizationalContact": {
@@ -589,7 +590,7 @@
               "required": ["copyright"]
             }
           }
-        },                    
+        },
         {
           "if": {
             "properties": { "author": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },

--- a/cdxev/auxiliary/schema/bom-1.4-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.4-custom.schema.json
@@ -585,9 +585,6 @@
           "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
         }
       },
-      "dependencies": {
-        "supplier": {"properties": {"supplier": {"required": ["name"]}}}
-      },
       "allOf": [
         {
           "anyOf": [

--- a/cdxev/auxiliary/schema/bom-1.4-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.4-custom.schema.json
@@ -585,6 +585,9 @@
           "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
         }
       },
+      "dependencies": {
+        "supplier": {"properties": {"supplier": {"required": ["name"]}}}
+      },
       "allOf": [
         {
           "anyOf": [
@@ -635,15 +638,22 @@
           }
         },
         {
-          "if": {
-            "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
-            "required": ["supplier"]
+          "if":{ 
+            "dependencies": {
+              "supplier": {"properties": {"supplier": {"required": ["name"]}}}
+            }
           },
           "then": {
-            "properties": { "copyright": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },
-            "required": ["copyright"]
+            "if": {
+              "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
+              "required": ["supplier"]
+            },
+            "then": {
+              "properties": { "copyright": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },
+              "required": ["copyright"]
+            }
           }
-        },
+        }, 
         {
           "if": {
             "properties": { "author": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },

--- a/cdxev/auxiliary/schema/bom-1.4-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.4-custom.schema.json
@@ -653,7 +653,7 @@
               "required": ["copyright"]
             }
           }
-        }, 
+        },
         {
           "if": {
             "properties": { "author": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },

--- a/cdxev/auxiliary/schema/bom-1.4-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.4-custom.schema.json
@@ -289,7 +289,24 @@
             "$ref": "#/definitions/organizationalContact"
           }
         }
+      },
+            "anyOf": [
+        {
+            "required": [
+                "name"
+            ]
+        },
+        {
+            "required": [
+                "url"
+            ]
+        },
+        {
+          "required": [
+              "contact"
+          ]
       }
+    ]
     },
     "organizationalContact": {
       "type": "object",
@@ -631,24 +648,22 @@
           },
           "then": {
             "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
-            "required": ["supplier"]
+            "dependencies": {
+              "supplier": {"properties": {"supplier": {"required": ["name"]}}}
+            }
           }
         },
         {
-          "if":{ 
+          "if": {
+            "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
+            "required": ["supplier"],
             "dependencies": {
               "supplier": {"properties": {"supplier": {"required": ["name"]}}}
             }
           },
           "then": {
-            "if": {
-              "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
-              "required": ["supplier"]
-            },
-            "then": {
-              "properties": { "copyright": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },
-              "required": ["copyright"]
-            }
+            "properties": { "copyright": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },
+            "required": ["copyright"]
           }
         },
         {

--- a/cdxev/auxiliary/schema/bom-1.4-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.4-custom.schema.json
@@ -648,6 +648,7 @@
           },
           "then": {
             "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
+            "required": ["supplier"],
             "dependencies": {
               "supplier": {"properties": {"supplier": {"required": ["name"]}}}
             }

--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -714,7 +714,7 @@
               "required": ["copyright"]
             }
           }
-        }, 
+        },
         {
           "if": {
             "properties": { "author": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },

--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -646,6 +646,9 @@
           "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
         }
       },
+      "dependencies": {
+        "supplier": {"properties": {"supplier": {"required": ["name"]}}}
+      },
       "allOf": [
         {
           "anyOf": [
@@ -696,15 +699,22 @@
           }
         },
         {
-          "if": {
-            "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
-            "required": ["supplier"]
+          "if":{ 
+            "dependencies": {
+              "supplier": {"properties": {"supplier": {"required": ["name"]}}}
+            }
           },
           "then": {
-            "properties": { "copyright": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },
-            "required": ["copyright"]
+            "if": {
+              "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
+              "required": ["supplier"]
+            },
+            "then": {
+              "properties": { "copyright": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },
+              "required": ["copyright"]
+            }
           }
-        },
+        }, 
         {
           "if": {
             "properties": { "author": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },

--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -646,9 +646,6 @@
           "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
         }
       },
-      "dependencies": {
-        "supplier": {"properties": {"supplier": {"required": ["name"]}}}
-      },
       "allOf": [
         {
           "anyOf": [

--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -383,7 +383,24 @@
           "description": "A contact at the organization. Multiple contacts are allowed.",
           "items": {"$ref": "#/definitions/organizationalContact"}
         }
+      },
+      "anyOf": [
+        {
+            "required": [
+                "name"
+            ]
+        },
+        {
+            "required": [
+                "url"
+            ]
+        },
+        {
+          "required": [
+              "contact"
+          ]
       }
+    ]
     },
     "organizationalContact": {
       "type": "object",
@@ -692,24 +709,22 @@
           },
           "then": {
             "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
-            "required": ["supplier"]
+            "dependencies": {
+              "supplier": {"properties": {"supplier": {"required": ["name"]}}}
+            }
           }
         },
         {
-          "if":{ 
+          "if": {
+            "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
+            "required": ["supplier"],
             "dependencies": {
               "supplier": {"properties": {"supplier": {"required": ["name"]}}}
             }
           },
           "then": {
-            "if": {
-              "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
-              "required": ["supplier"]
-            },
-            "then": {
-              "properties": { "copyright": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },
-              "required": ["copyright"]
-            }
+            "properties": { "copyright": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" } },
+            "required": ["copyright"]
           }
         },
         {

--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -709,6 +709,7 @@
           },
           "then": {
             "properties": {"supplier": {"properties": {"name": { "pattern": "([Ff][Ee][Ss][Tt][Oo])" }}} },
+            "required": ["supplier"],
             "dependencies": {
               "supplier": {"properties": {"supplier": {"required": ["name"]}}}
             }

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1092,7 +1092,7 @@ class TestInternalMetaData(unittest.TestCase):
                 "component": {
                     "type": "application",
                     "bom-ref": "acme-app",
-                    "supplier": {"name": "Acme"},
+                    "author": "Acme",
                     "copyright": "Festo SE & Co. KG 2022, all rights reserved",
                     "name": "Acme_Application",
                     "version": "9.1.1",
@@ -1110,4 +1110,5 @@ class TestInternalMetaData(unittest.TestCase):
         for spec_version in list_of_spec_versions:
             sbom["specVersion"] = spec_version
             issues = validate_test(sbom)
+            print(issues)
             self.assertEqual(search_for_word_issues("supplier", issues), True)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -293,13 +293,13 @@ class TestValidateComponents(unittest.TestCase):
                     issues = validate_test(sbom)
                     self.assertEqual(search_for_word_issues(fields, issues), True)
 
-    def test_supplier_name_missing(self) -> None:
+    def test_supplier_only_url(self) -> None:
         for spec_version in list_of_spec_versions:
             sbom = get_test_sbom()
             sbom["specVersion"] = spec_version
             sbom["components"][0]["supplier"] = {"url": ["https://example.com"]}
             issues = validate_test(sbom)
-            self.assertEqual(search_for_word_issues("name", issues), True)
+            self.assertEqual(issues, ["no issue"])
 
     def test_components_component_supplier_and_author_missing(self) -> None:
         for spec_version in list_of_spec_versions:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -902,6 +902,20 @@ class TestInternalNameSchema(unittest.TestCase):
             sbom["specVersion"] = spec_version
             issues = validate_test(sbom)
             self.assertEqual(search_for_word_issues("supplier", issues), True)
+            self.assertEqual(
+                search_for_word_issues("([Ff][Ee][Ss][Tt][Oo])", issues), True
+            )
+
+    def test_internal_component_copyright_festo_supplier_empty(self) -> None:
+        sbom = get_test_sbom()
+        sbom["components"][0]["supplier"] = {}
+        sbom["components"][0][
+            "copyright"
+        ] = "Festo SE & Co. KG 2022, all rights reserved"
+        for spec_version in list_of_spec_versions:
+            sbom["specVersion"] = spec_version
+            issues = validate_test(sbom)
+            self.assertEqual(search_for_word_issues("name", issues), True)
 
 
 class TestInternalMetaData(unittest.TestCase):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -293,6 +293,14 @@ class TestValidateComponents(unittest.TestCase):
                     issues = validate_test(sbom)
                     self.assertEqual(search_for_word_issues(fields, issues), True)
 
+    def test_supplier_name_missing(self) -> None:
+        for spec_version in list_of_spec_versions:
+            sbom = get_test_sbom()
+            sbom["specVersion"] = spec_version
+            sbom["components"][0]["supplier"] = {"url": ["https://example.com"]}
+            issues = validate_test(sbom)
+            self.assertEqual(search_for_word_issues("name", issues), True)
+
     def test_components_component_supplier_and_author_missing(self) -> None:
         for spec_version in list_of_spec_versions:
             sbom = get_test_sbom()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1110,5 +1110,4 @@ class TestInternalMetaData(unittest.TestCase):
         for spec_version in list_of_spec_versions:
             sbom["specVersion"] = spec_version
             issues = validate_test(sbom)
-            print(issues)
             self.assertEqual(search_for_word_issues("supplier", issues), True)


### PR DESCRIPTION
The supplier has to contain a "name", "url", or "contact".

If the copyright contains  "([Ff][Ee][Ss][Tt][Oo])" the supplier name is required and has to contain "([Ff][Ee][Ss][Tt][Oo])" as well.
