### PR TITLE
fix: allow for updates of supplier name and url

### DIFF
--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -119,11 +119,11 @@ class InferSupplier(Operation):
     """
     At least one of the 'author', 'supplier' or 'publisher' fields must be set on any component but
     the supplier field is desired.
-    If not already present this function wil, try to infer a 'supplier.name'
+    If not already present this function will, try to infer a 'supplier.name'
     and 'supplier.url'.
     The supplier name will be inferred from:
 
-    - If an 'publisher' is present, it is used as supplier name.
+    - If a 'publisher' is present, it is used as supplier name.
     - If no 'publisher but an 'author' is present, it is used as supplier name.
 
     The 'supplier.url' will be inferred from the following sources, in order of precedence:
@@ -134,8 +134,6 @@ class InferSupplier(Operation):
 
     For all of the URLs there is the additional condition that they must utilize the http or https
     scheme.
-
-    If no supplier is present, the function will try to create one with those information
     """
 
     def infer_supplier(self, component: dict) -> None:

--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -157,10 +157,12 @@ class InferSupplier(Operation):
                         component.get("bom-ref", "<no bom-ref>"),
                         ext_ref["url"],
                     )
-                    return
+                    break
+
         if "publisher" in component:
             component["supplier"] = {"name": component["publisher"]}
             return
+
         if "author" in component:
             component["supplier"] = {"name": component["author"]}
             return

--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -117,21 +117,25 @@ class DefaultAuthorOperation(Operation):
 
 class InferSupplier(Operation):
     """
-    As we need a contact in case of a security incident, at least one of the 'author', 'supplier'
-    or 'publisher' fields must be set on any component. If that's not the case, this operation
-    attempts to infer the 'supplier.url'  from the following sources, in order of precedence:
+    At least one of the 'author', 'supplier' or 'publisher' fields must be set on any component but
+    the supplier field is desired.
+    If not already present this function wil, try to infer a 'supplier.name'
+    and 'supplier.url'.
+    The supplier name will be inferred from:
+
+    - If an 'publisher' is present, it is used as supplier name.
+    - If no 'publisher but an 'author' is present, it is used as supplier name.
+
+    The 'supplier.url' will be inferred from the following sources, in order of precedence:
 
     - If an 'externalReference' of type 'website' is present, it is used as supplier URL.
     - If an 'externalReference' of type 'issue-tracker' is present, it is used as supplier URL.
     - If an 'externalReference' of type 'vcs' is present, it is used as supplier URL.
 
-    as well as the 'supplier.name' from:
-
-    - If an 'publisher' is present, it is used as supplier name.
-    - If an 'author' is present, it is used as supplier name.
-
     For all of the URLs there is the additional condition that they must utilize the http or https
     scheme.
+
+    If no supplier is present, the function will try to create one with those information
     """
 
     def infer_supplier(self, component: dict) -> None:

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -17,7 +17,7 @@ Currently, the command adds or modifies the following pieces of information:
 * If a component does have a publisher and/or author but does not have a *supplier*, the tool will try to infer the `supplier.name` from the fields (in order of precedence):
   * *publisher*
   * *author*
-* If the component contains no supplier but *externalReferences*, the tool will try to infer the *supplier.url* from (in order of precedence):
+* If the component contains no *supplier* but *externalReferences*, the tool will try to infer the *supplier.url* from (in order of precedence):
   * *externalReferences* of type *website*
   * *externalReferences* of type *issue-tracker*
   * *externalReferences* of type *vcs*

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -17,7 +17,7 @@ Currently, the command adds or modifies the following pieces of information:
 * If a component does have a publisher and/or author but does not have a *supplier*, the tool will try to infer the `supplier.name` from the fields (in order of precedence):
   * *publisher*
   * *author*
-* If a component contains no *supplier* but *externalReferences*, the tool will try to infer the *supplier.url* from (in order of precedence):
+* If a component contains externalReferences and no supplier.url is provided, the tool will try to infer the *supplier.url* from (in order of precedence):
   * *externalReferences* of type *website*
   * *externalReferences* of type *issue-tracker*
   * *externalReferences* of type *vcs*

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -17,7 +17,7 @@ Currently, the command adds or modifies the following pieces of information:
 * If a component does have a publisher and/or author but does not have a *supplier*, the tool will try to infer the `supplier.name` from the fields (in order of precedence):
   * *publisher*
   * *author*
- And if the component contains *externalReferences*, the tool will try to infer the *supplier.url* from (in order of precedence):
+* If the component contains no supplier but *externalReferences*, the tool will try to infer the *supplier.url* from (in order of precedence):
   * *externalReferences* of type *website*
   * *externalReferences* of type *issue-tracker*
   * *externalReferences* of type *vcs*

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -17,7 +17,7 @@ Currently, the command adds or modifies the following pieces of information:
 * If a component does have a publisher and/or author but does not have a *supplier*, the tool will try to infer the `supplier.name` from the fields (in order of precedence):
   * *publisher*
   * *author*
-* If the component contains no *supplier* but *externalReferences*, the tool will try to infer the *supplier.url* from (in order of precedence):
+* If a component contains no *supplier* but *externalReferences*, the tool will try to infer the *supplier.url* from (in order of precedence):
   * *externalReferences* of type *website*
   * *externalReferences* of type *issue-tracker*
   * *externalReferences* of type *vcs*

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -14,10 +14,10 @@ Currently, the command adds or modifies the following pieces of information:
 
 * If the SBOM metadata doesn't specify an *author* from the SBOM, it will be set to `{"name": "automated"}`.
 * The *compositions* array will be overwritten with a new one which specifies a single *incomplete* aggregate. This aggregate contains all components, including the metadata component.
-* If a component does not have a *supplier*, the tool will try to infer the supplier from the fields (in order of precedence):
+* If a component does have a publisher and/or author but does not have a *supplier*, the tool will try to infer the `supplier.name` from the fields (in order of precedence):
   * *publisher*
   * *author*
-* If a component does not have an *author*, *publisher* or *supplier*, the tool will try to infer the supplier from (in order of precedence):
+ And if the component contains *externalReferences*, the tool will try to infer the *supplier.url* from (in order of precedence):
   * *externalReferences* of type *website*
   * *externalReferences* of type *issue-tracker*
   * *externalReferences* of type *vcs*

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -179,6 +179,68 @@ class InferSupplierTestCase(AmendTestCase):
             self.sbom_fixture["components"][0]["author"],
         )
 
+    def test_supplier_gets_not_overwritten(self) -> None:
+        self.sbom_fixture["components"][0]["supplier"] = {
+            "bom-ref": "Reference to a supplier entry"
+        }
+        run_amend(self.sbom_fixture)
+        self.assertEqual(
+            self.sbom_fixture["components"][0]["supplier"]["bom-ref"],
+            "Reference to a supplier entry",
+        )
+        self.assertEqual(
+            self.sbom_fixture["components"][0]["supplier"]["url"][0],
+            self.sbom_fixture["components"][0]["externalReferences"][0]["url"],
+        )
+        self.assertEqual(
+            self.sbom_fixture["components"][0]["supplier"]["name"],
+            self.sbom_fixture["components"][0]["author"],
+        )
+
+    def test_supplier_name_url_get_not_overwritten(self) -> None:
+        self.sbom_fixture["components"][0]["supplier"] = {
+            "name": "Some name of a supplier",
+            "url": "https://someurl.com",
+        }
+        run_amend(self.sbom_fixture)
+        self.assertEqual(
+            self.sbom_fixture["components"][0]["supplier"]["name"],
+            "Some name of a supplier",
+        )
+        self.assertEqual(
+            self.sbom_fixture["components"][0]["supplier"]["url"], "https://someurl.com"
+        )
+
+    def test_supplier_add_url_to_name(self) -> None:
+        self.sbom_fixture["components"][0]["supplier"] = {
+            "name": "Some name of a supplier"
+        }
+        run_amend(self.sbom_fixture)
+        self.assertEqual(
+            self.sbom_fixture["components"][0]["supplier"]["name"],
+            "Some name of a supplier",
+        )
+        self.assertEqual(
+            self.sbom_fixture["components"][0]["supplier"]["url"][0],
+            self.sbom_fixture["components"][0]["externalReferences"][0]["url"],
+        )
+
+    def test_supplier_set_nothing_in_an_empty_component(self) -> None:
+        self.sbom_fixture["components"][0] = {"bom-ref": "component 0"}
+        run_amend(self.sbom_fixture)
+        self.assertEqual(self.sbom_fixture["components"][0], {"bom-ref": "component 0"})
+
+    def test_supplier_add_name_to_url(self) -> None:
+        self.sbom_fixture["components"][0]["supplier"] = {"url": "https://someurl.com"}
+        run_amend(self.sbom_fixture)
+        self.assertEqual(
+            self.sbom_fixture["components"][0]["supplier"]["name"],
+            self.sbom_fixture["components"][0]["author"],
+        )
+        self.assertEqual(
+            self.sbom_fixture["components"][0]["supplier"]["url"], "https://someurl.com"
+        )
+
     def test_supplier_from_website(self) -> None:
         component = {
             "externalReferences": [

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -195,7 +195,7 @@ class InferSupplierTestCase(AmendTestCase):
         )
         self.assertEqual(
             self.sbom_fixture["components"][0]["supplier"]["bom-ref"],
-            "Reference to a supplier entry"
+            "Reference to a supplier entry",
         )
 
     def test_supplier_add_url_to_name(self) -> None:

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -237,9 +237,6 @@ class InferSupplierTestCase(AmendTestCase):
             self.sbom_fixture["components"][0]["supplier"]["name"],
             self.sbom_fixture["components"][0]["author"],
         )
-        self.assertEqual(
-            self.sbom_fixture["components"][0]["supplier"]["url"], "https://someurl.com"
-        )
 
     def test_supplier_from_website(self) -> None:
         component = {

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -179,26 +179,9 @@ class InferSupplierTestCase(AmendTestCase):
             self.sbom_fixture["components"][0]["author"],
         )
 
-    def test_supplier_gets_not_overwritten(self) -> None:
+    def test_supplier_get_not_overwritten(self) -> None:
         self.sbom_fixture["components"][0]["supplier"] = {
-            "bom-ref": "Reference to a supplier entry"
-        }
-        run_amend(self.sbom_fixture)
-        self.assertEqual(
-            self.sbom_fixture["components"][0]["supplier"]["bom-ref"],
-            "Reference to a supplier entry",
-        )
-        self.assertEqual(
-            self.sbom_fixture["components"][0]["supplier"]["url"][0],
-            self.sbom_fixture["components"][0]["externalReferences"][0]["url"],
-        )
-        self.assertEqual(
-            self.sbom_fixture["components"][0]["supplier"]["name"],
-            self.sbom_fixture["components"][0]["author"],
-        )
-
-    def test_supplier_name_url_get_not_overwritten(self) -> None:
-        self.sbom_fixture["components"][0]["supplier"] = {
+            "bom-ref": "Reference to a supplier entry",
             "name": "Some name of a supplier",
             "url": "https://someurl.com",
         }
@@ -209,6 +192,10 @@ class InferSupplierTestCase(AmendTestCase):
         )
         self.assertEqual(
             self.sbom_fixture["components"][0]["supplier"]["url"], "https://someurl.com"
+        )
+        self.assertEqual(
+            self.sbom_fixture["components"][0]["supplier"]["bom-ref"],
+            "Reference to a supplier entry"
         )
 
     def test_supplier_add_url_to_name(self) -> None:


### PR DESCRIPTION
Allows for updates of supplier.url AND supplier.name.
Also contains the change to the documentation.