### PR TITLE
Feat: Create copyright from supplier

### DIFF
--- a/cdxev/amend/__init__.py
+++ b/cdxev/amend/__init__.py
@@ -5,6 +5,7 @@ from .operations import (
     DefaultAuthorOperation,
     InferSupplier,
     ProcessLicense,
+    InferCopyright
 )
 
 register_operation(AddBomRefOperation())
@@ -12,3 +13,4 @@ register_operation(DefaultAuthorOperation())
 register_operation(CompositionsOperation())
 register_operation(InferSupplier())
 register_operation(ProcessLicense())
+register_operation(InferCopyright())

--- a/cdxev/amend/__init__.py
+++ b/cdxev/amend/__init__.py
@@ -3,9 +3,9 @@ from .operations import (
     AddBomRefOperation,
     CompositionsOperation,
     DefaultAuthorOperation,
+    InferCopyright,
     InferSupplier,
     ProcessLicense,
-    InferCopyright
 )
 
 register_operation(AddBomRefOperation())

--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -3,8 +3,8 @@ This module defines the amend operations which can be performed on an SBOM.
 It also declares a base class to inherit from when implementing new operations.
 """
 
-import datetime
 import importlib.resources
+import datetime
 import json
 import logging
 import uuid
@@ -230,6 +230,7 @@ class ProcessLicense(Operation):
         process_license(
             component, self.list_of_license_names, self.path_to_license_folder
         )
+        delete_license_unknown(component)
 
 
 class InferCopyright(Operation):
@@ -251,7 +252,7 @@ class InferCopyright(Operation):
 
         year = datetime.date.today().year
         supplier_name = component.get("supplier", {}).get("name", "")
-        copyright = f"Copyright {year} {supplier_name}, all rights reserved"
+        copyright = f"Copyright {year} {supplier_name}"
         component["copyright"] = copyright
 
     def handle_component(

--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -3,8 +3,8 @@ This module defines the amend operations which can be performed on an SBOM.
 It also declares a base class to inherit from when implementing new operations.
 """
 
-import importlib.resources
 import datetime
+import importlib.resources
 import json
 import logging
 import uuid

--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -251,7 +251,7 @@ class InferCopyright(Operation):
 
         year = datetime.date.today().year
         supplier_name = component.get("supplier", {}).get("name", "")
-        copyright = f"Copyright {supplier_name} {year}, all rights reserved"
+        copyright = f"Copyright {year} {supplier_name}, all rights reserved"
         component["copyright"] = copyright
 
     def handle_component(

--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -230,4 +230,35 @@ class ProcessLicense(Operation):
         process_license(
             component, self.list_of_license_names, self.path_to_license_folder
         )
-        delete_license_unknown(component)
+
+
+class InferCopyright(Operation):
+    """
+    If neither a license nor a copyright is present in a component,
+    this function will create a 'copyright' field in the schema
+    'supplier.name year, all rights reserved'
+    """
+
+    def infer_copyright(self, component: dict) -> None:
+        if "copyright" in component.keys() or "licenses" in component.keys():
+            return
+
+        if "supplier" not in component.keys():
+            return
+
+        if "name" not in component.get("supplier", {}).keys():
+            return
+
+        year = datetime.date.today().year
+        supplier_name = component.get("supplier", {}).get("name", "")
+        copyright = f"Copyright {supplier_name} {year}, all rights reserved"
+        component["copyright"] = copyright
+
+    def handle_component(
+        self, component: dict, path_to_license_folder: str = ""
+    ) -> None:
+        self.infer_copyright(component)
+
+    def handle_metadata(self, metadata: dict) -> None:
+        component = metadata.get("component", {})
+        self.infer_copyright(component)

--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -252,7 +252,7 @@ class InferCopyright(Operation):
 
         year = datetime.date.today().year
         supplier_name = component.get("supplier", {}).get("name", "")
-        copyright = f"Copyright {year} {supplier_name}"
+        copyright = f"Copyright (c) {year} {supplier_name}"
         component["copyright"] = copyright
 
     def handle_component(

--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -7,6 +7,7 @@ import importlib.resources
 import json
 import logging
 import uuid
+import datetime
 
 from cdxev.amend.process_license import delete_license_unknown, process_license
 

--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -3,11 +3,11 @@ This module defines the amend operations which can be performed on an SBOM.
 It also declares a base class to inherit from when implementing new operations.
 """
 
+import datetime
 import importlib.resources
 import json
 import logging
 import uuid
-import datetime
 
 from cdxev.amend.process_license import delete_license_unknown, process_license
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -25,7 +25,7 @@ Currently, the command adds or modifies the following pieces of information:
 * If the path to a folder with license text files is provided, the text will be included in the SBOM, if the license has the corresponding `name`.
 * If a `license.name` is similar to an SPDX-ID, it will be replaced, e.g. `{"license": {"name": "The Apache License, Version 2.0"}}` leads to `{"license": {"id": "Apache-2.0"}}`. For this purpose a [JSON-file](https://github.com/Festo-se/cyclonedx-editor-validator/blob/main/cdxev/amend/license_name_spdx_id_map.json) is used, where we provide a mapping of license names to SPDX-IDs, based on this [license-mapping](https://github.com/CycloneDX/cyclonedx-core-java/blob/master/src/main/resources/license-mapping.json).
 * If the SBOM contains a license which `name` includes any variation of the letter sequence "unknown" and no or an empty `text`, the license will be removed. Empty `licenses` fields will also be removed.
-* If neither `licenses` nor `copyright` exist but a supplier.name is present, the tool will create a copyright with the schema 'Copyright supplier.name current year, all rights reserved'. For example ´Copyright Acme. Inc. 2024, all rights reserved´ is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
+* If neither `licenses` nor `copyright` exist but a supplier.name is present, the tool will create a copyright with the schema 'Copyright supplier.name current year, all rights reserved'. For example ´Copyright 2024 Acme. Inc., all rights reserved´ is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
 
 ### Copy license texts from files
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -25,7 +25,7 @@ Currently, the command adds or modifies the following pieces of information:
 * If the path to a folder with license text files is provided, the text will be included in the SBOM, if the license has the corresponding `name`.
 * If a `license.name` is similar to an SPDX-ID, it will be replaced, e.g. `{"license": {"name": "The Apache License, Version 2.0"}}` leads to `{"license": {"id": "Apache-2.0"}}`. For this purpose a [JSON-file](https://github.com/Festo-se/cyclonedx-editor-validator/blob/main/cdxev/amend/license_name_spdx_id_map.json) is used, where we provide a mapping of license names to SPDX-IDs, based on this [license-mapping](https://github.com/CycloneDX/cyclonedx-core-java/blob/master/src/main/resources/license-mapping.json).
 * If the SBOM contains a license which `name` includes any variation of the letter sequence "unknown" and no or an empty `text`, the license will be removed. Empty `licenses` fields will also be removed.
-* If neither `licenses` nor `copyright` exist but a `supplier.name` is present, the tool will create a copyright with the schema 'Copyright current year supplier.name'. For example "Copyright 2024 Acme Inc." is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
+* If neither `licenses` nor `copyright` exist but a `supplier.name` is present, the tool will create a copyright with the schema "Copyright `current year` `supplier.name`". For example "Copyright 2024 Acme Inc." is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
 
 ### Copy license texts from files
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -25,7 +25,7 @@ Currently, the command adds or modifies the following pieces of information:
 * If the path to a folder with license text files is provided, the text will be included in the SBOM, if the license has the corresponding `name`.
 * If a `license.name` is similar to an SPDX-ID, it will be replaced, e.g. `{"license": {"name": "The Apache License, Version 2.0"}}` leads to `{"license": {"id": "Apache-2.0"}}`. For this purpose a [JSON-file](https://github.com/Festo-se/cyclonedx-editor-validator/blob/main/cdxev/amend/license_name_spdx_id_map.json) is used, where we provide a mapping of license names to SPDX-IDs, based on this [license-mapping](https://github.com/CycloneDX/cyclonedx-core-java/blob/master/src/main/resources/license-mapping.json).
 * If the SBOM contains a license which `name` includes any variation of the letter sequence "unknown" and no or an empty `text`, the license will be removed. Empty `licenses` fields will also be removed.
-* If neither `licenses` nor `copyright` exist but a supplier.name is present, the tool will create a copyright with the schema 'Copyright supplier.name current year, all rights reserved'. For example ´Copyright 2024 Acme. Inc., all rights reserved´ is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
+* If neither `licenses` nor `copyright` exist but a supplier.name is present, the tool will create a copyright with the schema 'Copyright current year supplier.name, all rights reserved'. For example ´Copyright 2024 Acme. Inc., all rights reserved´ is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
 
 ### Copy license texts from files
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -25,6 +25,7 @@ Currently, the command adds or modifies the following pieces of information:
 * If the path to a folder with license text files is provided, the text will be included in the SBOM, if the license has the corresponding `name`.
 * If a `license.name` is similar to an SPDX-ID, it will be replaced, e.g. `{"license": {"name": "The Apache License, Version 2.0"}}` leads to `{"license": {"id": "Apache-2.0"}}`. For this purpose a [JSON-file](https://github.com/Festo-se/cyclonedx-editor-validator/blob/main/cdxev/amend/license_name_spdx_id_map.json) is used, where we provide a mapping of license names to SPDX-IDs, based on this [license-mapping](https://github.com/CycloneDX/cyclonedx-core-java/blob/master/src/main/resources/license-mapping.json).
 * If the SBOM contains a license which `name` includes any variation of the letter sequence "unknown" and no or an empty `text`, the license will be removed. Empty `licenses` fields will also be removed.
+* If neither a license nor a copyright but a supplier.name is present, the tool will create a copyright with the schema 'supplier.name current year, all rights reserved', for example ´Acme. Inc. 2024, all rights reserved´ is created from the `{"supplier":{"name": "Acme Inc."}}`
 
 ### Copy license texts from files
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -25,7 +25,7 @@ Currently, the command adds or modifies the following pieces of information:
 * If the path to a folder with license text files is provided, the text will be included in the SBOM, if the license has the corresponding `name`.
 * If a `license.name` is similar to an SPDX-ID, it will be replaced, e.g. `{"license": {"name": "The Apache License, Version 2.0"}}` leads to `{"license": {"id": "Apache-2.0"}}`. For this purpose a [JSON-file](https://github.com/Festo-se/cyclonedx-editor-validator/blob/main/cdxev/amend/license_name_spdx_id_map.json) is used, where we provide a mapping of license names to SPDX-IDs, based on this [license-mapping](https://github.com/CycloneDX/cyclonedx-core-java/blob/master/src/main/resources/license-mapping.json).
 * If the SBOM contains a license which `name` includes any variation of the letter sequence "unknown" and no or an empty `text`, the license will be removed. Empty `licenses` fields will also be removed.
-* If neither `licenses` nor `copyright` exist but a `supplier.name` is present, the tool will create a copyright with the schema "Copyright `current year` `supplier.name`". For example "Copyright 2024 Acme Inc." is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
+* If neither `licenses` nor `copyright` exist but a `supplier.name` is present, the tool will create a copyright with the schema "Copyright (c) `current year` `supplier.name`". For example "Copyright (c) 2024 Acme Inc." is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
 
 ### Copy license texts from files
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -25,7 +25,7 @@ Currently, the command adds or modifies the following pieces of information:
 * If the path to a folder with license text files is provided, the text will be included in the SBOM, if the license has the corresponding `name`.
 * If a `license.name` is similar to an SPDX-ID, it will be replaced, e.g. `{"license": {"name": "The Apache License, Version 2.0"}}` leads to `{"license": {"id": "Apache-2.0"}}`. For this purpose a [JSON-file](https://github.com/Festo-se/cyclonedx-editor-validator/blob/main/cdxev/amend/license_name_spdx_id_map.json) is used, where we provide a mapping of license names to SPDX-IDs, based on this [license-mapping](https://github.com/CycloneDX/cyclonedx-core-java/blob/master/src/main/resources/license-mapping.json).
 * If the SBOM contains a license which `name` includes any variation of the letter sequence "unknown" and no or an empty `text`, the license will be removed. Empty `licenses` fields will also be removed.
-* If neither a license nor a copyright but a supplier.name is present, the tool will create a copyright with the schema 'supplier.name current year, all rights reserved', for example ´Acme. Inc. 2024, all rights reserved´ is created from the `{"supplier":{"name": "Acme Inc."}}`
+* If neither `licenses` nor `copyright` exist but a supplier.name is present, the tool will create a copyright with the schema 'supplier.name current year, all rights reserved', for example ´Acme. Inc. 2024, all rights reserved´ is created from the `{"supplier":{"name": "Acme Inc."}}`
 
 ### Copy license texts from files
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -25,7 +25,7 @@ Currently, the command adds or modifies the following pieces of information:
 * If the path to a folder with license text files is provided, the text will be included in the SBOM, if the license has the corresponding `name`.
 * If a `license.name` is similar to an SPDX-ID, it will be replaced, e.g. `{"license": {"name": "The Apache License, Version 2.0"}}` leads to `{"license": {"id": "Apache-2.0"}}`. For this purpose a [JSON-file](https://github.com/Festo-se/cyclonedx-editor-validator/blob/main/cdxev/amend/license_name_spdx_id_map.json) is used, where we provide a mapping of license names to SPDX-IDs, based on this [license-mapping](https://github.com/CycloneDX/cyclonedx-core-java/blob/master/src/main/resources/license-mapping.json).
 * If the SBOM contains a license which `name` includes any variation of the letter sequence "unknown" and no or an empty `text`, the license will be removed. Empty `licenses` fields will also be removed.
-* If neither `licenses` nor `copyright` exist but a supplier.name is present, the tool will create a copyright with the schema 'Copyright current year supplier.name, all rights reserved'. For example ´Copyright 2024 Acme. Inc., all rights reserved´ is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
+* If neither `licenses` nor `copyright` exist but a `supplier.name` is present, the tool will create a copyright with the schema 'Copyright current year supplier.name'. For example "Copyright 2024 Acme Inc." is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
 
 ### Copy license texts from files
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -25,7 +25,7 @@ Currently, the command adds or modifies the following pieces of information:
 * If the path to a folder with license text files is provided, the text will be included in the SBOM, if the license has the corresponding `name`.
 * If a `license.name` is similar to an SPDX-ID, it will be replaced, e.g. `{"license": {"name": "The Apache License, Version 2.0"}}` leads to `{"license": {"id": "Apache-2.0"}}`. For this purpose a [JSON-file](https://github.com/Festo-se/cyclonedx-editor-validator/blob/main/cdxev/amend/license_name_spdx_id_map.json) is used, where we provide a mapping of license names to SPDX-IDs, based on this [license-mapping](https://github.com/CycloneDX/cyclonedx-core-java/blob/master/src/main/resources/license-mapping.json).
 * If the SBOM contains a license which `name` includes any variation of the letter sequence "unknown" and no or an empty `text`, the license will be removed. Empty `licenses` fields will also be removed.
-* If neither `licenses` nor `copyright` exist but a supplier.name is present, the tool will create a copyright with the schema 'supplier.name current year, all rights reserved'. For example ´Acme. Inc. 2024, all rights reserved´ is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
+* If neither `licenses` nor `copyright` exist but a supplier.name is present, the tool will create a copyright with the schema 'Copyright supplier.name current year, all rights reserved'. For example ´Copyright Acme. Inc. 2024, all rights reserved´ is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
 
 ### Copy license texts from files
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -25,7 +25,7 @@ Currently, the command adds or modifies the following pieces of information:
 * If the path to a folder with license text files is provided, the text will be included in the SBOM, if the license has the corresponding `name`.
 * If a `license.name` is similar to an SPDX-ID, it will be replaced, e.g. `{"license": {"name": "The Apache License, Version 2.0"}}` leads to `{"license": {"id": "Apache-2.0"}}`. For this purpose a [JSON-file](https://github.com/Festo-se/cyclonedx-editor-validator/blob/main/cdxev/amend/license_name_spdx_id_map.json) is used, where we provide a mapping of license names to SPDX-IDs, based on this [license-mapping](https://github.com/CycloneDX/cyclonedx-core-java/blob/master/src/main/resources/license-mapping.json).
 * If the SBOM contains a license which `name` includes any variation of the letter sequence "unknown" and no or an empty `text`, the license will be removed. Empty `licenses` fields will also be removed.
-* If neither `licenses` nor `copyright` exist but a supplier.name is present, the tool will create a copyright with the schema 'supplier.name current year, all rights reserved', for example ´Acme. Inc. 2024, all rights reserved´ is created from the `{"supplier":{"name": "Acme Inc."}}`
+* If neither `licenses` nor `copyright` exist but a supplier.name is present, the tool will create a copyright with the schema 'supplier.name current year, all rights reserved'. For example ´Acme. Inc. 2024, all rights reserved´ is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
 
 ### Copy license texts from files
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -25,7 +25,7 @@ Currently, the command adds or modifies the following pieces of information:
 * If the path to a folder with license text files is provided, the text will be included in the SBOM, if the license has the corresponding `name`.
 * If a `license.name` is similar to an SPDX-ID, it will be replaced, e.g. `{"license": {"name": "The Apache License, Version 2.0"}}` leads to `{"license": {"id": "Apache-2.0"}}`. For this purpose a [JSON-file](https://github.com/Festo-se/cyclonedx-editor-validator/blob/main/cdxev/amend/license_name_spdx_id_map.json) is used, where we provide a mapping of license names to SPDX-IDs, based on this [license-mapping](https://github.com/CycloneDX/cyclonedx-core-java/blob/master/src/main/resources/license-mapping.json).
 * If the SBOM contains a license which `name` includes any variation of the letter sequence "unknown" and no or an empty `text`, the license will be removed. Empty `licenses` fields will also be removed.
-* If neither `licenses` nor `copyright` exist but a `supplier.name` is present, the tool will create a copyright with the schema "Copyright (c) `current year` `supplier.name`". For example "Copyright (c) 2024 Acme Inc." is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
+* If neither `licenses` nor `copyright` exist but a `supplier.name` is present, the tool will create a `copyright` with the content "Copyright (c) `current year` `supplier.name`". For example "Copyright (c) 2024 Acme Inc." is created from the `{"supplier":{"name": "Acme Inc."}}` in the year 2024.
 
 ### Copy license texts from files
 

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -582,7 +582,7 @@ class TestInferCopyright(AmendTestCase):
     def test_create_copyright(self) -> None:
         component = {"supplier": {"name": "Acme Inc."}}
         year = datetime.date.today().year
-        copyright = f"Acme Inc. {year}, all rights reserved"
+        copyright = f"Copyright Acme Inc. {year}, all rights reserved"
         expected = {"copyright": copyright, "supplier": {"name": "Acme Inc."}}
         self.operation.handle_component(component)
         self.assertDictEqual(expected, component)
@@ -593,7 +593,7 @@ class TestInferCopyright(AmendTestCase):
         run_amend(self.sbom_fixture)
         self.assertEqual(
             self.sbom_fixture["metadata"]["component"]["copyright"],
-            f"Acme Inc. {year}, all rights reserved",
+            f"Copyright Acme Inc. {year}, all rights reserved",
         )
 
     def test_set_copyright_from_supplier_in_components(self) -> None:
@@ -605,7 +605,7 @@ class TestInferCopyright(AmendTestCase):
         company = self.sbom_fixture["components"][0]["supplier"]["name"]
         self.assertEqual(
             self.sbom_fixture["components"][0]["copyright"],
-            f"{company} {year}, all rights reserved",
+            f"Copyright {company} {year}, all rights reserved",
         )
 
 

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -582,7 +582,7 @@ class TestInferCopyright(AmendTestCase):
     def test_create_copyright(self) -> None:
         component = {"supplier": {"name": "Acme Inc."}}
         year = datetime.date.today().year
-        copyright = f"Copyright Acme Inc. {year}, all rights reserved"
+        copyright = f"Copyright {year} Acme Inc., all rights reserved"
         expected = {"copyright": copyright, "supplier": {"name": "Acme Inc."}}
         self.operation.handle_component(component)
         self.assertDictEqual(expected, component)
@@ -593,7 +593,7 @@ class TestInferCopyright(AmendTestCase):
         run_amend(self.sbom_fixture)
         self.assertEqual(
             self.sbom_fixture["metadata"]["component"]["copyright"],
-            f"Copyright Acme Inc. {year}, all rights reserved",
+            f"Copyright {year} Acme Inc., all rights reserved",
         )
 
     def test_set_copyright_from_supplier_in_components(self) -> None:
@@ -605,7 +605,7 @@ class TestInferCopyright(AmendTestCase):
         company = self.sbom_fixture["components"][0]["supplier"]["name"]
         self.assertEqual(
             self.sbom_fixture["components"][0]["copyright"],
-            f"Copyright {company} {year}, all rights reserved",
+            f"Copyright {year} {company}, all rights reserved",
         )
 
 

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -1,6 +1,6 @@
 import copy
-import datetime
 import json
+import datetime
 import typing as t
 import unittest
 
@@ -556,6 +556,188 @@ class GetLicenseTextFromFile(unittest.TestCase):
             )
 
 
+class TestDeleteUnknownComponent(AmendTestCase):
+    def test_delete_unknown_component(self) -> None:
+        licenses = [
+            {"license": {"name": "unknown.something"}},
+            {"license": {"name": "whateverUnknown"}},
+            {"license": {"name": "unKnowN etc"}},
+            {"license": {"name": "AunknowNM", "text": {"content": ""}}},
+            {"license": {"name": "unknown", "text": {"content": "license text"}}},
+            {"license": {"name": "some license", "text": {"content": "license text"}}},
+            {"license": {"name": "some license"}},
+            {"license": {"name": ""}},
+        ]
+        component = {"licenses": copy.deepcopy(licenses)}
+        process_license.delete_license_unknown(component)
+        self.assertEqual(component["licenses"], licenses[4:])
+
+    def test_amend_delete_license_unknown(self) -> None:
+        sbom = {
+            "metadata": {
+                "component": {
+                    "bom-ref": "a bom-ref",
+                    "licenses": [
+                        {"license": {"name": "some_license"}},
+                        {"license": {"name": "license"}},
+                        {"license": {"name": "unknown", "text": {"content": ""}}},
+                        {
+                            "license": {
+                                "name": "unknown",
+                                "text": {"content": "some text"},
+                            }
+                        },
+                    ],
+                },
+                "authors": [{"name": "automated"}],
+            },
+            "components": [
+                {
+                    "bom-ref": "a second bom-ref",
+                    "licenses": [
+                        {"license": {"name": "some_license"}},
+                        {"license": {"name": "license"}},
+                    ],
+                },
+                {
+                    "bom-ref": "a third bom-ref",
+                    "licenses": [
+                        {"license": {"name": "some_unknown_license"}},
+                        {"license": {"name": "license"}},
+                        {
+                            "license": {
+                                "name": "unknown",
+                                "text": {"content": "some description"},
+                            }
+                        },
+                    ],
+                },
+                {"name": "test", "bom-ref": "reference"},
+            ],
+            "compositions": [
+                {
+                    "aggregate": "incomplete",
+                    "assemblies": ["a bom-ref", "a second bom-ref", "a third bom-ref"],
+                }
+            ],
+        }
+        sbom_changed = {
+            "metadata": {
+                "component": {
+                    "bom-ref": "a bom-ref",
+                    "licenses": [
+                        {"license": {"name": "some_license"}},
+                        {"license": {"name": "license"}},
+                        {
+                            "license": {
+                                "name": "unknown",
+                                "text": {"content": "some text"},
+                            }
+                        },
+                    ],
+                },
+                "authors": [{"name": "automated"}],
+            },
+            "components": [
+                {
+                    "bom-ref": "a second bom-ref",
+                    "licenses": [
+                        {"license": {"name": "some_license"}},
+                        {"license": {"name": "license"}},
+                    ],
+                },
+                {
+                    "bom-ref": "a third bom-ref",
+                    "licenses": [
+                        {"license": {"name": "license"}},
+                        {
+                            "license": {
+                                "name": "unknown",
+                                "text": {"content": "some description"},
+                            }
+                        },
+                    ],
+                },
+                {"name": "test", "bom-ref": "reference"},
+            ],
+            "compositions": [
+                {
+                    "aggregate": "incomplete",
+                    "assemblies": [
+                        "a bom-ref",
+                        "a second bom-ref",
+                        "a third bom-ref",
+                        "reference",
+                    ],
+                }
+            ],
+        }
+        run_amend(sbom)
+        self.assertEqual(sbom, sbom_changed)
+
+    def test_amend_delete_single_license(self) -> None:
+        sbom = {
+            "metadata": {
+                "component": {
+                    "bom-ref": "a bom-ref",
+                    "licenses": [
+                        {"license": {"name": "unknown", "text": {"content": ""}}},
+                    ],
+                },
+                "authors": [{"name": "automated"}],
+            },
+            "components": [
+                {
+                    "bom-ref": "a second bom-ref",
+                    "licenses": [
+                        {"license": {"name": "some_license"}},
+                        {"license": {"name": "license"}},
+                    ],
+                },
+                {
+                    "bom-ref": "a third bom-ref",
+                    "licenses": [
+                        {"license": {"name": "some_unknown_license"}},
+                    ],
+                },
+            ],
+            "compositions": [
+                {
+                    "aggregate": "incomplete",
+                    "assemblies": ["a bom-ref", "a second bom-ref", "a third bom-ref"],
+                }
+            ],
+        }
+        sbom_changed = {
+            "metadata": {
+                "component": {
+                    "bom-ref": "a bom-ref",
+                },
+                "authors": [{"name": "automated"}],
+            },
+            "components": [
+                {
+                    "bom-ref": "a second bom-ref",
+                    "licenses": [
+                        {"license": {"name": "some_license"}},
+                        {"license": {"name": "license"}},
+                    ],
+                },
+                {
+                    "bom-ref": "a third bom-ref",
+                },
+            ],
+            "compositions": [
+                {
+                    "aggregate": "incomplete",
+                    "assemblies": ["a bom-ref", "a second bom-ref", "a third bom-ref"],
+                }
+            ],
+        }
+        run_amend(sbom)
+        self.assertEqual(sbom, sbom_changed)
+
+
 class TestInferCopyright(AmendTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -582,7 +764,7 @@ class TestInferCopyright(AmendTestCase):
     def test_create_copyright(self) -> None:
         component = {"supplier": {"name": "Acme Inc."}}
         year = datetime.date.today().year
-        copyright = f"Copyright {year} Acme Inc., all rights reserved"
+        copyright = f"Copyright {year} Acme Inc."
         expected = {"copyright": copyright, "supplier": {"name": "Acme Inc."}}
         self.operation.handle_component(component)
         self.assertDictEqual(expected, component)
@@ -593,7 +775,7 @@ class TestInferCopyright(AmendTestCase):
         run_amend(self.sbom_fixture)
         self.assertEqual(
             self.sbom_fixture["metadata"]["component"]["copyright"],
-            f"Copyright {year} Acme Inc., all rights reserved",
+            f"Copyright {year} Acme Inc.",
         )
 
     def test_set_copyright_from_supplier_in_components(self) -> None:
@@ -605,7 +787,7 @@ class TestInferCopyright(AmendTestCase):
         company = self.sbom_fixture["components"][0]["supplier"]["name"]
         self.assertEqual(
             self.sbom_fixture["components"][0]["copyright"],
-            f"Copyright {year} {company}, all rights reserved",
+            f"Copyright {year} {company}",
         )
 
 

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -13,7 +13,7 @@ from cdxev.amend.operations import (
     InferSupplier,
     Operation,
     ProcessLicense,
-    InferCopyright
+    InferCopyright,
 )
 from cdxev.error import AppError
 from tests.auxiliary.sbomFunctionsTests import compare_sboms
@@ -589,27 +589,23 @@ class TestInferCopyright(AmendTestCase):
 
     def test_set_copyright_from_supplier_in_metadata(self) -> None:
         year = datetime.date.today().year
-        self.sbom_fixture["metadata"]["component"]["supplier"] = {
-            "name": "Acme Inc."
-        }
+        self.sbom_fixture["metadata"]["component"]["supplier"] = {"name": "Acme Inc."}
         run_amend(self.sbom_fixture)
         self.assertEqual(
             self.sbom_fixture["metadata"]["component"]["copyright"],
-            f"Acme Inc. {year}, all rights reserved"
+            f"Acme Inc. {year}, all rights reserved",
         )
 
     def test_set_copyright_from_supplier_in_components(self) -> None:
         self.sbom_fixture["components"][0].pop("licenses")
         self.sbom_fixture["components"][0].pop("externalReferences")
-        self.sbom_fixture["components"][0]["supplier"] = {
-            "name": "Acme Inc."
-        }
+        self.sbom_fixture["components"][0]["supplier"] = {"name": "Acme Inc."}
         year = datetime.date.today().year
         run_amend(self.sbom_fixture)
         company = self.sbom_fixture["components"][0]["supplier"]["name"]
         self.assertEqual(
             self.sbom_fixture["components"][0]["copyright"],
-            f"{company} {year}, all rights reserved"
+            f"{company} {year}, all rights reserved",
         )
 
 

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -1,8 +1,8 @@
 import copy
+import datetime
 import json
 import typing as t
 import unittest
-import datetime
 
 from cdxev.amend import process_license
 from cdxev.amend.command import run as run_amend
@@ -10,10 +10,10 @@ from cdxev.amend.operations import (
     AddBomRefOperation,
     CompositionsOperation,
     DefaultAuthorOperation,
+    InferCopyright,
     InferSupplier,
     Operation,
     ProcessLicense,
-    InferCopyright,
 )
 from cdxev.error import AppError
 from tests.auxiliary.sbomFunctionsTests import compare_sboms

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -764,7 +764,7 @@ class TestInferCopyright(AmendTestCase):
     def test_create_copyright(self) -> None:
         component = {"supplier": {"name": "Acme Inc."}}
         year = datetime.date.today().year
-        copyright = f"Copyright {year} Acme Inc."
+        copyright = f"Copyright (c) {year} Acme Inc."
         expected = {"copyright": copyright, "supplier": {"name": "Acme Inc."}}
         self.operation.handle_component(component)
         self.assertDictEqual(expected, component)
@@ -775,7 +775,7 @@ class TestInferCopyright(AmendTestCase):
         run_amend(self.sbom_fixture)
         self.assertEqual(
             self.sbom_fixture["metadata"]["component"]["copyright"],
-            f"Copyright {year} Acme Inc.",
+            f"Copyright (c) {year} Acme Inc.",
         )
 
     def test_set_copyright_from_supplier_in_components(self) -> None:
@@ -787,7 +787,7 @@ class TestInferCopyright(AmendTestCase):
         company = self.sbom_fixture["components"][0]["supplier"]["name"]
         self.assertEqual(
             self.sbom_fixture["components"][0]["copyright"],
-            f"Copyright {year} {company}",
+            f"Copyright (c) {year} {company}",
         )
 
 

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -1,6 +1,6 @@
 import copy
-import json
 import datetime
+import json
 import typing as t
 import unittest
 

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -2,6 +2,7 @@ import copy
 import json
 import typing as t
 import unittest
+import datetime
 
 from cdxev.amend import process_license
 from cdxev.amend.command import run as run_amend
@@ -12,6 +13,7 @@ from cdxev.amend.operations import (
     InferSupplier,
     Operation,
     ProcessLicense,
+    InferCopyright
 )
 from cdxev.error import AppError
 from tests.auxiliary.sbomFunctionsTests import compare_sboms
@@ -554,186 +556,61 @@ class GetLicenseTextFromFile(unittest.TestCase):
             )
 
 
-class TestDeleteUnknownComponent(AmendTestCase):
-    def test_delete_unknown_component(self) -> None:
-        licenses = [
-            {"license": {"name": "unknown.something"}},
-            {"license": {"name": "whateverUnknown"}},
-            {"license": {"name": "unKnowN etc"}},
-            {"license": {"name": "AunknowNM", "text": {"content": ""}}},
-            {"license": {"name": "unknown", "text": {"content": "license text"}}},
-            {"license": {"name": "some license", "text": {"content": "license text"}}},
-            {"license": {"name": "some license"}},
-            {"license": {"name": ""}},
-        ]
-        component = {"licenses": copy.deepcopy(licenses)}
-        process_license.delete_license_unknown(component)
-        self.assertEqual(component["licenses"], licenses[4:])
+class TestInferCopyright(AmendTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.operation = InferCopyright()
 
-    def test_amend_delete_license_unknown(self) -> None:
-        sbom = {
-            "metadata": {
-                "component": {
-                    "bom-ref": "a bom-ref",
-                    "licenses": [
-                        {"license": {"name": "some_license"}},
-                        {"license": {"name": "license"}},
-                        {"license": {"name": "unknown", "text": {"content": ""}}},
-                        {
-                            "license": {
-                                "name": "unknown",
-                                "text": {"content": "some text"},
-                            }
-                        },
-                    ],
-                },
-                "authors": [{"name": "automated"}],
-            },
-            "components": [
-                {
-                    "bom-ref": "a second bom-ref",
-                    "licenses": [
-                        {"license": {"name": "some_license"}},
-                        {"license": {"name": "license"}},
-                    ],
-                },
-                {
-                    "bom-ref": "a third bom-ref",
-                    "licenses": [
-                        {"license": {"name": "some_unknown_license"}},
-                        {"license": {"name": "license"}},
-                        {
-                            "license": {
-                                "name": "unknown",
-                                "text": {"content": "some description"},
-                            }
-                        },
-                    ],
-                },
-                {"name": "test", "bom-ref": "reference"},
-            ],
-            "compositions": [
-                {
-                    "aggregate": "incomplete",
-                    "assemblies": ["a bom-ref", "a second bom-ref", "a third bom-ref"],
-                }
-            ],
-        }
-        sbom_changed = {
-            "metadata": {
-                "component": {
-                    "bom-ref": "a bom-ref",
-                    "licenses": [
-                        {"license": {"name": "some_license"}},
-                        {"license": {"name": "license"}},
-                        {
-                            "license": {
-                                "name": "unknown",
-                                "text": {"content": "some text"},
-                            }
-                        },
-                    ],
-                },
-                "authors": [{"name": "automated"}],
-            },
-            "components": [
-                {
-                    "bom-ref": "a second bom-ref",
-                    "licenses": [
-                        {"license": {"name": "some_license"}},
-                        {"license": {"name": "license"}},
-                    ],
-                },
-                {
-                    "bom-ref": "a third bom-ref",
-                    "licenses": [
-                        {"license": {"name": "license"}},
-                        {
-                            "license": {
-                                "name": "unknown",
-                                "text": {"content": "some description"},
-                            }
-                        },
-                    ],
-                },
-                {"name": "test", "bom-ref": "reference"},
-            ],
-            "compositions": [
-                {
-                    "aggregate": "incomplete",
-                    "assemblies": [
-                        "a bom-ref",
-                        "a second bom-ref",
-                        "a third bom-ref",
-                        "reference",
-                    ],
-                }
-            ],
-        }
-        run_amend(sbom)
-        self.assertEqual(sbom, sbom_changed)
+    def test_no_supplier_is_given(self) -> None:
+        component = {"name": "something"}
+        expected = {"name": "something"}
+        self.operation.handle_component(component)
+        self.assertDictEqual(expected, component)
 
-    def test_amend_delete_single_license(self) -> None:
-        sbom = {
-            "metadata": {
-                "component": {
-                    "bom-ref": "a bom-ref",
-                    "licenses": [
-                        {"license": {"name": "unknown", "text": {"content": ""}}},
-                    ],
-                },
-                "authors": [{"name": "automated"}],
-            },
-            "components": [
-                {
-                    "bom-ref": "a second bom-ref",
-                    "licenses": [
-                        {"license": {"name": "some_license"}},
-                        {"license": {"name": "license"}},
-                    ],
-                },
-                {
-                    "bom-ref": "a third bom-ref",
-                    "licenses": [
-                        {"license": {"name": "some_unknown_license"}},
-                    ],
-                },
-            ],
-            "compositions": [
-                {
-                    "aggregate": "incomplete",
-                    "assemblies": ["a bom-ref", "a second bom-ref", "a third bom-ref"],
-                }
-            ],
+    def test_supplier_and_license_is_present(self) -> None:
+        component = {"licenses": [], "supplier": {"name": "some_supplier"}}
+        expected = {"licenses": [], "supplier": {"name": "some_supplier"}}
+        self.operation.handle_component(component)
+        self.assertDictEqual(expected, component)
+
+    def test_supplier_and_copyright_is_present(self) -> None:
+        component = {"copyright": "some copyright", "supplier": {"name": "Acme Inc."}}
+        expected = {"copyright": "some copyright", "supplier": {"name": "Acme Inc."}}
+        self.operation.handle_component(component)
+        self.assertDictEqual(expected, component)
+
+    def test_create_copyright(self) -> None:
+        component = {"supplier": {"name": "Acme Inc."}}
+        year = datetime.date.today().year
+        copyright = f"Acme Inc. {year}, all rights reserved"
+        expected = {"copyright": copyright, "supplier": {"name": "Acme Inc."}}
+        self.operation.handle_component(component)
+        self.assertDictEqual(expected, component)
+
+    def test_set_copyright_from_supplier_in_metadata(self) -> None:
+        year = datetime.date.today().year
+        self.sbom_fixture["metadata"]["component"]["supplier"] = {
+            "name": "Acme Inc."
         }
-        sbom_changed = {
-            "metadata": {
-                "component": {
-                    "bom-ref": "a bom-ref",
-                },
-                "authors": [{"name": "automated"}],
-            },
-            "components": [
-                {
-                    "bom-ref": "a second bom-ref",
-                    "licenses": [
-                        {"license": {"name": "some_license"}},
-                        {"license": {"name": "license"}},
-                    ],
-                },
-                {
-                    "bom-ref": "a third bom-ref",
-                },
-            ],
-            "compositions": [
-                {
-                    "aggregate": "incomplete",
-                    "assemblies": ["a bom-ref", "a second bom-ref", "a third bom-ref"],
-                }
-            ],
+        run_amend(self.sbom_fixture)
+        self.assertEqual(
+            self.sbom_fixture["metadata"]["component"]["copyright"],
+            f"Acme Inc. {year}, all rights reserved"
+        )
+
+    def test_set_copyright_from_supplier_in_components(self) -> None:
+        self.sbom_fixture["components"][0].pop("licenses")
+        self.sbom_fixture["components"][0].pop("externalReferences")
+        self.sbom_fixture["components"][0]["supplier"] = {
+            "name": "Acme Inc."
         }
-        run_amend(sbom)
-        self.assertEqual(sbom, sbom_changed)
+        year = datetime.date.today().year
+        run_amend(self.sbom_fixture)
+        company = self.sbom_fixture["components"][0]["supplier"]["name"]
+        self.assertEqual(
+            self.sbom_fixture["components"][0]["copyright"],
+            f"{company} {year}, all rights reserved"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Use the supplier.name to create a copyright if licenses or copyright are not present
closes #121