### PR TITLE
fix: fix bugs in amend CLI options

### DIFF
--- a/cdxev/__main__.py
+++ b/cdxev/__main__.py
@@ -328,7 +328,6 @@ def create_amend_parser(
         ),
         choices=list(operations_by_name.keys()),
         metavar="<operation>",
-        default=default_operations,
         action="append",
     )
     parser.add_argument(
@@ -349,6 +348,7 @@ def create_amend_parser(
     add_output_argument(parser)
 
     parser.set_defaults(operations_by_name=operations_by_name)
+    parser.set_defaults(default_operations=default_operations)
     parser.set_defaults(cmd_handler=invoke_amend)
     return parser
 
@@ -646,7 +646,7 @@ def invoke_amend(args: argparse.Namespace) -> int:
     # Prepare the operation options that were passed on the command-line
     config = {}
     operations = []
-    for op in args.operation:
+    for op in args.operation or args.default_operations:
         details = args.operations_by_name[op]
         operations.append(details.cls)
         op_arguments = {}

--- a/cdxev/__main__.py
+++ b/cdxev/__main__.py
@@ -653,7 +653,7 @@ def invoke_amend(args: argparse.Namespace) -> int:
         for opt in details.options:
             dest = opt["dest"]
             op_arguments[dest] = getattr(args, dest)
-        config[op] = op_arguments
+        config[details.cls] = op_arguments
 
     amend.run(sbom, operations, config)
     write_sbom(sbom, args.output)


### PR DESCRIPTION
The `--operation` option used to just add an operation to the list of default operations. That wasn't the intended behavior and has been fixed. It now overrides the default list.

The `--license-dir` option of the `add-license-text` operation used to cause a crash. This has been fixed.