### PR TITLE
docs: Improve command documentation

### DIFF
--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -8,7 +8,7 @@ Before use, please consider the [known limitations](https://festo-se.github.io/c
 
 ## amend
 
-This command accepts a single input file and will apply one or multiple *operations* to it. Each operation modifies certain aspects of the SBOM. These modifications cannot be targeted at individual components in the SBOM which sets the *amend* command apart from *set*. It's use-case is ensuring an SBOM fulfils certain requirements in an automated fashion.
+This command accepts a single input file and will apply one or multiple *operations* to it. Each operation modifies certain aspects of the SBOM. These modifications cannot be targeted at individual components in the SBOM which sets the *amend* command apart from *set*. Its use-case is ensuring an SBOM fulfils certain requirements in an automated fashion.
 
 See the command help with `cdx-ev amend --help` for a list of available operations. All operations marked `[default]` will run unless the command-line option `--operation` is provided.
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -284,7 +284,7 @@ This command is used to validate the SBOM against a JSON schema.
 This tool can validate SBOMs against any user-provided JSON schema but for convenience, two schema types are built in:
 
 * The *default* schema type validates against the [stock CycloneDX schema](https://github.com/CycloneDX/specification).
-* The *custom* schema type uses a more restrictive schema which accepts a subset of CycloneDX. Additional requirements incorporated into the schema mostly originate from the [NTIA](https://www.ntia.gov/files/ntia/publications/sbom_minimum_elements_report.pdf) but also include some of the authors' recommendations.
+* The *custom* schema type uses a more restrictive schema which accepts a subset of CycloneDX. Additional requirements incorporated into the schema mostly originate from the [NTIA](https://www.ntia.gov/files/ntia/publications/sbom_minimum_elements_report.pdf).
 
 You can select the schema with the `--schema-type` and `--schema-path` options:
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -8,7 +8,7 @@ Before use, please consider the [known limitations](https://festo-se.github.io/c
 
 ## amend
 
-This command accepts a single input file and will apply one or multiple *operations* to it. Each operation modifies certain aspects of the SBOM. These modifications cannot be targetted at individual components in the SBOM which sets the *amend* command apart from *set*. It's use-case is ensuring an SBOM fulfils certain requirements in an automated fashion.
+This command accepts a single input file and will apply one or multiple *operations* to it. Each operation modifies certain aspects of the SBOM. These modifications cannot be targeted at individual components in the SBOM which sets the *amend* command apart from *set*. It's use-case is ensuring an SBOM fulfils certain requirements in an automated fashion.
 
 See the command help with `cdx-ev amend --help` for a list of available operations. All operations marked `[default]` will run unless the command-line option `--operation` is provided.
 
@@ -39,7 +39,7 @@ Given this license in the input:
     }
 
 it would be filled with the text in any file named `My license`, `My license.txt`, `My license.md`, or any other extension.  
-However, the file `My license.2.txt` would be ignored, because with or without it's extension (`.txt`), it doesn't match the license name.
+However, the file `My license.2.txt` would be ignored, because with or without its extension (`.txt`), it doesn't match the license name.
 
 ## build-public
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -16,7 +16,24 @@ For more information on a particular operation, use the `cdx-ev amend --help-ope
 
 Note that the order of operations cannot be controlled. If you want to ensure two operations run in a certain order you must run the command twice, each time with a different set of operations.
 
-### Insert license texts from files
+__Example:__
+
+    # Run all default operations on an SBOM.
+    cdx-ev amend bom.json
+
+    # Run only the default-author and add-bom-ref operations.
+    cdx-ev amend --operation default-author --operation add-bom-ref bom.json
+
+    # Run the add-license-text operation. License texts are stored in a directory named 'license_texts'.
+    # Afterwards, run the delete-ambiguous-licenses operation.
+    cdx-ev amend --operation add-license-text --license-dir ./license_texts bom.json --output bom.json
+    cdx-ev amend --operation delete-ambiguous-licenses bom.json
+
+### Operations
+
+This section details the more complex operations which require further explanation beyond the help text provided by `--help-operation <operation>`.
+
+#### add-license-text
 
 The operation `add-license-text` can be used to insert known full license texts for licenses identified by name. You can use this, for instance, in workflows where SBOMs are created or edited by hand - so a clutter-free JSON is preferred - then, in a last step, full texts are inserted using this operation.
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -277,21 +277,27 @@ So only a message that the component was not found and could not be updated is l
 
 ## validate
 
-This command is used to validate the SBOM according to a specification.
+This command is used to validate the SBOM against a JSON schema.
 
-### Use of different schemas
+### Schema selection
 
-The package is currently delivered with the specification for CycloneDX 1.3 and 1.4. Further, it is provided with a custom schema, which not only requires the minimum elements as defined by the [NTIA](https://www.ntia.gov/files/ntia/publications/sbom_minimum_elements_report.pdf) but also some further recommended fields, e.g. licenses and stating the known unknowns (through the `compositions`-field).
-You can control the usage of the specification with the flag `--schema-type`:
+This tool can validate SBOMs against any user-provided JSON schema but for convenience, two schema types are built in:
 
-    cdx-ev validate bom.json --schema-type=custom # use provided custom schema in package
-    cdx-ev validate bom.json # default CycloneDX specification will be used
+* The *default* schema type validates against the [stock CycloneDX schema](https://github.com/CycloneDX/specification).
+* The *custom* schema type uses a more restrictive schema which accepts a subset of CycloneDX. Additional requirements incorporated into the schema mostly originate from the [NTIA](https://www.ntia.gov/files/ntia/publications/sbom_minimum_elements_report.pdf) but also include some of the authors' recommendations.
 
-### Use of local schema
+You can select the schema with the `--schema-type` and `--schema-path` options:
 
-With the `--schema-path` flag, users can supply their own schema to the validator.
+    cdx-ev validate bom.json [--schema-type default]           # stock CycloneDX schema
+    cdx-ev validate bom.json --schema-type custom              # built-in custom schema
+    cdx-ev validate bom.json --schema-path <json_schema.json>  # your own schema
 
-    cdx-ev validate bom.json --schema-path=C:\users\documents\sbom_schemas\example_schema.json  # uses a schema "example_schema.json" saved on the users computer to verify the sbom
+For all built-in schemas, the tool attempts to determine the correct CycloneDX version from the input SBOM and falls back to version 1.3 if that fails. The following versions are currently supported:
+
+| Type | Supported CycloneDX versions |
+| ---- | ---------------------------- |
+| `default` | 1.2 to 1.5 |
+| `custom` | 1.3 to 1.5 |
 
 ### Validation of filename
 
@@ -299,9 +305,9 @@ The tool, by default, also validates the filename of the SBOM. Which filenames a
 
 * `--no-filename-validation` completely disables validation.
 * Use `--filename-pattern` to provide a custom regex. The filename must be a full match, regex anchors (^ and $) are not required. Regex patterns often include special characters. Pay attention to escaping rules for your shell to ensure proper results.
-* In all other cases, the acceptable filenames depend on the `--schema-type` option:
-  * When no `--schema-type` is provided or it is explicitly set to `default` (i.e., vanilla CycloneDX), the validator accepts the two patterns recommended by the [CycloneDX specification](https://cyclonedx.org/specification/overview/#recognized-file-patterns): `bom.json` or `*.cdx.json`.
-  * Using the `custom` schema, filenames must match one of these patterns: `bom.json` or `<name>_<version>_<hash>|<timestamp>|<hash>_<timestamp>.cdx.json`. Read on for some clarifications.
+* In all other cases, the acceptable filenames depend on the selected schema:
+  * When using the stock CycloneDX schema (`--schema-type default` or no option at all) or when using your own schema (`--schema-path` option), the validator accepts the two patterns recommended by the [CycloneDX specification](https://cyclonedx.org/specification/overview/#recognized-file-patterns): `bom.json` or `*.cdx.json`.
+  * When validating against the built-in custom schema (`--schema-type custom`), filenames must match one of these patterns: `bom.json` or `<name>_<version>_<hash>|<timestamp>|<hash>_<timestamp>.cdx.json`. Read on for some clarifications.
 
 `<name>` and `<version>` correspond to the respective fields in `metadata.component` in the SBOM.
 

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -27,10 +27,11 @@ License texts are inserted only if:
 * The license has no or an empty `text.content` field.
 * A matching file is found.
 
-You must provide one file per license text in a flat directory. The filename must match the license name specified in the SBOM. The filename's extension (anything after and including the last period) can be present in the license name but it doesn't need to.
+You must provide one file per license text in a flat directory. The stem of the filename, that is everything up to the extension (i.e., up to but not including the last period), must match the license name specified in the SBOM.
 
 __Example:__
-Given this license in the input:
+
+Given this license in the input SBOM:
 
     {
         "license": {
@@ -38,15 +39,15 @@ Given this license in the input:
         }
     }
 
-it would be filled with the text in any file named `My license`, `My license.txt`, `My license.md`, or any other extension.  
-However, the file `My license.2.txt` would be ignored, because with or without its extension (`.txt`), it doesn't match the license name.
+the operation would search the full license text in any file named `My license`, `My license.txt`, `My license.md`, or any other extension.
+However, the file `My license.2.txt` would be disregarded, because its stem (`My license.2`) doesn't match the license name.
 
 ## build-public
 
-This command creates a reduced version of an SBOM fit for publication. It:
+This command creates a redacted version of an SBOM fit for publication. It
 
-* deletes components matching a JSON schema provided by the user, and
-* removes any *property* (i.e., item in the `properties` array of a component) whose name starts with `internal:` from all components.
+* can optionally delete entire components matching a JSON schema provided by the user, and it
+* deletes any *property* (i.e., item in the `properties` array of a component) whose name starts with `internal:` from all components.
 
 The actions are performed in this order, meaning that *internal* properties will be taken into account when matching the JSON schema.
 
@@ -193,6 +194,8 @@ The *target component* can be identified through any of the identifiable propert
 
 If *coordinates* are used to identify the target, they must match the component fully. In other words, if __only__ *name* is given, it will __only match__ components with that name which do __not__ contain *version* or *group* fields.
 
+If the target component isn't found in the SBOM, the program aborts with an error by default. This error can be downgraded to a warning using the `--ignore-missing` flag.
+
 #### Protected fields
 
 Some fields are protected and cannot be set by default. The full list of protected properties is:
@@ -269,12 +272,6 @@ This file can then be applied as the following example shows:
     # Perform several operations on properties using set-command
     cdx-ev set bom.json --from-file mysetfile.json
 
-If the file contains a component not present in the SBOM, a error is thrown.
-This can be disabled with the `--ignore-missing` command.
-So only a message that the component was not found and could not be updated is logged.
-
-    cdx-ev set bom.json --from-file mysetfile.json --ignore-missing
-
 ## validate
 
 This command is used to validate the SBOM against a JSON schema.
@@ -326,7 +323,7 @@ These formats are currently supported:
 Examples:
 
     # Write human-readable messages to stderr and a report in warnings-ng format to report.json
-    cdx-ev validate bom.json --report-format=warnings-ng --report-path=report.json
+    cdx-ev validate bom.json --report-format warnings-ng --report-path report.json
 
     # Write only a report in GitLab Code Quality format to cq.json
-    cdx-ev --quiet validate bom.json --report-format=gitlab-code-quality --report-path=cq.json
+    cdx-ev --quiet validate bom.json --report-format gitlab-code-quality --report-path cq.json


### PR DESCRIPTION
Changes to `available_commands.md`:

- Move the `build-public` section to where it should be alphabetically.
- Update documentation for add-license-text operation. This should have been done in #160 but it was forgotten.
- Rewrite of validate documentation.
  - Include CycloneDX version support.
  - Describe effect of --schema-path on filename validation.