### PR TITLE
fix: delete nested components in build public command

### DIFF
--- a/cdxev/auxiliary/sbomFunctions.py
+++ b/cdxev/auxiliary/sbomFunctions.py
@@ -187,8 +187,7 @@ def get_bom_refs_from_dependencies(dependencies: Sequence[dict]) -> list[str]:
 
 
 def get_ref_from_components(
-        list_of_components: Sequence[dict],
-        only_top_level: bool = True
+    list_of_components: Sequence[dict], only_top_level: bool = True
 ) -> list[str]:
     """
     Function that returns a list of bom-refs from a list of components.

--- a/cdxev/auxiliary/sbomFunctions.py
+++ b/cdxev/auxiliary/sbomFunctions.py
@@ -186,7 +186,10 @@ def get_bom_refs_from_dependencies(dependencies: Sequence[dict]) -> list[str]:
     return list_of_bom_refs
 
 
-def get_ref_from_components(list_of_components: Sequence[dict]) -> list[str]:
+def get_ref_from_components(
+        list_of_components: Sequence[dict],
+        only_top_level: bool = True
+) -> list[str]:
     """
     Function that returns a list of bom-refs from a list of components.
     This also includes nested components.

--- a/cdxev/auxiliary/sbomFunctions.py
+++ b/cdxev/auxiliary/sbomFunctions.py
@@ -186,9 +186,7 @@ def get_bom_refs_from_dependencies(dependencies: Sequence[dict]) -> list[str]:
     return list_of_bom_refs
 
 
-def get_ref_from_components(
-    list_of_components: Sequence[dict], only_top_level: bool = True
-) -> list[str]:
+def get_ref_from_components(list_of_components: Sequence[dict]) -> list[str]:
     """
     Function that returns a list of bom-refs from a list of components.
     This also includes nested components.

--- a/cdxev/build_public_bom.py
+++ b/cdxev/build_public_bom.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Sequence
 
 from jsonschema import Draft7Validator, FormatChecker
+
 from cdxev.auxiliary.sbomFunctions import extract_components
 
 

--- a/cdxev/build_public_bom.py
+++ b/cdxev/build_public_bom.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Sequence
 
 from jsonschema import Draft7Validator, FormatChecker
+from cdxev.auxiliary.sbomFunctions import extract_components
 
 
 def remove_internal_information_from_properties(component: dict) -> None:
@@ -76,6 +77,9 @@ def remove_component_tagged_internal(
             # if not, the property within namespace internal will be removed
             if validator_for_being_internal.is_valid(component):
                 list_of_removed_component_bom_refs.append(component.get("bom-ref", ""))
+                sub_components = extract_components(component.get("components", []))
+            for comp in sub_components:
+                list_of_removed_component_bom_refs.append(comp.get("bom-ref", ""))
             else:
                 remove_internal_information_from_properties(component)
                 cleared_components.append(component)

--- a/cdxev/build_public_bom.py
+++ b/cdxev/build_public_bom.py
@@ -78,8 +78,8 @@ def remove_component_tagged_internal(
             if validator_for_being_internal.is_valid(component):
                 list_of_removed_component_bom_refs.append(component.get("bom-ref", ""))
                 sub_components = extract_components(component.get("components", []))
-            for comp in sub_components:
-                list_of_removed_component_bom_refs.append(comp.get("bom-ref", ""))
+                for comp in sub_components:
+                    list_of_removed_component_bom_refs.append(comp.get("bom-ref", ""))
             else:
                 remove_internal_information_from_properties(component)
                 cleared_components.append(component)

--- a/docs/available_commands.md
+++ b/docs/available_commands.md
@@ -67,6 +67,7 @@ This command creates a redacted version of an SBOM fit for publication. It
 * deletes any *property* (i.e., item in the `properties` array of a component) whose name starts with `internal:` from all components.
 
 The actions are performed in this order, meaning that *internal* properties will be taken into account when matching the JSON schema.
+If a component containing nested components is deleted, those nested components are deleted as well.
 
 The JSON schema must be formulated according to the Draft 7 specification.
 

--- a/tests/auxiliary/test_build_public_bom_sboms/Acme_Application_9.1.1_20220217T101458.cdx.json
+++ b/tests/auxiliary/test_build_public_bom_sboms/Acme_Application_9.1.1_20220217T101458.cdx.json
@@ -234,8 +234,14 @@
     {
       "ref": "comp1",
       "dependsOn": [
+        "sub_comp1",
         "comp2",
         "comp4"
+      ]
+    },
+    {
+      "ref": "sub_comp1",
+      "dependsOn": [
       ]
     },
     {

--- a/tests/auxiliary/test_build_public_bom_sboms/internal_removed_sbom.json
+++ b/tests/auxiliary/test_build_public_bom_sboms/internal_removed_sbom.json
@@ -142,9 +142,14 @@
     {
       "ref": "comp1",
       "dependsOn": [
+        "sub_comp1",
         "comp2",
         "comp4"
       ]
+    },
+    {
+      "ref": "sub_comp1",
+      "dependsOn": []
     },
     {
       "ref": "comp2",

--- a/tests/test_build_public_bom.py
+++ b/tests/test_build_public_bom.py
@@ -37,6 +37,7 @@ relative_path_to_example_schema_2 = (
 )
 path_to_example_schema_2 = Path(os.path.abspath(relative_path_to_example_schema_2))
 
+
 relative_path_to_documentation_schema_1 = (
     "tests/auxiliary/test_build_public_bom_sboms/schema/documentation_schema_1.json"
 )
@@ -154,8 +155,6 @@ class TestCreateExternalBom(unittest.TestCase):
         sbom = get_test_sbom()
         public_sbom = get_public_sbom()
         external_bom = b_p_b.build_public_bom(sbom, path_to_example_schema_1)
-        dumpsbom(public_sbom, "public.json")
-        dumpsbom(external_bom, "external.json")
         self.assertDictEqual(public_sbom, external_bom)
 
     def test_build_public_group_is_internal_name_contained_is_public(self) -> None:
@@ -260,4 +259,25 @@ class TestCreateExternalBom(unittest.TestCase):
                 ],
             }
         ]
+        self.assertDictEqual(external_bom, public_sbom)
+
+    def test_build_public_delete_nested_components(self) -> None:
+        sbom = get_test_sbom()
+        sbom["components"][0]["group"] = "com.acme.internal"
+        public_sbom = get_test_sbom()
+        public_sbom["components"].pop(0)
+        public_sbom["compositions"][0]["assemblies"].pop(0)
+        public_sbom["compositions"][0]["assemblies"].pop(0)
+        public_sbom["dependencies"][0]["dependsOn"].pop(0)
+        public_sbom["dependencies"][0]["dependsOn"].append("comp4")
+        public_sbom["dependencies"].pop(1)
+        public_sbom["dependencies"].pop(1)
+        public_sbom["metadata"]["component"]["properties"].pop(1)
+        public_sbom["components"][0]["properties"].pop(1)
+        public_sbom["components"][0]["properties"].pop(2)
+        public_sbom["components"][5]["properties"].pop(0)
+        public_sbom["components"][2]["properties"].pop(0)
+        public_sbom["components"][1]["properties"].pop(0)
+        public_sbom["components"][4]["properties"].pop(0)
+        external_bom = b_p_b.build_public_bom(sbom, path_to_documentation_schema_1)
         self.assertDictEqual(external_bom, public_sbom)

--- a/tests/test_build_public_bom.py
+++ b/tests/test_build_public_bom.py
@@ -37,7 +37,6 @@ relative_path_to_example_schema_2 = (
 )
 path_to_example_schema_2 = Path(os.path.abspath(relative_path_to_example_schema_2))
 
-
 relative_path_to_documentation_schema_1 = (
     "tests/auxiliary/test_build_public_bom_sboms/schema/documentation_schema_1.json"
 )
@@ -155,6 +154,8 @@ class TestCreateExternalBom(unittest.TestCase):
         sbom = get_test_sbom()
         public_sbom = get_public_sbom()
         external_bom = b_p_b.build_public_bom(sbom, path_to_example_schema_1)
+        dumpsbom(public_sbom, "public.json")
+        dumpsbom(external_bom, "external.json")
         self.assertDictEqual(public_sbom, external_bom)
 
     def test_build_public_group_is_internal_name_contained_is_public(self) -> None:


### PR DESCRIPTION
Nested components of a deleted component will now also be removed from the SBOM.

closes #151 

depends on #196 