### PR TITLE
feat: make validate write to stdout

### DIFF
--- a/cdxev/__main__.py
+++ b/cdxev/__main__.py
@@ -486,7 +486,7 @@ def create_validation_parser(
     subparsers: argparse._SubParsersAction,
 ) -> argparse.ArgumentParser:
     parser = subparsers.add_parser(
-        "validate", help="Validates a SBOM against a given specification."
+        "validate", help="Validates an SBOM against a given specification."
     )
     parser.add_argument(
         "input",

--- a/cdxev/validator/validate.py
+++ b/cdxev/validator/validate.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import sys
 import typing as t
 from pathlib import Path
 
@@ -16,8 +17,6 @@ from cdxev.error import AppError
 from cdxev.log import LogMessage
 from cdxev.validator.customreports import GitLabCQReporter, WarningsNgReporter
 from cdxev.validator.helper import load_spdx_schema, open_schema, validate_filename
-
-logger = logging.getLogger(__name__)
 
 
 def validate_sbom(
@@ -35,6 +34,10 @@ def validate_sbom(
         raise AssertionError(  # pragma: no cover
             "Exactly one of schema_path or schema_type must be non-None"
         )
+
+    logger = logging.getLogger(__name__)
+    logger.propagate = False
+    logger.addHandler(logging.StreamHandler(sys.stdout))
 
     if input_format == "json":
         try:

--- a/docs/source/usage/validate.rst
+++ b/docs/source/usage/validate.rst
@@ -60,7 +60,7 @@ Either ``<timestamp>`` or ``<hash>`` must be present. If both are specified, ``<
 Output
 ------
 
-By default, the command writes human-readable validation results to *stderr* only. For integration into CI/CD several machine-readable report formats are supported as well. To have a report written to a file, select the format using the ``--report-format`` option and an output path using the ``--report-path`` option.
+By default, the command writes human-readable validation results to *stdout* only. For integration into CI/CD several machine-readable report formats are supported as well. To have a report written to a file, select the format using the ``--report-format`` option and an output path using the ``--report-path`` option.
 
 These formats are currently supported:
 
@@ -69,7 +69,7 @@ These formats are currently supported:
 
 Examples::
 
-    # Write human-readable messages to stderr and a report in warnings-ng format to report.json
+    # Write human-readable messages to stdout and a report in warnings-ng format to report.json
     cdx-ev validate bom.json --report-format warnings-ng --report-path report.json
 
     # Write only a report in GitLab Code Quality format to cq.json

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -817,9 +817,9 @@ class TestValidate:
             str(input),
         )
         if expected_errors:
-            exit_code, _, stderr = run_main(capsys)
+            exit_code, stdout, _ = run_main(capsys)
             for e in expected_errors:
-                assert e in stderr
+                assert e in stdout
         else:
             exit_code, _ = run_main()
 
@@ -877,7 +877,7 @@ class TestValidate:
         self,
         argv: Callable[..., None],
         data_dir: Path,
-        caplog: pytest.LogCaptureFixture,
+        capsys: pytest.CaptureFixture[str],
     ):
         argv(
             "validate",
@@ -885,39 +885,34 @@ class TestValidate:
             "fail",
             str(data_dir / "validate" / "valid" / "default" / "laravel_1.4.cdx.json"),
         )
-        exit_code, *_ = run_main()
+        exit_code, stdout, _ = run_main(capsys=capsys)
 
         assert exit_code == Status.VALIDATION_ERROR
-        assert len(caplog.records) == 1
-        assert (
-            caplog.records[0].msg.description  # type: ignore
-            == "filename doesn't match regular expression fail"
-        )
+        assert "filename doesn't match regular expression fail" in stdout
 
     def test_implicit_filename_validation(
         self,
         argv: Callable[..., None],
         data_dir: Path,
-        caplog: pytest.LogCaptureFixture,
+        capsys: pytest.CaptureFixture[str],
     ):
         argv(
             "validate",
             str(data_dir / "validate.invalid_filename.json"),
         )
-        exit_code, *_ = run_main()
+        exit_code, stdout, _ = run_main(capsys=capsys)
 
         assert exit_code == Status.OK
-        assert len(caplog.records) == 2
         assert (
-            caplog.records[0].msg
-            == "filename doesn't match regular expression ^(bom\\.json|.+\\.cdx\\.json)$"
+            "filename doesn't match regular expression ^(bom\\.json|.+\\.cdx\\.json)$"
+            in stdout
         )
 
     def test_custom_schema(
         self,
         argv: Callable[..., None],
         data_dir: Path,
-        caplog: pytest.LogCaptureFixture,
+        capsys: pytest.CaptureFixture[str],
     ):
         argv(
             "validate",
@@ -925,12 +920,10 @@ class TestValidate:
             str(data_dir / "validate.custom_schema.json"),
             str(data_dir / "validate" / "valid" / "default" / "laravel_1.4.cdx.json"),
         )
-        exit_code, *_ = run_main()
+        exit_code, stdout, _ = run_main(capsys=capsys)
 
         assert exit_code == Status.VALIDATION_ERROR
-
-        assert len(caplog.records) == 1
-        assert caplog.records[0].msg.description.endswith("is not of type 'array'")  # type: ignore
+        assert stdout.endswith("is not of type 'array'\n")
 
     def test_invalid_schema(
         self,


### PR DESCRIPTION
The validate command now writes it's output to _stdout_ instead of _stderr_.