### PR TITLE
chore: exclude tests from mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ build_command = "pip install poetry && poetry build"
 
 [tool.mypy]
 packages = "cdxev"
+# Excludes tests even when mypy is invoked with a path (as the VS Code extension does, for instance)
+exclude = ['tests/']
 disallow_untyped_defs = true
 no_error_summary = true
 


### PR DESCRIPTION
The current mypy config makes it run only on the `cdxev` package, when invoked without any path. However, mypy completely ignores the `package` config in `pyproject.toml` when it is invoked with a path to a folder or file. Unfortunately, that is exactly what the VS Code extension does, it runs mypy either with the path to a file or to the workspace folder.

This PR adds an additional `exclude` option to `pyproject.toml` which mypy always observes.