### PR TITLE
fix: implemented schema changes to licenses field from CDX 1.5 and 1.6

### DIFF
--- a/cdxev/auxiliary/schema/bom-1.4-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.4-custom.schema.json
@@ -4,28 +4,16 @@
   "type": "object",
   "title": "CycloneDX Software Bill of Materials Standard",
   "$comment": "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
-  "if": {
-    "required": [
-      "components"
-    ]
-  },
-  "then": {
-    "required": [
-      "bomFormat",
-      "specVersion",
-      "version",
-      "metadata",
-      "compositions",
+  "required": [
+    "bomFormat",
+    "specVersion",
+    "version",
+    "metadata",
+    "compositions"
+  ],
+  "dependencies": {
+    "components": [
       "dependencies"
-    ]
-  },
-  "else": {
-    "required": [
-      "bomFormat",
-      "specVersion",
-      "version",
-      "metadata",
-      "compositions"
     ]
   },
   "additionalProperties": false,

--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -4,28 +4,16 @@
   "type": "object",
   "title": "CycloneDX Software Bill of Materials Standard",
   "$comment": "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
-  "if": {
-    "required": [
-      "components"
-    ]
-  },
-  "then": {
-    "required": [
-      "bomFormat",
-      "specVersion",
-      "version",
-      "metadata",
-      "compositions",
+  "required": [
+    "bomFormat",
+    "specVersion",
+    "version",
+    "metadata",
+    "compositions"
+  ],
+  "dependencies": {
+    "components": [
       "dependencies"
-    ]
-  },
-  "else": {
-    "required": [
-      "bomFormat",
-      "specVersion",
-      "version",
-      "metadata",
-      "compositions"
     ]
   },
   "additionalProperties": false,

--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -4,30 +4,6 @@
   "type": "object",
   "title": "CycloneDX Software Bill of Materials Standard",
   "$comment": "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
-  "if": {
-    "required": [
-      "components"
-    ]
-  },
-  "then": {
-    "required": [
-      "bomFormat",
-      "specVersion",
-      "version",
-      "metadata",
-      "compositions",
-      "dependencies"
-    ]
-  },
-  "else": {
-    "required": [
-      "bomFormat",
-      "specVersion",
-      "version",
-      "metadata",
-      "compositions"
-    ]
-  },
   "additionalProperties": false,
   "properties": {
     "$schema": {
@@ -65,6 +41,7 @@
       "type": "integer",
       "title": "BOM Version",
       "description": "Whenever an existing BOM is modified, either manually or through automated processes, the version of the BOM SHOULD be incremented by 1. When a system is presented with multiple BOMs with identical serial numbers, the system SHOULD use the most recent version of the BOM. The default version is '1'.",
+      "minimum": 1,
       "default": 1,
       "examples": [
         1
@@ -77,7 +54,6 @@
     },
     "components": {
       "type": "array",
-      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/component"
       },
@@ -87,7 +63,6 @@
     },
     "services": {
       "type": "array",
-      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/service"
       },
@@ -97,16 +72,14 @@
     },
     "externalReferences": {
       "type": "array",
-      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/externalReference"
       },
       "title": "External References",
-      "description": "External references provide a way to document systems, sites, and information that may be relevant but which are not included with the BOM."
+      "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
     },
     "dependencies": {
       "type": "array",
-      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/dependency"
       },
@@ -116,17 +89,15 @@
     },
     "compositions": {
       "type": "array",
-      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/compositions"
       },
       "uniqueItems": true,
       "title": "Compositions",
-      "description": "Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness."
+      "description": "Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness. The completeness of vulnerabilities expressed in a BOM may also be described."
     },
     "vulnerabilities": {
       "type": "array",
-      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/vulnerability"
       },
@@ -136,26 +107,26 @@
     },
     "annotations": {
       "type": "array",
-      "additionalItems": false,
       "items": {
-        "type": "object"
+        "$ref": "#/definitions/annotations"
       },
+      "uniqueItems": true,
       "title": "Annotations",
-      "description": "Comments made by people, organizations, or tools about any object with a bom-ref."
+      "description": "Comments made by people, organizations, or tools about any object with a bom-ref, such as components, services, vulnerabilities, or the BOM itself. Unlike inventory information, annotations may contain opinion or commentary from various stakeholders. Annotations may be inline (with inventory) or externalized via BOM-Link, and may optionally be signed."
     },
     "formulation": {
       "type": "array",
-      "additionalItems": false,
       "items": {
-        "type": "object"
+        "$ref": "#/definitions/formula"
       },
+      "uniqueItems": true,
       "title": "Formulation",
-      "description": "Describes how a component or service was manufactured or deployed."
+      "description": "Describes how a component or service was manufactured or deployed. This is achieved through the use of formulas, workflows, tasks, and steps, which declare the precise steps to reproduce along with the observed formulas describing the steps which transpired in the manufacturing process."
     },
     "properties": {
       "type": "array",
       "title": "Properties",
-      "additionalItems": false,
+      "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
       "items": {
         "$ref": "#/definitions/property"
       }
@@ -168,12 +139,13 @@
   },
   "definitions": {
     "refType": {
-      "$comment": "Identifier-DataType for interlinked elements.",
+      "description": "Identifier for referable and therefore interlink-able elements.",
       "type": "string",
-      "additionalProperties": false
+      "minLength": 1,
+      "$comment": "value SHOULD not start with the BOM-Link intro 'urn:cdx:'"
     },
     "refLinkType": {
-      "description": "Descriptor for an element identified by the attribute 'bom-ref' in the same BOM document.",
+      "description": "Descriptor for an element identified by the attribute 'bom-ref' in the same BOM document.\nIn contrast to `bomLinkElementType`.",
       "allOf": [
         {
           "$ref": "#/definitions/refType"
@@ -182,17 +154,19 @@
     },
     "bomLinkDocumentType": {
       "title": "BOM-Link Document",
-      "description": "Descriptor for another BOM document.",
+      "description": "Descriptor for another BOM document. See https://cyclonedx.org/capabilities/bomlink/",
       "type": "string",
       "format": "iri-reference",
-      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*$"
+      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*$",
+      "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
     },
     "bomLinkElementType": {
       "title": "BOM-Link Element",
-      "description": "Descriptor for an element in a BOM document.",
+      "description": "Descriptor for an element in a BOM document. See https://cyclonedx.org/capabilities/bomlink/",
       "type": "string",
       "format": "iri-reference",
-      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*#.+$"
+      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*#.+$",
+      "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
     },
     "bomLink": {
       "anyOf": [
@@ -220,8 +194,53 @@
         "lifecycles": {
           "type": "array",
           "title": "Lifecycles",
+          "description": "",
           "items": {
-            "type": "object"
+            "type": "object",
+            "title": "Lifecycle",
+            "description": "The product lifecycle(s) that this BOM represents.",
+            "oneOf": [
+              {
+                "required": [
+                  "phase"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "phase": {
+                    "type": "string",
+                    "title": "Phase",
+                    "description": "A pre-defined phase in the product lifecycle.\n\n* __design__ = BOM produced early in the development lifecycle containing inventory of components and services that are proposed or planned to be used. The inventory may need to be procured, retrieved, or resourced prior to use.\n* __pre-build__ = BOM consisting of information obtained prior to a build process and may contain source files and development artifacts and manifests. The inventory may need to be resolved and retrieved prior to use.\n* __build__ = BOM consisting of information obtained during a build process where component inventory is available for use. The precise versions of resolved components are usually available at this time as well as the provenance of where the components were retrieved from.\n* __post-build__ = BOM consisting of information obtained after a build process has completed and the resulting components(s) are available for further analysis. Built components may exist as the result of a CI/CD process, may have been installed or deployed to a system or device, and may need to be retrieved or extracted from the system or device.\n* __operations__ = BOM produced that represents inventory that is running and operational. This may include staging or production environments and will generally encompass multiple SBOMs describing the applications and operating system, along with HBOMs describing the hardware that makes up the system. Operations Bill of Materials (OBOM) can provide full-stack inventory of runtime environments, configurations, and additional dependencies.\n* __discovery__ = BOM consisting of information observed through network discovery providing point-in-time enumeration of embedded, on-premise, and cloud-native services such as server applications, connected devices, microservices, and serverless functions.\n* __decommission__ = BOM containing inventory that will be, or has been retired from operations.",
+                    "enum": [
+                      "design",
+                      "pre-build",
+                      "build",
+                      "post-build",
+                      "operations",
+                      "discovery",
+                      "decommission"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "name"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the lifecycle phase"
+                  },
+                  "description": {
+                    "type": "string",
+                    "title": "Description",
+                    "description": "The description of the lifecycle phase"
+                  }
+                }
+              }
+            ]
           }
         },
         "tools": {
@@ -229,6 +248,7 @@
             {
               "type": "object",
               "title": "Creation Tools",
+              "description": "The tool(s) used in the creation of the BOM.",
               "additionalProperties": false,
               "properties": {
                 "components": {
@@ -238,19 +258,26 @@
                     "required": [
                       "type"
                     ]
-                  }
+                  },
+                  "uniqueItems": true,
+                  "title": "Components",
+                  "description": "A list of software and hardware components used as tools"
                 },
                 "services": {
                   "type": "array",
                   "items": {
                     "type": "object"
-                  }
+                  },
+                  "uniqueItems": true,
+                  "title": "Services",
+                  "description": "A list of services used as tools. This may include microservices, function-as-a-service, and other types of network or intra-process services."
                 }
               }
             },
             {
               "type": "array",
               "title": "Creation Tools (legacy)",
+              "description": "[Deprecated] The tool(s) used in the creation of the BOM.",
               "items": {
                 "$ref": "#/definitions/tool"
               }
@@ -261,7 +288,6 @@
           "type": "array",
           "title": "Authors",
           "description": "The person(s) who created the BOM. Authors are common in BOMs created through manual processes. BOMs created through automated means may not have authors.",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/organizationalContact"
           }
@@ -282,10 +308,9 @@
           "$ref": "#/definitions/organizationalEntity"
         },
         "licenses": {
-          "type": "array",
           "title": "BOM License(s)",
           "minItems": 1,
-          "additionalItems": false,
+          "type": "array",
           "items": {
             "$ref": "#/definitions/licenseChoice"
           }
@@ -293,7 +318,7 @@
         "properties": {
           "type": "array",
           "title": "Properties",
-          "additionalItems": false,
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -308,7 +333,7 @@
     "tool": {
       "type": "object",
       "title": "Tool",
-      "description": "Information about the automated or manual tool used",
+      "description": "[Deprecated] - DO NOT USE. This will be removed in a future version. This will be removed in a future version. Use component or service instead. Information about the automated or manual tool used",
       "additionalProperties": false,
       "properties": {
         "vendor": {
@@ -328,7 +353,6 @@
         },
         "hashes": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/hash"
           },
@@ -337,12 +361,11 @@
         },
         "externalReferences": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/externalReference"
           },
           "title": "External References",
-          "description": "External references provide a way to document systems, sites, and information that may be relevant but which are not included with the BOM."
+          "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
         }
       }
     },
@@ -360,11 +383,11 @@
         "name": {
           "type": "string",
           "title": "Name",
-          "minLength": 1,
           "description": "The name of the organization",
           "examples": [
             "Example Inc."
-          ]
+          ],
+          "minLength": 1
         },
         "url": {
           "type": "array",
@@ -382,7 +405,6 @@
           "type": "array",
           "title": "Contact",
           "description": "A contact at the organization. Multiple contacts are allowed.",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/organizationalContact"
           }
@@ -474,6 +496,7 @@
             "data"
           ],
           "title": "Component Type",
+          "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component. Types include:\n\n* __application__ = A software application. Refer to [https://en.wikipedia.org/wiki/Application_software](https://en.wikipedia.org/wiki/Application_software) for information about applications.\n* __framework__ = A software framework. Refer to [https://en.wikipedia.org/wiki/Software_framework](https://en.wikipedia.org/wiki/Software_framework) for information on how frameworks vary slightly from libraries.\n* __library__ = A software library. Refer to [https://en.wikipedia.org/wiki/Library_(computing)](https://en.wikipedia.org/wiki/Library_(computing))\n for information about libraries. All third-party and open source reusable components will likely be a library. If the library also has key features of a framework, then it should be classified as a framework. If not, or is unknown, then specifying library is RECOMMENDED.\n* __container__ = A packaging and/or runtime format, not specific to any particular technology, which isolates software inside the container from software outside of a container through virtualization technology. Refer to [https://en.wikipedia.org/wiki/OS-level_virtualization](https://en.wikipedia.org/wiki/OS-level_virtualization)\n* __platform__ = A runtime environment which interprets or executes software. This may include runtimes such as those that execute bytecode or low-code/no-code application platforms.\n* __operating-system__ = A software operating system without regard to deployment model (i.e. installed on physical hardware, virtual machine, image, etc) Refer to [https://en.wikipedia.org/wiki/Operating_system](https://en.wikipedia.org/wiki/Operating_system)\n* __device__ = A hardware device such as a processor, or chip-set. A hardware device containing firmware SHOULD include a component for the physical hardware itself, and another component of type 'firmware' or 'operating-system' (whichever is relevant), describing information about the software running on the device.\n  See also the list of [known device properties](https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/device.md).\n* __device-driver__ = A special type of software that operates or controls a particular type of device. Refer to [https://en.wikipedia.org/wiki/Device_driver](https://en.wikipedia.org/wiki/Device_driver)\n* __firmware__ = A special type of software that provides low-level control over a devices hardware. Refer to [https://en.wikipedia.org/wiki/Firmware](https://en.wikipedia.org/wiki/Firmware)\n* __file__ = A computer file. Refer to [https://en.wikipedia.org/wiki/Computer_file](https://en.wikipedia.org/wiki/Computer_file) for information about files.\n* __machine-learning-model__ = A model based on training data that can make predictions or decisions without being explicitly programmed to do so.\n* __data__ = A collection of discrete values that convey information.",
           "examples": [
             "library"
           ]
@@ -523,21 +546,21 @@
         },
         "name": {
           "type": "string",
-          "minLength": 1,
           "title": "Component Name",
           "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
           "examples": [
             "tomcat-catalina"
-          ]
+          ],
+          "minLength": 1
         },
         "version": {
           "type": "string",
           "title": "Component Version",
-          "minLength": 1,
           "description": "The component version. The version should ideally comply with semantic versioning but is not enforced.",
           "examples": [
             "9.0.14"
-          ]
+          ],
+          "minLength": 1
         },
         "description": {
           "type": "string",
@@ -558,19 +581,17 @@
         "hashes": {
           "type": "array",
           "title": "Component Hashes",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/hash"
           }
         },
         "licenses": {
+          "title": "Component License(s)",
+          "minItems": 1,
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/licenseChoice"
-          },
-          "minItems": 1,
-          "title": "Component License(s)"
+          }
         },
         "copyright": {
           "type": "string",
@@ -603,17 +624,19 @@
         },
         "modified": {
           "type": "boolean",
-          "title": "Component Modified From Original"
+          "title": "Component Modified From Original",
+          "description": "[Deprecated] - DO NOT USE. This will be removed in a future version. Use the pedigree element instead to supply information on exactly how the component was modified. A boolean value indicating if the component has been modified from the original. A value of true indicates the component is a derivative of the original. A value of false indicates the component has not been modified from the original."
         },
         "pedigree": {
           "type": "object",
           "title": "Component Pedigree",
+          "description": "Component pedigree is a way to document complex supply chain scenarios where components are created, distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to document variants where the exact relation may not be known.",
           "additionalProperties": false,
           "properties": {
             "ancestors": {
               "type": "array",
               "title": "Ancestors",
-              "additionalItems": false,
+              "description": "Describes zero or more components in which a component is derived from. This is commonly used to describe forks from existing projects where the forked version contains a ancestor node containing the original component it was forked from. For example, Component A is the original component. Component B is the component being used and documented in the BOM. However, Component B contains a pedigree node with a single ancestor documenting Component A - the original component from which Component B is derived from.",
               "items": {
                 "$ref": "#/definitions/component"
               }
@@ -621,7 +644,7 @@
             "descendants": {
               "type": "array",
               "title": "Descendants",
-              "additionalItems": false,
+              "description": "Descendants are the exact opposite of ancestors. This provides a way to document all forks (and their forks) of an original or root component.",
               "items": {
                 "$ref": "#/definitions/component"
               }
@@ -629,7 +652,7 @@
             "variants": {
               "type": "array",
               "title": "Variants",
-              "additionalItems": false,
+              "description": "Variants describe relations where the relationship between the components are not known. For example, if Component A contains nearly identical code to Component B. They are both related, but it is unclear if one is derived from the other, or if they share a common ancestor.",
               "items": {
                 "$ref": "#/definitions/component"
               }
@@ -637,7 +660,7 @@
             "commits": {
               "type": "array",
               "title": "Commits",
-              "additionalItems": false,
+              "description": "A list of zero or more commits which provide a trail describing how the component deviates from an ancestor, descendant, or variant.",
               "items": {
                 "$ref": "#/definitions/commit"
               }
@@ -645,64 +668,69 @@
             "patches": {
               "type": "array",
               "title": "Patches",
-              "additionalItems": false,
+              "description": ">A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complimentary to commits or may be used in place of commits.",
               "items": {
                 "$ref": "#/definitions/patch"
               }
             },
             "notes": {
               "type": "string",
-              "title": "Notes"
+              "title": "Notes",
+              "description": "Notes, observations, and other non-structured commentary describing the components pedigree."
             }
           }
         },
         "externalReferences": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/externalReference"
           },
-          "title": "External References"
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
         },
         "components": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/component"
           },
           "uniqueItems": true,
-          "title": "Components"
+          "title": "Components",
+          "description": "A list of software and hardware components included in the parent component. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system &#8594; subsystem &#8594; parts assembly in physical supply chains."
         },
         "evidence": {
           "$ref": "#/definitions/componentEvidence",
-          "title": "Evidence"
+          "title": "Evidence",
+          "description": "Provides the ability to document evidence collected through various forms of extraction or analysis."
         },
         "releaseNotes": {
           "$ref": "#/definitions/releaseNotes",
-          "title": "Release notes"
+          "title": "Release notes",
+          "description": "Specifies optional release notes."
         },
         "modelCard": {
-          "type": "object",
+          "$ref": "#/definitions/modelCard",
           "title": "Machine Learning Model Card"
         },
         "data": {
           "type": "array",
           "items": {
-            "type": "object"
+            "$ref": "#/definitions/componentData"
           },
-          "title": "Data"
+          "title": "Data",
+          "description": "This object SHOULD be specified for any component of type `data` and MUST NOT be specified for other component types."
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "additionalItems": false,
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
           "items": {
             "$ref": "#/definitions/property"
           }
         },
         "signature": {
           "$ref": "#/definitions/signature",
-          "title": "Signature"
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
         }
       },
       "anyOf": [
@@ -1082,8 +1110,8 @@
         "content": {
           "type": "string",
           "title": "Attachment Text",
-          "minLength": 1,
-          "description": "The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text."
+          "description": "The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text.",
+          "minLength": 1
         }
       }
     },
@@ -1120,8 +1148,7 @@
         "BLAKE2b-512",
         "BLAKE3"
       ],
-      "title": "Hash Algorithm",
-      "additionalProperties": false
+      "title": "Hash Algorithm"
     },
     "hash-content": {
       "type": "string",
@@ -1129,8 +1156,7 @@
       "examples": [
         "3942447fac867ae5cdb3229b658f4d48"
       ],
-      "pattern": "^([a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$",
-      "additionalProperties": false
+      "pattern": "^([a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$"
     },
     "license": {
       "type": "object",
@@ -1164,12 +1190,12 @@
         },
         "name": {
           "type": "string",
-          "minLength": 1,
           "title": "License Name",
           "description": "If SPDX does not define the license used, this field may be used to provide the license name",
           "examples": [
             "Acme Software License"
-          ]
+          ],
+          "minLength": 1
         },
         "text": {
           "title": "License text",
@@ -1190,32 +1216,11 @@
           "title": "Licensing information",
           "description": "Licensing details describing the licensor/licensee, license type, renewal and expiration dates, and other important metadata",
           "additionalProperties": false,
-          "required": [
-            "licenseTypes"
-          ],
-          "if": {
-            "properties": {
-              "licenseTypes": {
-                "contains": {
-                  "not": {
-                    "const": "appliance"
-                  }
-                }
-              }
-            },
-            "required": [
-              "licenseTypes"
-            ]
-          },
-          "then": {
-            "required": [
-              "licensor"
-            ]
-          },
           "properties": {
             "altIds": {
               "type": "array",
               "title": "Alternate License Identifiers",
+              "description": "License identifiers that may be used to manage licenses and their lifecycle",
               "items": {
                 "type": "string"
               }
@@ -1258,10 +1263,12 @@
               "properties": {
                 "organization": {
                   "title": "Licensee (Organization)",
+                  "description": "The organization that was granted the license",
                   "$ref": "#/definitions/organizationalEntity"
                 },
                 "individual": {
                   "title": "Licensee (Individual)",
+                  "description": "The individual, not associated with an organization, that was granted the license",
                   "$ref": "#/definitions/organizationalContact"
                 }
               },
@@ -1286,10 +1293,12 @@
               "properties": {
                 "organization": {
                   "title": "Purchaser (Organization)",
+                  "description": "The organization that purchased the license",
                   "$ref": "#/definitions/organizationalEntity"
                 },
                 "individual": {
                   "title": "Purchaser (Individual)",
+                  "description": "The individual, not associated with an organization, that purchased the license",
                   "$ref": "#/definitions/organizationalContact"
                 }
               },
@@ -1308,11 +1317,13 @@
             },
             "purchaseOrder": {
               "type": "string",
-              "title": "Purchase Order"
+              "title": "Purchase Order",
+              "description": "The purchase order identifier the purchaser sent to a supplier or vendor to authorize a purchase"
             },
             "licenseTypes": {
               "type": "array",
               "title": "License Type",
+              "description": "The type of license(s) that was granted to the licensee\n\n* __academic__ = A license that grants use of software solely for the purpose of education or research.\n* __appliance__ = A license covering use of software embedded in a specific piece of hardware.\n* __client-access__ = A Client Access License (CAL) allows client computers to access services provided by server software.\n* __concurrent-user__ = A Concurrent User license (aka floating license) limits the number of licenses for a software application and licenses are shared among a larger number of users.\n* __core-points__ = A license where the core of a computer's processor is assigned a specific number of points.\n* __custom-metric__ = A license for which consumption is measured by non-standard metrics.\n* __device__ = A license that covers a defined number of installations on computers and other types of devices.\n* __evaluation__ = A license that grants permission to install and use software for trial purposes.\n* __named-user__ = A license that grants access to the software to one or more pre-defined users.\n* __node-locked__ = A license that grants access to the software on one or more pre-defined computers or devices.\n* __oem__ = An Original Equipment Manufacturer license that is delivered with hardware, cannot be transferred to other hardware, and is valid for the life of the hardware.\n* __perpetual__ = A license where the software is sold on a one-time basis and the licensee can use a copy of the software indefinitely.\n* __processor-points__ = A license where each installation consumes points per processor.\n* __subscription__ = A license where the licensee pays a fee to use the software or service.\n* __user__ = A license that grants access to the software or service by a specified number of users.\n* __other__ = Another license type.\n",
               "items": {
                 "type": "string",
                 "enum": [
@@ -1338,18 +1349,43 @@
             "lastRenewal": {
               "type": "string",
               "format": "date-time",
-              "title": "Last Renewal"
+              "title": "Last Renewal",
+              "description": "The timestamp indicating when the license was last renewed. For new purchases, this is often the purchase or acquisition date. For non-perpetual licenses or subscriptions, this is the timestamp of when the license was last renewed."
             },
             "expiration": {
               "type": "string",
               "format": "date-time",
-              "title": "Expiration"
+              "title": "Expiration",
+              "description": "The timestamp indicating when the current license expires (if applicable)."
             }
+          },
+          "required": [
+            "licenseTypes"
+          ],
+          "if": {
+            "properties": {
+              "licenseTypes": {
+                "contains": {
+                  "not": {
+                    "const": "appliance"
+                  }
+                }
+              }
+            },
+            "required": [
+              "licenseTypes"
+            ]
+          },
+          "then": {
+            "required": [
+              "licensor"
+            ]
           }
         },
         "properties": {
           "type": "array",
           "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -1401,24 +1437,29 @@
       "properties": {
         "uid": {
           "type": "string",
-          "title": "UID"
+          "title": "UID",
+          "description": "A unique identifier of the commit. This may be version control specific. For example, Subversion uses revision numbers whereas git uses commit hashes."
         },
         "url": {
           "type": "string",
           "title": "URL",
+          "description": "The URL to the commit. This URL will typically point to a commit in a version control system.",
           "format": "iri-reference"
         },
         "author": {
           "title": "Author",
+          "description": "The author who created the changes in the commit",
           "$ref": "#/definitions/identifiableAction"
         },
         "committer": {
           "title": "Committer",
+          "description": "The person who committed or pushed the commit",
           "$ref": "#/definitions/identifiableAction"
         },
         "message": {
           "type": "string",
-          "title": "Message"
+          "title": "Message",
+          "description": "The text description of the contents of the commit"
         }
       }
     },
@@ -1439,41 +1480,46 @@
             "backport",
             "cherry-pick"
           ],
-          "title": "Type"
+          "title": "Type",
+          "description": "Specifies the purpose for the patch including the resolution of defects, security issues, or new behavior or functionality.\n\n* __unofficial__ = A patch which is not developed by the creators or maintainers of the software being patched. Refer to [https://en.wikipedia.org/wiki/Unofficial_patch](https://en.wikipedia.org/wiki/Unofficial_patch)\n* __monkey__ = A patch which dynamically modifies runtime behavior. Refer to [https://en.wikipedia.org/wiki/Monkey_patch](https://en.wikipedia.org/wiki/Monkey_patch)\n* __backport__ = A patch which takes code from a newer version of software and applies it to older versions of the same software. Refer to [https://en.wikipedia.org/wiki/Backporting](https://en.wikipedia.org/wiki/Backporting)\n* __cherry-pick__ = A patch created by selectively applying commits from other versions or branches of the same software."
         },
         "diff": {
           "title": "Diff",
+          "description": "The patch file (or diff) that show changes. Refer to [https://en.wikipedia.org/wiki/Diff](https://en.wikipedia.org/wiki/Diff)",
           "$ref": "#/definitions/diff"
         },
         "resolves": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/issue"
           },
-          "title": "Resolves"
+          "title": "Resolves",
+          "description": "A collection of issues the patch resolves"
         }
       }
     },
     "diff": {
       "type": "object",
       "title": "Diff",
+      "description": "The patch file (or diff) that show changes. Refer to https://en.wikipedia.org/wiki/Diff",
       "additionalProperties": false,
       "properties": {
         "text": {
           "title": "Diff text",
+          "description": "Specifies the optional text of the diff",
           "$ref": "#/definitions/attachment"
         },
         "url": {
           "type": "string",
           "title": "URL",
+          "description": "Specifies the URL to the diff",
           "format": "iri-reference"
         }
       }
     },
     "issue": {
       "type": "object",
-      "title": "Issue",
+      "title": "Diff",
       "description": "An individual issue that has been resolved.",
       "required": [
         "type"
@@ -1487,32 +1533,39 @@
             "enhancement",
             "security"
           ],
-          "title": "Type"
+          "title": "Type",
+          "description": "Specifies the type of issue"
         },
         "id": {
           "type": "string",
-          "title": "ID"
+          "title": "ID",
+          "description": "The identifier of the issue assigned by the source of the issue"
         },
         "name": {
           "type": "string",
-          "title": "Name"
+          "title": "Name",
+          "description": "The name of the issue"
         },
         "description": {
           "type": "string",
-          "title": "Description"
+          "title": "Description",
+          "description": "A description of the issue"
         },
         "source": {
           "type": "object",
           "title": "Source",
+          "description": "The source of the issue where it is documented",
           "additionalProperties": false,
           "properties": {
             "name": {
               "type": "string",
-              "title": "Name"
+              "title": "Name",
+              "description": "The name of the source. For example 'National Vulnerability Database', 'NVD', and 'Apache'"
             },
             "url": {
               "type": "string",
               "title": "URL",
+              "description": "The url of the issue documentation as provided by the source",
               "format": "iri-reference"
             }
           }
@@ -1523,35 +1576,43 @@
             "type": "string",
             "format": "iri-reference"
           },
-          "title": "References"
+          "title": "References",
+          "description": "A collection of URL's for reference. Multiple URLs are allowed.",
+          "examples": [
+            "https://example.com"
+          ]
         }
       }
     },
     "identifiableAction": {
       "type": "object",
       "title": "Identifiable Action",
+      "description": "Specifies an individual commit",
       "additionalProperties": false,
       "properties": {
         "timestamp": {
           "type": "string",
           "format": "date-time",
-          "title": "Timestamp"
+          "title": "Timestamp",
+          "description": "The timestamp in which the action occurred"
         },
         "name": {
           "type": "string",
-          "title": "Name"
+          "title": "Name",
+          "description": "The name of the individual who performed the action"
         },
         "email": {
           "type": "string",
           "format": "idn-email",
-          "title": "E-mail"
+          "title": "E-mail",
+          "description": "The email address of the individual who performed the action"
         }
       }
     },
     "externalReference": {
       "type": "object",
       "title": "External Reference",
-      "description": "Specifies an individual external reference",
+      "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM.",
       "required": [
         "url",
         "type"
@@ -1559,18 +1620,30 @@
       "additionalProperties": false,
       "properties": {
         "url": {
-          "type": "string",
+          "anyOf": [
+            {
+              "title": "URL",
+              "type": "string",
+              "format": "iri-reference"
+            },
+            {
+              "title": "BOM-Link",
+              "$ref": "#/definitions/bomLink"
+            }
+          ],
           "title": "URL",
-          "format": "iri-reference",
+          "description": "The URI (URL or URN) to the external reference. External references are URIs and therefore can accept any URL scheme including https ([RFC-7230](https://www.ietf.org/rfc/rfc7230.txt)), mailto ([RFC-2368](https://www.ietf.org/rfc/rfc2368.txt)), tel ([RFC-3966](https://www.ietf.org/rfc/rfc3966.txt)), and dns ([RFC-4501](https://www.ietf.org/rfc/rfc4501.txt)). External references may also include formally registered URNs such as [CycloneDX BOM-Link](https://cyclonedx.org/capabilities/bomlink/) to reference CycloneDX BOMs or any object within a BOM. BOM-Link transforms applicable external references into relationships that can be expressed in a BOM or across BOMs.",
           "minLength": 1
         },
         "comment": {
           "type": "string",
-          "title": "Comment"
+          "title": "Comment",
+          "description": "An optional comment describing the external reference"
         },
         "type": {
           "type": "string",
           "title": "Type",
+          "description": "Specifies the type of external reference.\n\n* __vcs__ = Version Control System\n* __issue-tracker__ = Issue or defect tracking system, or an Application Lifecycle Management (ALM) system\n* __website__ = Website\n* __advisories__ = Security advisories\n* __bom__ = Bill of Materials (SBOM, OBOM, HBOM, SaaSBOM, etc)\n* __mailing-list__ = Mailing list or discussion group\n* __social__ = Social media account\n* __chat__ = Real-time chat platform\n* __documentation__ = Documentation, guides, or how-to instructions\n* __support__ = Community or commercial support\n* __distribution__ = Direct or repository download location\n* __distribution-intake__ = The location where a component was published to. This is often the same as \"distribution\" but may also include specialized publishing processes that act as an intermediary\n* __license__ = The URL to the license file. If a license URL has been defined in the license node, it should also be defined as an external reference for completeness\n* __build-meta__ = Build-system specific meta file (i.e. pom.xml, package.json, .nuspec, etc)\n* __build-system__ = URL to an automated build system\n* __release-notes__ = URL to release notes\n* __security-contact__ = Specifies a way to contact the maintainer, supplier, or provider in the event of a security incident. Common URIs include links to a disclosure procedure, a mailto (RFC-2368) that specifies an email address, a tel (RFC-3966) that specifies a phone number, or dns (RFC-4501) that specifies the records containing DNS Security TXT\n* __model-card__ = A model card describes the intended uses of a machine learning model, potential limitations, biases, ethical considerations, training parameters, datasets used to train the model, performance metrics, and other relevant data useful for ML transparency\n* __log__ = A record of events that occurred in a computer system or application, such as problems, errors, or information on current operations\n* __configuration__ = Parameters or settings that may be used by other components or services\n* __evidence__ = Information used to substantiate a claim\n* __formulation__ = Describes how a component or service was manufactured or deployed\n* __attestation__ = Human or machine-readable statements containing facts, evidence, or testimony\n* __threat-model__ = An enumeration of identified weaknesses, threats, and countermeasures, dataflow diagram (DFD), attack tree, and other supporting documentation in human-readable or machine-readable format\n* __adversary-model__ = The defined assumptions, goals, and capabilities of an adversary.\n* __risk-assessment__ = Identifies and analyzes the potential of future events that may negatively impact individuals, assets, and/or the environment. Risk assessments may also include judgments on the tolerability of each risk.\n* __vulnerability-assertion__ = A Vulnerability Disclosure Report (VDR) which asserts the known and previously unknown vulnerabilities that affect a component, service, or product including the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on a component, service, or product.\n* __exploitability-statement__ = A Vulnerability Exploitability eXchange (VEX) which asserts the known vulnerabilities that do not affect a product, product family, or organization, and optionally the ones that do. The VEX should include the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on the product, product family, or organization.\n* __pentest-report__ = Results from an authorized simulated cyberattack on a component or service, otherwise known as a penetration test\n* __static-analysis-report__ = SARIF or proprietary machine or human-readable report for which static analysis has identified code quality, security, and other potential issues with the source code\n* __dynamic-analysis-report__ = Dynamic analysis report that has identified issues such as vulnerabilities and misconfigurations\n* __runtime-analysis-report__ = Report generated by analyzing the call stack of a running application\n* __component-analysis-report__ = Report generated by Software Composition Analysis (SCA), container analysis, or other forms of component analysis\n* __maturity-report__ = Report containing a formal assessment of an organization, business unit, or team against a maturity model\n* __certification-report__ = Industry, regulatory, or other certification from an accredited (if applicable) certification body\n* __quality-metrics__ = Report or system in which quality metrics can be obtained\n* __codified-infrastructure__ = Code or configuration that defines and provisions virtualized infrastructure, commonly referred to as Infrastructure as Code (IaC)\n* __poam__ = Plans of Action and Milestones (POAM) compliment an \"attestation\" external reference. POAM is defined by NIST as a \"document that identifies tasks needing to be accomplished. It details resources required to accomplish the elements of the plan, any milestones in meeting the tasks and scheduled completion dates for the milestones\".\n* __other__ = Use this if no other types accurately describe the purpose of the external reference",
           "enum": [
             "vcs",
             "issue-tracker",
@@ -1583,43 +1656,68 @@
             "documentation",
             "support",
             "distribution",
+            "distribution-intake",
             "license",
             "build-meta",
             "build-system",
             "release-notes",
+            "security-contact",
+            "model-card",
+            "log",
+            "configuration",
+            "evidence",
+            "formulation",
+            "attestation",
+            "threat-model",
+            "adversary-model",
+            "risk-assessment",
+            "vulnerability-assertion",
+            "exploitability-statement",
+            "pentest-report",
+            "static-analysis-report",
+            "dynamic-analysis-report",
+            "runtime-analysis-report",
+            "component-analysis-report",
+            "maturity-report",
+            "certification-report",
+            "codified-infrastructure",
+            "quality-metrics",
+            "poam",
             "other"
           ]
         },
         "hashes": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/hash"
           },
-          "title": "Hashes"
+          "title": "Hashes",
+          "description": "The hashes of the external reference (if applicable)."
         }
       }
     },
     "dependency": {
       "type": "object",
       "title": "Dependency",
+      "description": "Defines the direct dependencies of a component or service. Components or services that do not have their own dependencies MUST be declared as empty elements within the graph. Components or services that are not represented in the dependency graph MAY have unknown dependencies. It is RECOMMENDED that implementations assume this to be opaque and not an indicator of a object being dependency-free. It is RECOMMENDED to leverage compositions to indicate unknown dependency graphs.",
       "required": [
         "ref"
       ],
       "additionalProperties": false,
       "properties": {
         "ref": {
-          "$ref": "#/definitions/refType",
-          "title": "Reference"
+          "$ref": "#/definitions/refLinkType",
+          "title": "Reference",
+          "description": "References a component or service by its bom-ref attribute"
         },
         "dependsOn": {
           "type": "array",
           "uniqueItems": true,
-          "additionalItems": false,
           "items": {
-            "$ref": "#/definitions/refType"
+            "$ref": "#/definitions/refLinkType"
           },
-          "title": "Depends On"
+          "title": "Depends On",
+          "description": "The bom-ref identifiers of the components or services that are dependencies of this dependency object."
         }
       }
     },
@@ -1633,27 +1731,42 @@
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
-          "title": "BOM Reference"
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the service elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
         },
         "provider": {
           "title": "Provider",
+          "description": "The organization that provides the service.",
           "$ref": "#/definitions/organizationalEntity"
         },
         "group": {
           "type": "string",
-          "title": "Service Group"
+          "title": "Service Group",
+          "description": "The grouping name, namespace, or identifier. This will often be a shortened, single name of the company or project that produced the service or domain name. Whitespace and special characters should be avoided.",
+          "examples": [
+            "com.acme"
+          ]
         },
         "name": {
           "type": "string",
-          "title": "Service Name"
+          "title": "Service Name",
+          "description": "The name of the service. This will often be a shortened, single name of the service.",
+          "examples": [
+            "ticker-service"
+          ]
         },
         "version": {
           "type": "string",
-          "title": "Service Version"
+          "title": "Service Version",
+          "description": "The service version.",
+          "examples": [
+            "1.0.0"
+          ]
         },
         "description": {
           "type": "string",
-          "title": "Service Description"
+          "title": "Service Description",
+          "description": "Specifies a description for the service"
         },
         "endpoints": {
           "type": "array",
@@ -1661,70 +1774,82 @@
             "type": "string",
             "format": "iri-reference"
           },
-          "title": "Endpoints"
+          "title": "Endpoints",
+          "description": "The endpoint URIs of the service. Multiple endpoints are allowed.",
+          "examples": [
+            "https://example.com/api/v1/ticker"
+          ]
         },
         "authenticated": {
           "type": "boolean",
-          "title": "Authentication Required"
+          "title": "Authentication Required",
+          "description": "A boolean value indicating if the service requires authentication. A value of true indicates the service requires authentication prior to use. A value of false indicates the service does not require authentication."
         },
         "x-trust-boundary": {
           "type": "boolean",
-          "title": "Crosses Trust Boundary"
+          "title": "Crosses Trust Boundary",
+          "description": "A boolean value indicating if use of the service crosses a trust zone or boundary. A value of true indicates that by using the service, a trust boundary is crossed. A value of false indicates that by using the service, a trust boundary is not crossed."
+        },
+        "trustZone": {
+          "type": "string",
+          "title": "Trust Zone",
+          "description": "The name of the trust zone the service resides in."
         },
         "data": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/serviceData"
           },
-          "title": "Data"
+          "title": "Data",
+          "description": "Specifies information about the data including the directional flow of data and the data classification."
         },
         "licenses": {
+          "title": "Component License(s)",
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/licenseChoice"
-          },
-          "title": "Component License(s)"
+          }
         },
         "externalReferences": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/externalReference"
           },
-          "title": "External References"
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
         },
         "services": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/service"
           },
           "uniqueItems": true,
-          "title": "Services"
+          "title": "Services",
+          "description": "A list of services included or deployed behind the parent service. This is not a dependency tree. It provides a way to specify a hierarchical representation of service assemblies."
         },
         "releaseNotes": {
           "$ref": "#/definitions/releaseNotes",
-          "title": "Release notes"
+          "title": "Release notes",
+          "description": "Specifies optional release notes."
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "additionalItems": false,
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
           "items": {
             "$ref": "#/definitions/property"
           }
         },
         "signature": {
           "$ref": "#/definitions/signature",
-          "title": "Signature"
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
         }
       }
     },
     "serviceData": {
       "type": "object",
-      "title": "Service Data",
+      "title": "Hash Objects",
       "required": [
         "flow",
         "classification"
@@ -1733,11 +1858,68 @@
       "properties": {
         "flow": {
           "$ref": "#/definitions/dataFlowDirection",
-          "title": "Directional Flow"
+          "title": "Directional Flow",
+          "description": "Specifies the flow direction of the data. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways, and unknown states that the direction is not known."
         },
         "classification": {
+          "$ref": "#/definitions/dataClassification"
+        },
+        "name": {
           "type": "string",
-          "title": "Classification"
+          "title": "Name",
+          "description": "Name for the defined data",
+          "examples": [
+            "Credit card reporting"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Short description of the data content and usage",
+          "examples": [
+            "Credit card information being exchanged in between the web app and the database"
+          ]
+        },
+        "governance": {
+          "type": "object",
+          "title": "Data Governance",
+          "$ref": "#/definitions/dataGovernance"
+        },
+        "source": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "title": "URL",
+                "type": "string",
+                "format": "iri-reference"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "#/definitions/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "Source",
+          "description": "The URI, URL, or BOM-Link of the components or services the data came in from"
+        },
+        "destination": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "title": "URL",
+                "type": "string",
+                "format": "iri-reference"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "#/definitions/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "Destination",
+          "description": "The URI, URL, or BOM-Link of the components or services the data is sent to"
         }
       }
     },
@@ -1749,7 +1931,8 @@
         "bi-directional",
         "unknown"
       ],
-      "title": "Data flow direction"
+      "title": "Data flow direction",
+      "description": "Specifies the flow direction of the data. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways, and unknown states that the direction is not known."
     },
     "copyright": {
       "type": "object",
@@ -1768,19 +1951,193 @@
     "componentEvidence": {
       "type": "object",
       "title": "Evidence",
+      "description": "Provides the ability to document evidence collected through various forms of extraction or analysis.",
       "additionalProperties": false,
       "properties": {
-        "licenses": {
+        "identity": {
+          "type": "object",
+          "description": "Evidence that substantiates the identity of a component.",
+          "required": [
+            "field"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "field": {
+              "type": "string",
+              "enum": [
+                "group",
+                "name",
+                "version",
+                "purl",
+                "cpe",
+                "swid",
+                "hash"
+              ],
+              "title": "Field",
+              "description": "The identity field of the component which the evidence describes."
+            },
+            "confidence": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "title": "Confidence",
+              "description": "The overall confidence of the evidence from 0 - 1, where 1 is 100% confidence."
+            },
+            "methods": {
+              "type": "array",
+              "title": "Methods",
+              "description": "The methods used to extract and/or analyze the evidence.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "technique",
+                  "confidence"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "technique": {
+                    "title": "Technique",
+                    "description": "The technique used in this method of analysis.",
+                    "type": "string",
+                    "enum": [
+                      "source-code-analysis",
+                      "binary-analysis",
+                      "manifest-analysis",
+                      "ast-fingerprint",
+                      "hash-comparison",
+                      "instrumentation",
+                      "dynamic-analysis",
+                      "filename",
+                      "attestation",
+                      "other"
+                    ]
+                  },
+                  "confidence": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1,
+                    "title": "Confidence",
+                    "description": "The confidence of the evidence from 0 - 1, where 1 is 100% confidence. Confidence is specific to the technique used. Each technique of analysis can have independent confidence."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The value or contents of the evidence."
+                  }
+                }
+              }
+            },
+            "tools": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "anyOf": [
+                  {
+                    "title": "Ref",
+                    "$ref": "#/definitions/refLinkType"
+                  },
+                  {
+                    "title": "BOM-Link Element",
+                    "$ref": "#/definitions/bomLinkElementType"
+                  }
+                ]
+              },
+              "title": "BOM References",
+              "description": "The object in the BOM identified by its bom-ref. This is often a component or service, but may be any object type supporting bom-refs. Tools used for analysis should already be defined in the BOM, either in the metadata/tools, components, or formulation."
+            }
+          }
+        },
+        "occurrences": {
           "type": "array",
-          "additionalItems": false,
+          "title": "Occurrences",
+          "description": "Evidence of individual instances of a component spread across multiple locations.",
+          "items": {
+            "type": "object",
+            "required": [
+              "location"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An optional identifier which can be used to reference the occurrence elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+              },
+              "location": {
+                "type": "string",
+                "title": "Location",
+                "description": "The location or path to where the component was found."
+              }
+            }
+          }
+        },
+        "callstack": {
+          "type": "object",
+          "description": "Evidence of the components use through the callstack.",
+          "additionalProperties": false,
+          "properties": {
+            "frames": {
+              "type": "array",
+              "title": "Methods",
+              "items": {
+                "type": "object",
+                "required": [
+                  "module"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "package": {
+                    "title": "Package",
+                    "description": "A package organizes modules into namespaces, providing a unique namespace for each type it contains.",
+                    "type": "string"
+                  },
+                  "module": {
+                    "title": "Module",
+                    "description": "A module or class that encloses functions/methods and other code.",
+                    "type": "string"
+                  },
+                  "function": {
+                    "title": "Function",
+                    "description": "A block of code designed to perform a particular task.",
+                    "type": "string"
+                  },
+                  "parameters": {
+                    "title": "Parameters",
+                    "description": "Optional arguments that are passed to the module or function.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "line": {
+                    "title": "Line",
+                    "description": "The line number the code that is called resides on.",
+                    "type": "integer"
+                  },
+                  "column": {
+                    "title": "Column",
+                    "description": "The column the code that is called resides.",
+                    "type": "integer"
+                  },
+                  "fullFilename": {
+                    "title": "Full Filename",
+                    "description": "The full path and filename of the module.",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "licenses": {
+          "title": "Component License(s)",
+          "type": "array",
           "items": {
             "$ref": "#/definitions/licenseChoice"
-          },
-          "title": "Component License(s)"
+          }
         },
         "copyright": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/copyright"
           },
@@ -1799,19 +2156,31 @@
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
-          "title": "BOM Reference"
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the composition elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
         },
         "aggregate": {
           "$ref": "#/definitions/aggregateType",
-          "title": "Aggregate"
+          "title": "Aggregate",
+          "description": "Specifies an aggregate type that describe how complete a relationship is.\n\n* __complete__ = The relationship is complete. No further relationships including constituent components, services, or dependencies are known to exist.\n* __incomplete__ = The relationship is incomplete. Additional relationships exist and may include constituent components, services, or dependencies.\n* __incomplete&#95;first&#95;party&#95;only__ = The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented.\n* __incomplete&#95;first&#95;party&#95;proprietary&#95;only__ = The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.\n* __incomplete&#95;first&#95;party&#95;opensource&#95;only__ = The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are opensource.\n* __incomplete&#95;third&#95;party&#95;only__ = The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented.\n* __incomplete&#95;third&#95;party&#95;proprietary&#95;only__ = The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.\n* __incomplete&#95;third&#95;party&#95;opensource&#95;only__ = The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are opensource.\n* __unknown__ = The relationship may be complete or incomplete. This usually signifies a 'best-effort' to obtain constituent components, services, or dependencies but the completeness is inconclusive.\n* __not&#95;specified__ = The relationship completeness is not specified.\n"
         },
         "assemblies": {
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "anyOf": [
+              {
+                "title": "Ref",
+                "$ref": "#/definitions/refLinkType"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "#/definitions/bomLinkElementType"
+              }
+            ]
           },
-          "title": "BOM references"
+          "title": "BOM references",
+          "description": "The bom-ref identifiers of the components or services being described. Assemblies refer to nested relationships whereby a constituent part may include other constituent parts. References do not cascade to child parts. References are explicit for the specified constituent part only."
         },
         "dependencies": {
           "type": "array",
@@ -1819,7 +2188,8 @@
           "items": {
             "type": "string"
           },
-          "title": "BOM references"
+          "title": "BOM references",
+          "description": "The bom-ref identifiers of the components or services being described. Dependencies refer to a relationship whereby an independent constituent part requires another independent constituent part. References do not cascade to transitive dependencies. References are explicit for the specified dependency only."
         },
         "vulnerabilities": {
           "type": "array",
@@ -1827,11 +2197,13 @@
           "items": {
             "type": "string"
           },
-          "title": "Vulnerabilities"
+          "title": "BOM references",
+          "description": "The bom-ref identifiers of the vulnerabilities being described."
         },
         "signature": {
           "$ref": "#/definitions/signature",
-          "title": "Signature"
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
         }
       }
     },
@@ -1842,32 +2214,37 @@
         "complete",
         "incomplete",
         "incomplete_first_party_only",
+        "incomplete_first_party_proprietary_only",
+        "incomplete_first_party_opensource_only",
         "incomplete_third_party_only",
+        "incomplete_third_party_proprietary_only",
+        "incomplete_third_party_opensource_only",
         "unknown",
         "not_specified"
-      ],
-      "additionalProperties": false
+      ]
     },
     "property": {
       "type": "object",
       "title": "Lightweight name-value pair",
+      "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
       "properties": {
         "name": {
           "type": "string",
-          "title": "Name"
+          "title": "Name",
+          "description": "The name of the property. Duplicate names are allowed, each potentially having a different value."
         },
         "value": {
           "type": "string",
-          "title": "Value"
+          "title": "Value",
+          "description": "The value of the property."
         }
-      },
-      "additionalProperties": false
+      }
     },
     "localeType": {
       "type": "string",
       "pattern": "^([a-z]{2})(-[A-Z]{2})?$",
       "title": "Locale",
-      "additionalProperties": false
+      "description": "Defines a syntax for representing two character language code (ISO-639) followed by an optional two character country code. The language code MUST be lower case. If the country code is specified, the country code MUST be upper case. The language code and country code MUST be separated by a minus sign. Examples: en, en-US, fr, fr-CA"
     },
     "releaseType": {
       "type": "string",
@@ -1878,11 +2255,12 @@
         "pre-release",
         "internal"
       ],
-      "additionalProperties": false
+      "description": "The software versioning type. It is RECOMMENDED that the release type use one of 'major', 'minor', 'patch', 'pre-release', or 'internal'. Representing all possible software release types is not practical, so standardizing on the recommended values, whenever possible, is strongly encouraged.\n\n* __major__ = A major release may contain significant changes or may introduce breaking changes.\n* __minor__ = A minor release, also known as an update, may contain a smaller number of changes than major releases.\n* __patch__ = Patch releases are typically unplanned and may resolve defects or important security issues.\n* __pre-release__ = A pre-release may include alpha, beta, or release candidates and typically have limited support. They provide the ability to preview a release prior to its general availability.\n* __internal__ = Internal releases are not for public consumption and are intended to be used exclusively by the project or manufacturer that produced it."
     },
     "note": {
       "type": "object",
       "title": "Note",
+      "description": "A note containing the locale and content.",
       "required": [
         "text"
       ],
@@ -1890,10 +2268,12 @@
       "properties": {
         "locale": {
           "$ref": "#/definitions/localeType",
-          "title": "Locale"
+          "title": "Locale",
+          "description": "The ISO-639 (or higher) language code and optional ISO-3166 (or higher) country code. Examples include: \"en\", \"en-US\", \"fr\" and \"fr-CA\""
         },
         "text": {
           "title": "Release note content",
+          "description": "Specifies the full content of the release note.",
           "$ref": "#/definitions/attachment"
         }
       }
@@ -1908,65 +2288,73 @@
       "properties": {
         "type": {
           "$ref": "#/definitions/releaseType",
-          "title": "Type"
+          "title": "Type",
+          "description": "The software versioning type the release note describes."
         },
         "title": {
           "type": "string",
-          "title": "Title"
+          "title": "Title",
+          "description": "The title of the release."
         },
         "featuredImage": {
           "type": "string",
           "format": "iri-reference",
-          "title": "Featured image"
+          "title": "Featured image",
+          "description": "The URL to an image that may be prominently displayed with the release note."
         },
         "socialImage": {
           "type": "string",
           "format": "iri-reference",
-          "title": "Social image"
+          "title": "Social image",
+          "description": "The URL to an image that may be used in messaging on social media platforms."
         },
         "description": {
           "type": "string",
-          "title": "Description"
+          "title": "Description",
+          "description": "A short description of the release."
         },
         "timestamp": {
           "type": "string",
           "format": "date-time",
-          "title": "Timestamp"
+          "title": "Timestamp",
+          "description": "The date and time (timestamp) when the release note was created."
         },
         "aliases": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "title": "Aliases"
+          "title": "Aliases",
+          "description": "One or more alternate names the release may be referred to. This may include unofficial terms used by development and marketing teams (e.g. code names)."
         },
         "tags": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "title": "Tags"
+          "title": "Tags",
+          "description": "One or more tags that may aid in search or retrieval of the release note."
         },
         "resolves": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/issue"
           },
-          "title": "Resolves"
+          "title": "Resolves",
+          "description": "A collection of issues that have been resolved."
         },
         "notes": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/note"
           },
-          "title": "Notes"
+          "title": "Notes",
+          "description": "Zero or more release notes containing the locale and content. Multiple note objects may be specified to support release notes in a wide variety of languages."
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "additionalItems": false,
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -1976,6 +2364,7 @@
     "advisory": {
       "type": "object",
       "title": "Advisory",
+      "description": "Title and location where advisory information can be obtained. An advisory is a notification of a threat to a component, service, or system.",
       "required": [
         "url"
       ],
@@ -1983,12 +2372,14 @@
       "properties": {
         "title": {
           "type": "string",
-          "title": "Title"
+          "title": "Title",
+          "description": "An optional name of the advisory."
         },
         "url": {
           "type": "string",
           "title": "URL",
-          "format": "iri-reference"
+          "format": "iri-reference",
+          "description": "Location where the advisory can be obtained."
         }
       }
     },
@@ -1996,11 +2387,12 @@
       "type": "integer",
       "minimum": 1,
       "title": "CWE",
-      "additionalProperties": false
+      "description": "Integer representation of a Common Weaknesses Enumerations (CWE). For example 399 (of https://cwe.mitre.org/data/definitions/399.html)"
     },
     "severity": {
       "type": "string",
       "title": "Severity",
+      "description": "Textual representation of the severity of the vulnerability adopted by the analysis method. If the analysis method uses values other than what is provided, the user is expected to translate appropriately.",
       "enum": [
         "critical",
         "high",
@@ -2009,24 +2401,26 @@
         "info",
         "none",
         "unknown"
-      ],
-      "additionalProperties": false
+      ]
     },
     "scoreMethod": {
       "type": "string",
       "title": "Method",
+      "description": "Specifies the severity or risk scoring methodology or standard used.\n\n* CVSSv2 - [Common Vulnerability Scoring System v2](https://www.first.org/cvss/v2/)\n* CVSSv3 - [Common Vulnerability Scoring System v3](https://www.first.org/cvss/v3-0/)\n* CVSSv31 - [Common Vulnerability Scoring System v3.1](https://www.first.org/cvss/v3-1/)\n* CVSSv4 - [Common Vulnerability Scoring System v4](https://www.first.org/cvss/v4-0/)\n* OWASP - [OWASP Risk Rating Methodology](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology)\n* SSVC - [Stakeholder Specific Vulnerability Categorization](https://github.com/CERTCC/SSVC) (all versions)",
       "enum": [
         "CVSSv2",
         "CVSSv3",
         "CVSSv31",
+        "CVSSv4",
         "OWASP",
+        "SSVC",
         "other"
-      ],
-      "additionalProperties": false
+      ]
     },
     "impactAnalysisState": {
       "type": "string",
       "title": "Impact Analysis State",
+      "description": "Declares the current state of an occurrence of a vulnerability, after automated or manual analysis. \n\n* __resolved__ = the vulnerability has been remediated. \n* __resolved\\_with\\_pedigree__ = the vulnerability has been remediated and evidence of the changes are provided in the affected components pedigree containing verifiable commit history and/or diff(s). \n* __exploitable__ = the vulnerability may be directly or indirectly exploitable. \n* __in\\_triage__ = the vulnerability is being investigated. \n* __false\\_positive__ = the vulnerability is not specific to the component or service and was falsely identified or associated. \n* __not\\_affected__ = the component or service is not affected by the vulnerability. Justification should be specified for all not_affected cases.",
       "enum": [
         "resolved",
         "resolved_with_pedigree",
@@ -2034,12 +2428,12 @@
         "in_triage",
         "false_positive",
         "not_affected"
-      ],
-      "additionalProperties": false
+      ]
     },
     "impactAnalysisJustification": {
       "type": "string",
       "title": "Impact Analysis Justification",
+      "description": "The rationale of why the impact analysis state was asserted. \n\n* __code\\_not\\_present__ = the code has been removed or tree-shaked. \n* __code\\_not\\_reachable__ = the vulnerable code is not invoked at runtime. \n* __requires\\_configuration__ = exploitability requires a configurable option to be set/unset. \n* __requires\\_dependency__ = exploitability requires a dependency that is not present. \n* __requires\\_environment__ = exploitability requires a certain environment which is not present. \n* __protected\\_by\\_compiler__ = exploitability requires a compiler flag to be set/unset. \n* __protected\\_at\\_runtime__ = exploits are prevented at runtime. \n* __protected\\_at\\_perimeter__ = attacks are blocked at physical, logical, or network perimeter. \n* __protected\\_by\\_mitigating\\_control__ = preventative measures have been implemented that reduce the likelihood and/or impact of the vulnerability.",
       "enum": [
         "code_not_present",
         "code_not_reachable",
@@ -2050,73 +2444,101 @@
         "protected_at_runtime",
         "protected_at_perimeter",
         "protected_by_mitigating_control"
-      ],
-      "additionalProperties": false
+      ]
     },
     "rating": {
       "type": "object",
       "title": "Rating",
+      "description": "Defines the severity or risk ratings of a vulnerability.",
       "additionalProperties": false,
       "properties": {
         "source": {
-          "$ref": "#/definitions/vulnerabilitySource"
+          "$ref": "#/definitions/vulnerabilitySource",
+          "description": "The source that calculated the severity or risk rating of the vulnerability."
         },
         "score": {
           "type": "number",
-          "title": "Score"
+          "title": "Score",
+          "description": "The numerical score of the rating."
         },
         "severity": {
-          "$ref": "#/definitions/severity"
+          "$ref": "#/definitions/severity",
+          "description": "Textual representation of the severity that corresponds to the numerical score of the rating."
         },
         "method": {
           "$ref": "#/definitions/scoreMethod"
         },
         "vector": {
           "type": "string",
-          "title": "Vector"
+          "title": "Vector",
+          "description": "Textual representation of the metric values used to score the vulnerability"
         },
         "justification": {
           "type": "string",
-          "title": "Justification"
+          "title": "Justification",
+          "description": "An optional reason for rating the vulnerability as it was"
         }
       }
     },
     "vulnerabilitySource": {
       "type": "object",
       "title": "Source",
+      "description": "The source of vulnerability information. This is often the organization that published the vulnerability.",
       "additionalProperties": false,
       "properties": {
         "url": {
           "type": "string",
-          "title": "URL"
+          "title": "URL",
+          "description": "The url of the vulnerability documentation as provided by the source.",
+          "examples": [
+            "https://nvd.nist.gov/vuln/detail/CVE-2021-39182"
+          ]
         },
         "name": {
           "type": "string",
-          "title": "Name"
+          "title": "Name",
+          "description": "The name of the source.",
+          "examples": [
+            "NVD",
+            "National Vulnerability Database",
+            "OSS Index",
+            "VulnDB",
+            "GitHub Advisories"
+          ]
         }
       }
     },
     "vulnerability": {
       "type": "object",
       "title": "Vulnerability",
+      "description": "Defines a weakness in a component or service that could be exploited or triggered by a threat source.",
       "additionalProperties": false,
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
-          "title": "BOM Reference"
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the vulnerability elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
         },
         "id": {
           "type": "string",
-          "title": "ID"
+          "title": "ID",
+          "description": "The identifier that uniquely identifies the vulnerability.",
+          "examples": [
+            "CVE-2021-39182",
+            "GHSA-35m5-8cvj-8783",
+            "SNYK-PYTHON-ENROCRYPT-1912876"
+          ]
         },
         "source": {
-          "$ref": "#/definitions/vulnerabilitySource"
+          "$ref": "#/definitions/vulnerabilitySource",
+          "description": "The source that published the vulnerability."
         },
         "references": {
           "type": "array",
           "title": "References",
-          "additionalItems": false,
+          "description": "Zero or more pointers to vulnerabilities that are the equivalent of the vulnerability specified. Often times, the same vulnerability may exist in multiple sources of vulnerability intelligence, but have different identifiers. References provide a way to correlate vulnerabilities across multiple sources of vulnerability intelligence.",
           "items": {
+            "type": "object",
             "required": [
               "id",
               "source"
@@ -2125,10 +2547,17 @@
             "properties": {
               "id": {
                 "type": "string",
-                "title": "ID"
+                "title": "ID",
+                "description": "An identifier that uniquely identifies the vulnerability.",
+                "examples": [
+                  "CVE-2021-39182",
+                  "GHSA-35m5-8cvj-8783",
+                  "SNYK-PYTHON-ENROCRYPT-1912876"
+                ]
               },
               "source": {
-                "$ref": "#/definitions/vulnerabilitySource"
+                "$ref": "#/definitions/vulnerabilitySource",
+                "description": "The source that published the vulnerability."
               }
             }
           }
@@ -2136,7 +2565,7 @@
         "ratings": {
           "type": "array",
           "title": "Ratings",
-          "additionalItems": false,
+          "description": "List of vulnerability ratings",
           "items": {
             "$ref": "#/definitions/rating"
           }
@@ -2144,27 +2573,63 @@
         "cwes": {
           "type": "array",
           "title": "CWEs",
-          "additionalItems": false,
+          "description": "List of Common Weaknesses Enumerations (CWEs) codes that describes this vulnerability. For example 399 (of https://cwe.mitre.org/data/definitions/399.html)",
+          "examples": [
+            399
+          ],
           "items": {
             "$ref": "#/definitions/cwe"
           }
         },
         "description": {
           "type": "string",
-          "title": "Description"
+          "title": "Description",
+          "description": "A description of the vulnerability as provided by the source."
         },
         "detail": {
           "type": "string",
-          "title": "Details"
+          "title": "Details",
+          "description": "If available, an in-depth description of the vulnerability as provided by the source organization. Details often include information useful in understanding root cause."
         },
         "recommendation": {
           "type": "string",
-          "title": "Recommendation"
+          "title": "Recommendation",
+          "description": "Recommendations of how the vulnerability can be remediated or mitigated."
+        },
+        "workaround": {
+          "type": "string",
+          "title": "Workarounds",
+          "description": "A bypass, usually temporary, of the vulnerability that reduces its likelihood and/or impact. Workarounds often involve changes to configuration or deployments."
+        },
+        "proofOfConcept": {
+          "type": "object",
+          "title": "Proof of Concept",
+          "description": "Evidence used to reproduce the vulnerability.",
+          "properties": {
+            "reproductionSteps": {
+              "type": "string",
+              "title": "Steps to Reproduce",
+              "description": "Precise steps to reproduce the vulnerability."
+            },
+            "environment": {
+              "type": "string",
+              "title": "Environment",
+              "description": "A description of the environment in which reproduction was possible."
+            },
+            "supportingMaterial": {
+              "type": "array",
+              "title": "Supporting Material",
+              "description": "Supporting material that helps in reproducing or understanding how reproduction is possible. This may include screenshots, payloads, and PoC exploit code.",
+              "items": {
+                "$ref": "#/definitions/attachment"
+              }
+            }
+          }
         },
         "advisories": {
           "type": "array",
           "title": "Advisories",
-          "additionalItems": false,
+          "description": "Published advisories of the vulnerability if provided.",
           "items": {
             "$ref": "#/definitions/advisory"
           }
@@ -2172,27 +2637,37 @@
         "created": {
           "type": "string",
           "format": "date-time",
-          "title": "Created"
+          "title": "Created",
+          "description": "The date and time (timestamp) when the vulnerability record was created in the vulnerability database."
         },
         "published": {
           "type": "string",
           "format": "date-time",
-          "title": "Published"
+          "title": "Published",
+          "description": "The date and time (timestamp) when the vulnerability record was first published."
         },
         "updated": {
           "type": "string",
           "format": "date-time",
-          "title": "Updated"
+          "title": "Updated",
+          "description": "The date and time (timestamp) when the vulnerability record was last updated."
+        },
+        "rejected": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Rejected",
+          "description": "The date and time (timestamp) when the vulnerability record was rejected (if applicable)."
         },
         "credits": {
           "type": "object",
           "title": "Credits",
+          "description": "Individuals or organizations credited with the discovery of the vulnerability.",
           "additionalProperties": false,
           "properties": {
             "organizations": {
               "type": "array",
               "title": "Organizations",
-              "additionalItems": false,
+              "description": "The organizations credited with vulnerability discovery.",
               "items": {
                 "$ref": "#/definitions/organizationalEntity"
               }
@@ -2200,7 +2675,7 @@
             "individuals": {
               "type": "array",
               "title": "Individuals",
-              "additionalItems": false,
+              "description": "The individuals, not associated with organizations, that are credited with vulnerability discovery.",
               "items": {
                 "$ref": "#/definitions/organizationalContact"
               }
@@ -2208,16 +2683,47 @@
           }
         },
         "tools": {
-          "type": "array",
-          "title": "Creation Tools",
-          "additionalItems": false,
-          "items": {
-            "$ref": "#/definitions/tool"
-          }
+          "oneOf": [
+            {
+              "type": "object",
+              "title": "Tools",
+              "description": "The tool(s) used to identify, confirm, or score the vulnerability.",
+              "additionalProperties": false,
+              "properties": {
+                "components": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/component"
+                  },
+                  "uniqueItems": true,
+                  "title": "Components",
+                  "description": "A list of software and hardware components used as tools"
+                },
+                "services": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/service"
+                  },
+                  "uniqueItems": true,
+                  "title": "Services",
+                  "description": "A list of services used as tools. This may include microservices, function-as-a-service, and other types of network or intra-process services."
+                }
+              }
+            },
+            {
+              "type": "array",
+              "title": "Tools (legacy)",
+              "description": "[Deprecated] The tool(s) used to identify, confirm, or score the vulnerability.",
+              "items": {
+                "$ref": "#/definitions/tool"
+              }
+            }
+          ]
         },
         "analysis": {
           "type": "object",
           "title": "Impact Analysis",
+          "description": "An assessment of the impact and exploitability of the vulnerability.",
           "additionalProperties": false,
           "properties": {
             "state": {
@@ -2229,7 +2735,7 @@
             "response": {
               "type": "array",
               "title": "Response",
-              "additionalItems": false,
+              "description": "A response to the vulnerability by the manufacturer, supplier, or project responsible for the affected component or service. More than one response is allowed. Responses are strongly encouraged for vulnerabilities where the analysis state is exploitable.",
               "items": {
                 "type": "string",
                 "enum": [
@@ -2243,29 +2749,53 @@
             },
             "detail": {
               "type": "string",
-              "title": "Detail"
+              "title": "Detail",
+              "description": "Detailed description of the impact including methods used during assessment. If a vulnerability is not exploitable, this field should include specific details on why the component or service is not impacted by this vulnerability."
+            },
+            "firstIssued": {
+              "type": "string",
+              "format": "date-time",
+              "title": "First Issued",
+              "description": "The date and time (timestamp) when the analysis was first issued."
+            },
+            "lastUpdated": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Last Updated",
+              "description": "The date and time (timestamp) when the analysis was last updated."
             }
           }
         },
         "affects": {
           "type": "array",
           "uniqueItems": true,
-          "additionalItems": false,
           "items": {
+            "type": "object",
             "required": [
               "ref"
             ],
             "additionalProperties": false,
             "properties": {
               "ref": {
-                "$ref": "#/definitions/refType",
-                "title": "Reference"
+                "anyOf": [
+                  {
+                    "title": "Ref",
+                    "$ref": "#/definitions/refLinkType"
+                  },
+                  {
+                    "title": "BOM-Link Element",
+                    "$ref": "#/definitions/bomLinkElementType"
+                  }
+                ],
+                "title": "Reference",
+                "description": "References a component or service by the objects bom-ref"
               },
               "versions": {
                 "type": "array",
                 "title": "Versions",
-                "additionalItems": false,
+                "description": "Zero or more individual versions or range of versions.",
                 "items": {
+                  "type": "object",
                   "oneOf": [
                     {
                       "required": [
@@ -2281,12 +2811,15 @@
                   "additionalProperties": false,
                   "properties": {
                     "version": {
+                      "description": "A single version of a component or service.",
                       "$ref": "#/definitions/version"
                     },
                     "range": {
-                      "$ref": "#/definitions/version"
+                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst",
+                      "$ref": "#/definitions/range"
                     },
                     "status": {
+                      "description": "The vulnerability status for the version or range of versions.",
                       "$ref": "#/definitions/affectedStatus",
                       "default": "affected"
                     }
@@ -2295,12 +2828,13 @@
               }
             }
           },
-          "title": "Affects"
+          "title": "Affects",
+          "description": "The components or services that are affected by the vulnerability."
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "additionalItems": false,
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -2308,30 +2842,1567 @@
       }
     },
     "affectedStatus": {
+      "description": "The vulnerability status of a given version or range of versions of a product. The statuses 'affected' and 'unaffected' indicate that the version is affected or unaffected by the vulnerability. The status 'unknown' indicates that it is unknown or unspecified whether the given version is affected. There can be many reasons for an 'unknown' status, including that an investigation has not been undertaken or that a vendor has not disclosed the status.",
       "type": "string",
       "enum": [
         "affected",
         "unaffected",
         "unknown"
-      ],
-      "additionalProperties": false
+      ]
     },
     "version": {
+      "description": "A single version of a component or service.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 1024,
-      "additionalProperties": false
+      "maxLength": 1024
     },
     "range": {
+      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst",
       "type": "string",
       "minLength": 1,
-      "maxLength": 1024,
-      "additionalProperties": false
+      "maxLength": 1024
+    },
+    "annotations": {
+      "type": "object",
+      "title": "Annotations",
+      "description": "A comment, note, explanation, or similar textual content which provides additional context to the object(s) being annotated.",
+      "required": [
+        "subjects",
+        "annotator",
+        "timestamp",
+        "text"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the annotation elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+        },
+        "subjects": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "anyOf": [
+              {
+                "title": "Ref",
+                "$ref": "#/definitions/refLinkType"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "#/definitions/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "BOM References",
+          "description": "The object in the BOM identified by its bom-ref. This is often a component or service, but may be any object type supporting bom-refs."
+        },
+        "annotator": {
+          "type": "object",
+          "title": "Annotator",
+          "description": "The organization, person, component, or service which created the textual content of the annotation.",
+          "oneOf": [
+            {
+              "required": [
+                "organization"
+              ]
+            },
+            {
+              "required": [
+                "individual"
+              ]
+            },
+            {
+              "required": [
+                "component"
+              ]
+            },
+            {
+              "required": [
+                "service"
+              ]
+            }
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "organization": {
+              "description": "The organization that created the annotation",
+              "$ref": "#/definitions/organizationalEntity"
+            },
+            "individual": {
+              "description": "The person that created the annotation",
+              "$ref": "#/definitions/organizationalContact"
+            },
+            "component": {
+              "description": "The tool or component that created the annotation",
+              "$ref": "#/definitions/component"
+            },
+            "service": {
+              "description": "The service that created the annotation",
+              "$ref": "#/definitions/service"
+            }
+          }
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The date and time (timestamp) when the annotation was created."
+        },
+        "text": {
+          "type": "string",
+          "title": "Text",
+          "description": "The textual content of the annotation."
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    },
+    "modelCard": {
+      "$comment": "Model card support in CycloneDX is derived from TensorFlow Model Card Toolkit released under the Apache 2.0 license and available from https://github.com/tensorflow/model-card-toolkit/blob/main/model_card_toolkit/schema/v0.0.2/model_card.schema.json. In addition, CycloneDX model card support includes portions of VerifyML, also released under the Apache 2.0 license and available from https://github.com/cylynx/verifyml/blob/main/verifyml/model_card_toolkit/schema/v0.0.4/model_card.schema.json.",
+      "type": "object",
+      "title": "Model Card",
+      "description": "A model card describes the intended uses of a machine learning model and potential limitations, including biases and ethical considerations. Model cards typically contain the training parameters, which datasets were used to train the model, performance metrics, and other relevant data useful for ML transparency. This object SHOULD be specified for any component of type `machine-learning-model` and MUST NOT be specified for other component types.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the model card elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+        },
+        "modelParameters": {
+          "type": "object",
+          "title": "Model Parameters",
+          "description": "Hyper-parameters for construction of the model.",
+          "additionalProperties": false,
+          "properties": {
+            "approach": {
+              "type": "object",
+              "title": "Approach",
+              "description": "The overall approach to learning used by the model for problem solving.",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "title": "Learning Type",
+                  "description": "Learning types describing the learning problem or hybrid learning problem.",
+                  "enum": [
+                    "supervised",
+                    "unsupervised",
+                    "reinforcement-learning",
+                    "semi-supervised",
+                    "self-supervised"
+                  ]
+                }
+              }
+            },
+            "task": {
+              "type": "string",
+              "title": "Task",
+              "description": "Directly influences the input and/or output. Examples include classification, regression, clustering, etc."
+            },
+            "architectureFamily": {
+              "type": "string",
+              "title": "Architecture Family",
+              "description": "The model architecture family such as transformer network, convolutional neural network, residual neural network, LSTM neural network, etc."
+            },
+            "modelArchitecture": {
+              "type": "string",
+              "title": "Model Architecture",
+              "description": "The specific architecture of the model such as GPT-1, ResNet-50, YOLOv3, etc."
+            },
+            "datasets": {
+              "type": "array",
+              "title": "Datasets",
+              "description": "The datasets used to train and evaluate the model.",
+              "items": {
+                "oneOf": [
+                  {
+                    "title": "Inline Component Data",
+                    "$ref": "#/definitions/componentData"
+                  },
+                  {
+                    "type": "object",
+                    "title": "Data Component Reference",
+                    "additionalProperties": false,
+                    "properties": {
+                      "ref": {
+                        "anyOf": [
+                          {
+                            "title": "Ref",
+                            "$ref": "#/definitions/refLinkType"
+                          },
+                          {
+                            "title": "BOM-Link Element",
+                            "$ref": "#/definitions/bomLinkElementType"
+                          }
+                        ],
+                        "title": "Reference",
+                        "description": "References a data component by the components bom-ref attribute"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "inputs": {
+              "type": "array",
+              "title": "Inputs",
+              "description": "The input format(s) of the model",
+              "items": {
+                "$ref": "#/definitions/inputOutputMLParameters"
+              }
+            },
+            "outputs": {
+              "type": "array",
+              "title": "Outputs",
+              "description": "The output format(s) from the model",
+              "items": {
+                "$ref": "#/definitions/inputOutputMLParameters"
+              }
+            }
+          }
+        },
+        "quantitativeAnalysis": {
+          "type": "object",
+          "title": "Quantitative Analysis",
+          "description": "A quantitative analysis of the model",
+          "additionalProperties": false,
+          "properties": {
+            "performanceMetrics": {
+              "type": "array",
+              "title": "Performance Metrics",
+              "description": "The model performance metrics being reported. Examples may include accuracy, F1 score, precision, top-3 error rates, MSC, etc.",
+              "items": {
+                "$ref": "#/definitions/performanceMetric"
+              }
+            },
+            "graphics": {
+              "$ref": "#/definitions/graphicsCollection"
+            }
+          }
+        },
+        "considerations": {
+          "type": "object",
+          "title": "Considerations",
+          "description": "What considerations should be taken into account regarding the model's construction, training, and application?",
+          "additionalProperties": false,
+          "properties": {
+            "users": {
+              "type": "array",
+              "title": "Users",
+              "description": "Who are the intended users of the model?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "useCases": {
+              "type": "array",
+              "title": "Use Cases",
+              "description": "What are the intended use cases of the model?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "technicalLimitations": {
+              "type": "array",
+              "title": "Technical Limitations",
+              "description": "What are the known technical limitations of the model? E.g. What kind(s) of data should the model be expected not to perform well on? What are the factors that might degrade model performance?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "performanceTradeoffs": {
+              "type": "array",
+              "title": "Performance Tradeoffs",
+              "description": "What are the known tradeoffs in accuracy/performance of the model?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ethicalConsiderations": {
+              "type": "array",
+              "title": "Ethical Considerations",
+              "description": "What are the ethical (or environmental) risks involved in the application of this model?",
+              "items": {
+                "$ref": "#/definitions/risk"
+              }
+            },
+            "fairnessAssessments": {
+              "type": "array",
+              "title": "Fairness Assessments",
+              "description": "How does the model affect groups at risk of being systematically disadvantaged? What are the harms and benefits to the various affected groups?",
+              "items": {
+                "$ref": "#/definitions/fairnessAssessment"
+              }
+            }
+          }
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "inputOutputMLParameters": {
+      "type": "object",
+      "title": "Input and Output Parameters",
+      "additionalProperties": false,
+      "properties": {
+        "format": {
+          "description": "The data format for input/output to the model. Example formats include string, image, time-series",
+          "type": "string"
+        }
+      }
+    },
+    "componentData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the dataset elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+        },
+        "type": {
+          "type": "string",
+          "title": "Type of Data",
+          "description": "The general theme or subject matter of the data being specified.\n\n* __source-code__ = Any type of code, code snippet, or data-as-code.\n* __configuration__ = Parameters or settings that may be used by other components.\n* __dataset__ = A collection of data.\n* __definition__ = Data that can be used to create new instances of what the definition defines.\n* __other__ = Any other type of data that does not fit into existing definitions.",
+          "enum": [
+            "source-code",
+            "configuration",
+            "dataset",
+            "definition",
+            "other"
+          ]
+        },
+        "name": {
+          "description": "The name of the dataset.",
+          "type": "string"
+        },
+        "contents": {
+          "type": "object",
+          "title": "Data Contents",
+          "description": "The contents or references to the contents of the data being described.",
+          "additionalProperties": false,
+          "properties": {
+            "attachment": {
+              "title": "Data Attachment",
+              "description": "An optional way to include textual or encoded data.",
+              "$ref": "#/definitions/attachment"
+            },
+            "url": {
+              "type": "string",
+              "title": "Data URL",
+              "description": "The URL to where the data can be retrieved.",
+              "format": "iri-reference"
+            },
+            "properties": {
+              "type": "array",
+              "title": "Configuration Properties",
+              "description": "Provides the ability to document name-value parameters used for configuration.",
+              "items": {
+                "$ref": "#/definitions/property"
+              }
+            }
+          }
+        },
+        "classification": {
+          "$ref": "#/definitions/dataClassification"
+        },
+        "sensitiveData": {
+          "type": "array",
+          "description": "A description of any sensitive data in a dataset.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "graphics": {
+          "$ref": "#/definitions/graphicsCollection"
+        },
+        "description": {
+          "description": "A description of the dataset. Can describe size of dataset, whether it's used for source code, training, testing, or validation, etc.",
+          "type": "string"
+        },
+        "governance": {
+          "type": "object",
+          "title": "Data Governance",
+          "$ref": "#/definitions/dataGovernance"
+        }
+      }
+    },
+    "dataGovernance": {
+      "type": "object",
+      "title": "Data Governance",
+      "additionalProperties": false,
+      "properties": {
+        "custodians": {
+          "type": "array",
+          "title": "Data Custodians",
+          "description": "Data custodians are responsible for the safe custody, transport, and storage of data.",
+          "items": {
+            "$ref": "#/definitions/dataGovernanceResponsibleParty"
+          }
+        },
+        "stewards": {
+          "type": "array",
+          "title": "Data Stewards",
+          "description": "Data stewards are responsible for data content, context, and associated business rules.",
+          "items": {
+            "$ref": "#/definitions/dataGovernanceResponsibleParty"
+          }
+        },
+        "owners": {
+          "type": "array",
+          "title": "Data Owners",
+          "description": "Data owners are concerned with risk and appropriate access to data.",
+          "items": {
+            "$ref": "#/definitions/dataGovernanceResponsibleParty"
+          }
+        }
+      }
+    },
+    "dataGovernanceResponsibleParty": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "organization": {
+          "title": "Organization",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "contact": {
+          "title": "Individual",
+          "$ref": "#/definitions/organizationalContact"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "organization"
+          ]
+        },
+        {
+          "required": [
+            "contact"
+          ]
+        }
+      ]
+    },
+    "graphicsCollection": {
+      "type": "object",
+      "title": "Graphics Collection",
+      "description": "A collection of graphics that represent various measurements.",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "description": "A description of this collection of graphics.",
+          "type": "string"
+        },
+        "collection": {
+          "description": "A collection of graphics.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/graphic"
+          }
+        }
+      }
+    },
+    "graphic": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "The name of the graphic.",
+          "type": "string"
+        },
+        "image": {
+          "title": "Graphic Image",
+          "description": "The graphic (vector or raster). Base64 encoding MUST be specified for binary images.",
+          "$ref": "#/definitions/attachment"
+        }
+      }
+    },
+    "performanceMetric": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "The type of performance metric.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value of the performance metric.",
+          "type": "string"
+        },
+        "slice": {
+          "description": "The name of the slice this metric was computed on. By default, assume this metric is not sliced.",
+          "type": "string"
+        },
+        "confidenceInterval": {
+          "description": "The confidence interval of the metric.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "lowerBound": {
+              "description": "The lower bound of the confidence interval.",
+              "type": "string"
+            },
+            "upperBound": {
+              "description": "The upper bound of the confidence interval.",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "risk": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "The name of the risk.",
+          "type": "string"
+        },
+        "mitigationStrategy": {
+          "description": "Strategy used to address this risk.",
+          "type": "string"
+        }
+      }
+    },
+    "fairnessAssessment": {
+      "type": "object",
+      "title": "Fairness Assessment",
+      "description": "Information about the benefits and harms of the model to an identified at risk group.",
+      "additionalProperties": false,
+      "properties": {
+        "groupAtRisk": {
+          "type": "string",
+          "description": "The groups or individuals at risk of being systematically disadvantaged by the model."
+        },
+        "benefits": {
+          "type": "string",
+          "description": "Expected benefits to the identified groups."
+        },
+        "harms": {
+          "type": "string",
+          "description": "Expected harms to the identified groups."
+        },
+        "mitigationStrategy": {
+          "type": "string",
+          "description": "With respect to the benefits and harms outlined, please describe any mitigation strategy implemented."
+        }
+      }
+    },
+    "dataClassification": {
+      "type": "string",
+      "title": "Data Classification",
+      "description": "Data classification tags data according to its type, sensitivity, and value if altered, stolen, or destroyed."
+    },
+    "formula": {
+      "title": "Formula",
+      "description": "Describes workflows and resources that captures rules and other aspects of how the associated BOM component or service was formed.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the formula elsewhere in the BOM. Every bom-ref MUST be unique within the BOM.",
+          "$ref": "#/definitions/refType"
+        },
+        "components": {
+          "title": "Components",
+          "description": "Transient components that are used in tasks that constitute one or more of this formula's workflows",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/component"
+          },
+          "uniqueItems": true
+        },
+        "services": {
+          "title": "Services",
+          "description": "Transient services that are used in tasks that constitute one or more of this formula's workflows",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/service"
+          },
+          "uniqueItems": true
+        },
+        "workflows": {
+          "title": "Workflows",
+          "description": "List of workflows that can be declared to accomplish specific orchestrated goals and independently triggered.",
+          "$comment": "Different workflows can be designed to work together to perform end-to-end CI/CD builds and deployments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/workflow"
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "workflow": {
+      "title": "Workflow",
+      "description": "A specialized orchestration task.",
+      "$comment": "Workflow are as task themselves and can trigger other workflow tasks.  These relationships can be modeled in the taskDependencies graph.",
+      "type": "object",
+      "required": [
+        "bom-ref",
+        "uid",
+        "taskTypes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the workflow elsewhere in the BOM. Every bom-ref MUST be unique within the BOM.",
+          "$ref": "#/definitions/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/resourceReferenceChoice"
+          }
+        },
+        "tasks": {
+          "title": "Tasks",
+          "description": "The tasks that comprise the workflow.",
+          "$comment": "Note that tasks can appear more than once as different instances (by name or UID).",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/task"
+          }
+        },
+        "taskDependencies": {
+          "title": "Task dependency graph",
+          "description": "The graph of dependencies between tasks within the workflow.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/dependency"
+          }
+        },
+        "taskTypes": {
+          "title": "Task types",
+          "description": "Indicates the types of activities performed by the set of workflow tasks.",
+          "$comment": "Currently, these types reflect common CI/CD actions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/taskType"
+          }
+        },
+        "trigger": {
+          "title": "Trigger",
+          "description": "The trigger that initiated the task.",
+          "$ref": "#/definitions/trigger"
+        },
+        "steps": {
+          "title": "Steps",
+          "description": "The sequence of steps for the task.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "uniqueItems": true
+        },
+        "inputs": {
+          "title": "Inputs",
+          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+          "examples": [
+            "a `configuration` file which was declared as a local `component` or `externalReference`"
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inputType"
+          },
+          "uniqueItems": true
+        },
+        "outputs": {
+          "title": "Outputs",
+          "description": "Represents resources and data output from a task at runtime by executor or task commands",
+          "examples": [
+            "a log file or metrics data produced by the task"
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/outputType"
+          },
+          "uniqueItems": true
+        },
+        "timeStart": {
+          "title": "Time start",
+          "description": "The date and time (timestamp) when the task started.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "timeEnd": {
+          "title": "Time end",
+          "description": "The date and time (timestamp) when the task ended.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "workspaces": {
+          "title": "Workspaces",
+          "description": "A set of named filesystem or data resource shareable by workflow tasks.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/workspace"
+          }
+        },
+        "runtimeTopology": {
+          "title": "Runtime topology",
+          "description": "A graph of the component runtime topology for workflow's instance.",
+          "$comment": "A description of the runtime component and service topology.  This can describe a partial or complete topology used to host and execute the task (e.g., hardware, operating systems, configurations, etc.),",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/dependency"
+          }
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "task": {
+      "title": "Task",
+      "description": "Describes the inputs, sequence of steps and resources used to accomplish a task and its output.",
+      "$comment": "Tasks are building blocks for constructing assemble CI/CD workflows or pipelines.",
+      "type": "object",
+      "required": [
+        "bom-ref",
+        "uid",
+        "taskTypes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the task elsewhere in the BOM. Every bom-ref MUST be unique within the BOM.",
+          "$ref": "#/definitions/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/resourceReferenceChoice"
+          }
+        },
+        "taskTypes": {
+          "title": "Task types",
+          "description": "Indicates the types of activities performed by the set of workflow tasks.",
+          "$comment": "Currently, these types reflect common CI/CD actions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/taskType"
+          }
+        },
+        "trigger": {
+          "title": "Trigger",
+          "description": "The trigger that initiated the task.",
+          "$ref": "#/definitions/trigger"
+        },
+        "steps": {
+          "title": "Steps",
+          "description": "The sequence of steps for the task.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "uniqueItems": true
+        },
+        "inputs": {
+          "title": "Inputs",
+          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+          "examples": [
+            "a `configuration` file which was declared as a local `component` or `externalReference`"
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inputType"
+          },
+          "uniqueItems": true
+        },
+        "outputs": {
+          "title": "Outputs",
+          "description": "Represents resources and data output from a task at runtime by executor or task commands",
+          "examples": [
+            "a log file or metrics data produced by the task"
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/outputType"
+          },
+          "uniqueItems": true
+        },
+        "timeStart": {
+          "title": "Time start",
+          "description": "The date and time (timestamp) when the task started.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "timeEnd": {
+          "title": "Time end",
+          "description": "The date and time (timestamp) when the task ended.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "workspaces": {
+          "title": "Workspaces",
+          "description": "A set of named filesystem or data resource shareable by workflow tasks.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/workspace"
+          },
+          "uniqueItems": true
+        },
+        "runtimeTopology": {
+          "title": "Runtime topology",
+          "description": "A graph of the component runtime topology for task's instance.",
+          "$comment": "A description of the runtime component and service topology.  This can describe a partial or complete topology used to host and execute the task (e.g., hardware, operating systems, configurations, etc.),",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/dependency"
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "step": {
+      "type": "object",
+      "description": "Executes specific commands or tools in order to accomplish its owning task as part of a sequence.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "A name for the step.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the step.",
+          "type": "string"
+        },
+        "commands": {
+          "title": "Commands",
+          "description": "Ordered list of commands or directives for the step",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/command"
+          }
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "executed": {
+          "title": "Executed",
+          "description": "A text representation of the executed command.",
+          "type": "string"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "workspace": {
+      "title": "Workspace",
+      "description": "A named filesystem or data resource shareable by workflow tasks.",
+      "type": "object",
+      "required": [
+        "bom-ref",
+        "uid"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the workspace elsewhere in the BOM. Every bom-ref MUST be unique within the BOM.",
+          "$ref": "#/definitions/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "aliases": {
+          "title": "Aliases",
+          "description": "The names for the workspace as referenced by other workflow tasks. Effectively, a name mapping so other tasks can use their own local name in their steps.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/resourceReferenceChoice"
+          }
+        },
+        "accessMode": {
+          "title": "Access mode",
+          "description": "Describes the read-write access control for the workspace relative to the owning resource instance.",
+          "type": "string",
+          "enum": [
+            "read-only",
+            "read-write",
+            "read-write-once",
+            "write-once",
+            "write-only"
+          ]
+        },
+        "mountPath": {
+          "title": "Mount path",
+          "description": "A path to a location on disk where the workspace will be available to the associated task's steps.",
+          "type": "string"
+        },
+        "managedDataType": {
+          "title": "Managed data type",
+          "description": "The name of a domain-specific data type the workspace represents.",
+          "$comment": "This property is for CI/CD frameworks that are able to provide access to structured, managed data at a more granular level than a filesystem.",
+          "examples": [
+            "ConfigMap",
+            "Secret"
+          ],
+          "type": "string"
+        },
+        "volumeRequest": {
+          "title": "Volume request",
+          "description": "Identifies the reference to the request for a specific volume type and parameters.",
+          "examples": [
+            "a kubernetes Persistent Volume Claim (PVC) name"
+          ],
+          "type": "string"
+        },
+        "volume": {
+          "title": "Volume",
+          "description": "Information about the actual volume instance allocated to the workspace.",
+          "$comment": "The actual volume allocated may be different than the request.",
+          "examples": [
+            "see https://kubernetes.io/docs/concepts/storage/persistent-volumes/"
+          ],
+          "$ref": "#/definitions/volume"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "volume": {
+      "title": "Volume",
+      "description": "An identifiable, logical unit of data storage tied to a physical device.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the volume instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the volume instance",
+          "type": "string"
+        },
+        "mode": {
+          "title": "Mode",
+          "description": "The mode for the volume instance.",
+          "type": "string",
+          "enum": [
+            "filesystem",
+            "block"
+          ],
+          "default": "filesystem"
+        },
+        "path": {
+          "title": "Path",
+          "description": "The underlying path created from the actual volume.",
+          "type": "string"
+        },
+        "sizeAllocated": {
+          "title": "Size allocated",
+          "description": "The allocated size of the volume accessible to the associated workspace. This should include the scalar size as well as IEC standard unit in either decimal or binary form.",
+          "examples": [
+            "10GB",
+            "2Ti",
+            "1Pi"
+          ],
+          "type": "string"
+        },
+        "persistent": {
+          "title": "Persistent",
+          "description": "Indicates if the volume persists beyond the life of the resource it is associated with.",
+          "type": "boolean"
+        },
+        "remote": {
+          "title": "Remote",
+          "description": "Indicates if the volume is remotely (i.e., network) attached.",
+          "type": "boolean"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "trigger": {
+      "title": "Trigger",
+      "description": "Represents a resource that can conditionally activate (or fire) tasks based upon associated events and their data.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "bom-ref",
+        "uid"
+      ],
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the trigger elsewhere in the BOM. Every bom-ref MUST be unique within the BOM.",
+          "$ref": "#/definitions/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/resourceReferenceChoice"
+          }
+        },
+        "type": {
+          "title": "Type",
+          "description": "The source type of event which caused the trigger to fire.",
+          "type": "string",
+          "enum": [
+            "manual",
+            "api",
+            "webhook",
+            "scheduled"
+          ]
+        },
+        "event": {
+          "title": "Event",
+          "description": "The event data that caused the associated trigger to activate.",
+          "$ref": "#/definitions/event"
+        },
+        "conditions": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/condition"
+          }
+        },
+        "timeActivated": {
+          "title": "Time activated",
+          "description": "The date and time (timestamp) when the trigger was activated.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "inputs": {
+          "title": "Inputs",
+          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+          "examples": [
+            "a `configuration` file which was declared as a local `component` or `externalReference`"
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inputType"
+          },
+          "uniqueItems": true
+        },
+        "outputs": {
+          "title": "Outputs",
+          "description": "Represents resources and data output from a task at runtime by executor or task commands",
+          "examples": [
+            "a log file or metrics data produced by the task"
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/outputType"
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "event": {
+      "title": "Event",
+      "description": "Represents something that happened that may trigger a response.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier of the event.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the event.",
+          "type": "string"
+        },
+        "timeReceived": {
+          "title": "Time Received",
+          "description": "The date and time (timestamp) when the event was received.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "data": {
+          "title": "Data",
+          "description": "Encoding of the raw event data.",
+          "$ref": "#/definitions/attachment"
+        },
+        "source": {
+          "title": "Source",
+          "description": "References the component or service that was the source of the event",
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "target": {
+          "title": "Target",
+          "description": "References the component or service that was the target of the event",
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "inputType": {
+      "title": "Input type",
+      "description": "Type that represents various input data types and formats.",
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "resource"
+          ]
+        },
+        {
+          "required": [
+            "parameters"
+          ]
+        },
+        {
+          "required": [
+            "environmentVars"
+          ]
+        },
+        {
+          "required": [
+            "data"
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "title": "Source",
+          "description": "A references to the component or service that provided the input to the task (e.g., reference to a service with data flow value of `inbound`)",
+          "examples": [
+            "source code repository",
+            "database"
+          ],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "target": {
+          "title": "Target",
+          "description": "A reference to the component or service that received or stored the input if not the task itself (e.g., a local, named storage workspace)",
+          "examples": [
+            "workspace",
+            "directory"
+          ],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "resource": {
+          "title": "Resource",
+          "description": "A reference to an independent resource provided as an input to a task by the workflow runtime.",
+          "examples": [
+            "reference to a configuration file in a repository (i.e., a bom-ref)",
+            "reference to a scanning service used in a task (i.e., a bom-ref)"
+          ],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "parameters": {
+          "title": "Parameters",
+          "description": "Inputs that have the form of parameters with names and values.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/parameter"
+          }
+        },
+        "environmentVars": {
+          "title": "Environment variables",
+          "description": "Inputs that have the form of parameters with names and values.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/property"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "data": {
+          "title": "Data",
+          "description": "Inputs that have the form of data.",
+          "$ref": "#/definitions/attachment"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "outputType": {
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "resource"
+          ]
+        },
+        {
+          "required": [
+            "environmentVars"
+          ]
+        },
+        {
+          "required": [
+            "data"
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Type",
+          "description": "Describes the type of data output.",
+          "type": "string",
+          "enum": [
+            "artifact",
+            "attestation",
+            "log",
+            "evidence",
+            "metrics",
+            "other"
+          ]
+        },
+        "source": {
+          "title": "Source",
+          "description": "Component or service that generated or provided the output from the task (e.g., a build tool)",
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "target": {
+          "title": "Target",
+          "description": "Component or service that received the output from the task (e.g., reference to an artifactory service with data flow value of `outbound`)",
+          "examples": [
+            "a log file described as an `externalReference` within its target domain."
+          ],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "resource": {
+          "title": "Resource",
+          "description": "A reference to an independent resource generated as output by the task.",
+          "examples": [
+            "configuration file",
+            "source code",
+            "scanning service"
+          ],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "data": {
+          "title": "Data",
+          "description": "Outputs that have the form of data.",
+          "$ref": "#/definitions/attachment"
+        },
+        "environmentVars": {
+          "title": "Environment variables",
+          "description": "Outputs that have the form of environment variables.",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/property"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "resourceReferenceChoice": {
+      "title": "Resource reference choice",
+      "description": "A reference to a locally defined resource (e.g., a bom-ref) or an externally accessible resource.",
+      "$comment": "Enables reference to a resource that participates in a workflow; using either internal (bom-ref) or external (externalReference) types.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ref": {
+          "title": "BOM Reference",
+          "description": "References an object by its bom-ref attribute",
+          "anyOf": [
+            {
+              "title": "Ref",
+              "$ref": "#/definitions/refLinkType"
+            },
+            {
+              "title": "BOM-Link Element",
+              "$ref": "#/definitions/bomLinkElementType"
+            }
+          ]
+        },
+        "externalReference": {
+          "title": "External reference",
+          "description": "Reference to an externally accessible resource.",
+          "$ref": "#/definitions/externalReference"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "ref"
+          ]
+        },
+        {
+          "required": [
+            "externalReference"
+          ]
+        }
+      ]
+    },
+    "condition": {
+      "title": "Condition",
+      "description": "A condition that was used to determine a trigger should be activated.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "title": "Description",
+          "description": "Describes the set of conditions which cause the trigger to activate.",
+          "type": "string"
+        },
+        "expression": {
+          "title": "Expression",
+          "description": "The logical expression that was evaluated that determined the trigger should be fired.",
+          "type": "string"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "taskType": {
+      "type": "string",
+      "enum": [
+        "copy",
+        "clone",
+        "lint",
+        "scan",
+        "merge",
+        "build",
+        "test",
+        "deliver",
+        "deploy",
+        "release",
+        "clean",
+        "other"
+      ]
+    },
+    "parameter": {
+      "title": "Parameter",
+      "description": "A representation of a functional parameter.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The name of the parameter.",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "description": "The value of the parameter.",
+          "type": "string"
+        },
+        "dataType": {
+          "title": "Data type",
+          "description": "The data type of the parameter.",
+          "type": "string"
+        }
+      }
     },
     "signature": {
       "$ref": "jsf-0.82.schema.json#/definitions/signature",
       "title": "Signature",
-      "additionalProperties": false
+      "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
     }
+  },
+  "if": {
+    "required": [
+      "components"
+    ]
+  },
+  "then": {
+    "required": [
+      "bomFormat",
+      "specVersion",
+      "version",
+      "metadata",
+      "compositions",
+      "dependencies"
+    ]
+  },
+  "else": {
+    "required": [
+      "bomFormat",
+      "specVersion",
+      "version",
+      "metadata",
+      "compositions"
+    ]
   }
 }

--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -65,7 +65,6 @@
       "type": "integer",
       "title": "BOM Version",
       "description": "Whenever an existing BOM is modified, either manually or through automated processes, the version of the BOM SHOULD be incremented by 1. When a system is presented with multiple BOMs with identical serial numbers, the system SHOULD use the most recent version of the BOM. The default version is '1'.",
-      "minimum": 1,
       "default": 1,
       "examples": [
         1
@@ -78,6 +77,7 @@
     },
     "components": {
       "type": "array",
+      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/component"
       },
@@ -87,6 +87,7 @@
     },
     "services": {
       "type": "array",
+      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/service"
       },
@@ -96,14 +97,16 @@
     },
     "externalReferences": {
       "type": "array",
+      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/externalReference"
       },
       "title": "External References",
-      "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+      "description": "External references provide a way to document systems, sites, and information that may be relevant but which are not included with the BOM."
     },
     "dependencies": {
       "type": "array",
+      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/dependency"
       },
@@ -113,15 +116,17 @@
     },
     "compositions": {
       "type": "array",
+      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/compositions"
       },
       "uniqueItems": true,
       "title": "Compositions",
-      "description": "Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness. The completeness of vulnerabilities expressed in a BOM may also be described."
+      "description": "Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness."
     },
     "vulnerabilities": {
       "type": "array",
+      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/vulnerability"
       },
@@ -131,26 +136,26 @@
     },
     "annotations": {
       "type": "array",
+      "additionalItems": false,
       "items": {
-        "$ref": "#/definitions/annotations"
+        "type": "object"
       },
-      "uniqueItems": true,
       "title": "Annotations",
-      "description": "Comments made by people, organizations, or tools about any object with a bom-ref, such as components, services, vulnerabilities, or the BOM itself. Unlike inventory information, annotations may contain opinion or commentary from various stakeholders. Annotations may be inline (with inventory) or externalized via BOM-Link, and may optionally be signed."
+      "description": "Comments made by people, organizations, or tools about any object with a bom-ref."
     },
     "formulation": {
       "type": "array",
+      "additionalItems": false,
       "items": {
-        "$ref": "#/definitions/formula"
+        "type": "object"
       },
-      "uniqueItems": true,
       "title": "Formulation",
-      "description": "Describes how a component or service was manufactured or deployed. This is achieved through the use of formulas, workflows, tasks, and steps, which declare the precise steps to reproduce along with the observed formulas describing the steps which transpired in the manufacturing process."
+      "description": "Describes how a component or service was manufactured or deployed."
     },
     "properties": {
       "type": "array",
       "title": "Properties",
-      "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
+      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/property"
       }
@@ -163,14 +168,12 @@
   },
   "definitions": {
     "refType": {
-      "description": "Identifier for referable and therefore interlink-able elements.",
+      "$comment": "Identifier-DataType for interlinked elements.",
       "type": "string",
-      "additionalProperties": false,
-      "minLength": 1,
-      "$comment": "value SHOULD not start with the BOM-Link intro 'urn:cdx:'"
+      "additionalProperties": false
     },
     "refLinkType": {
-      "description": "Descriptor for an element identified by the attribute 'bom-ref' in the same BOM document.\nIn contrast to `bomLinkElementType`.",
+      "description": "Descriptor for an element identified by the attribute 'bom-ref' in the same BOM document.",
       "allOf": [
         {
           "$ref": "#/definitions/refType"
@@ -179,19 +182,17 @@
     },
     "bomLinkDocumentType": {
       "title": "BOM-Link Document",
-      "description": "Descriptor for another BOM document. See https://cyclonedx.org/capabilities/bomlink/",
+      "description": "Descriptor for another BOM document.",
       "type": "string",
       "format": "iri-reference",
-      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*$",
-      "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
+      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*$"
     },
     "bomLinkElementType": {
       "title": "BOM-Link Element",
-      "description": "Descriptor for an element in a BOM document. See https://cyclonedx.org/capabilities/bomlink/",
+      "description": "Descriptor for an element in a BOM document.",
       "type": "string",
       "format": "iri-reference",
-      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*#.+$",
-      "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
+      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*#.+$"
     },
     "bomLink": {
       "anyOf": [
@@ -219,53 +220,8 @@
         "lifecycles": {
           "type": "array",
           "title": "Lifecycles",
-          "description": "",
           "items": {
-            "type": "object",
-            "title": "Lifecycle",
-            "description": "The product lifecycle(s) that this BOM represents.",
-            "oneOf": [
-              {
-                "required": [
-                  "phase"
-                ],
-                "additionalProperties": false,
-                "properties": {
-                  "phase": {
-                    "type": "string",
-                    "title": "Phase",
-                    "description": "A pre-defined phase in the product lifecycle.\n\n* __design__ = BOM produced early in the development lifecycle containing inventory of components and services that are proposed or planned to be used. The inventory may need to be procured, retrieved, or resourced prior to use.\n* __pre-build__ = BOM consisting of information obtained prior to a build process and may contain source files and development artifacts and manifests. The inventory may need to be resolved and retrieved prior to use.\n* __build__ = BOM consisting of information obtained during a build process where component inventory is available for use. The precise versions of resolved components are usually available at this time as well as the provenance of where the components were retrieved from.\n* __post-build__ = BOM consisting of information obtained after a build process has completed and the resulting components(s) are available for further analysis. Built components may exist as the result of a CI/CD process, may have been installed or deployed to a system or device, and may need to be retrieved or extracted from the system or device.\n* __operations__ = BOM produced that represents inventory that is running and operational. This may include staging or production environments and will generally encompass multiple SBOMs describing the applications and operating system, along with HBOMs describing the hardware that makes up the system. Operations Bill of Materials (OBOM) can provide full-stack inventory of runtime environments, configurations, and additional dependencies.\n* __discovery__ = BOM consisting of information observed through network discovery providing point-in-time enumeration of embedded, on-premise, and cloud-native services such as server applications, connected devices, microservices, and serverless functions.\n* __decommission__ = BOM containing inventory that will be, or has been retired from operations.",
-                    "enum": [
-                      "design",
-                      "pre-build",
-                      "build",
-                      "post-build",
-                      "operations",
-                      "discovery",
-                      "decommission"
-                    ]
-                  }
-                }
-              },
-              {
-                "required": [
-                  "name"
-                ],
-                "additionalProperties": false,
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "title": "Name",
-                    "description": "The name of the lifecycle phase"
-                  },
-                  "description": {
-                    "type": "string",
-                    "title": "Description",
-                    "description": "The description of the lifecycle phase"
-                  }
-                }
-              }
-            ]
+            "type": "object"
           }
         },
         "tools": {
@@ -273,33 +229,28 @@
             {
               "type": "object",
               "title": "Creation Tools",
-              "description": "The tool(s) used in the creation of the BOM.",
               "additionalProperties": false,
               "properties": {
                 "components": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/tools_component"
-                  },
-                  "uniqueItems": true,
-                  "title": "Components",
-                  "description": "A list of software and hardware components used as tools"
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ]
+                  }
                 },
                 "services": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/service"
-                  },
-                  "uniqueItems": true,
-                  "title": "Services",
-                  "description": "A list of services used as tools. This may include microservices, function-as-a-service, and other types of network or intra-process services."
+                    "type": "object"
+                  }
                 }
               }
             },
             {
               "type": "array",
               "title": "Creation Tools (legacy)",
-              "description": "[Deprecated] The tool(s) used in the creation of the BOM.",
               "items": {
                 "$ref": "#/definitions/tool"
               }
@@ -310,6 +261,7 @@
           "type": "array",
           "title": "Authors",
           "description": "The person(s) who created the BOM. Authors are common in BOMs created through manual processes. BOMs created through automated means may not have authors.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/organizationalContact"
           }
@@ -330,20 +282,18 @@
           "$ref": "#/definitions/organizationalEntity"
         },
         "licenses": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/licenseChoice"
-            },
-            {
-              "minItems": 1
-            }
-          ],
-          "title": "Component License(s)"
+          "type": "array",
+          "title": "BOM License(s)",
+          "minItems": 1,
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/licenseChoice"
+          }
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -358,7 +308,7 @@
     "tool": {
       "type": "object",
       "title": "Tool",
-      "description": "[Deprecated] - DO NOT USE. This will be removed in a future version. This will be removed in a future version. Use component or service instead. Information about the automated or manual tool used",
+      "description": "Information about the automated or manual tool used",
       "additionalProperties": false,
       "properties": {
         "vendor": {
@@ -378,6 +328,7 @@
         },
         "hashes": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/hash"
           },
@@ -386,11 +337,12 @@
         },
         "externalReferences": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/externalReference"
           },
           "title": "External References",
-          "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but which are not included with the BOM."
         }
       }
     },
@@ -430,6 +382,7 @@
           "type": "array",
           "title": "Contact",
           "description": "A contact at the organization. Multiple contacts are allowed.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/organizationalContact"
           }
@@ -521,7 +474,6 @@
             "data"
           ],
           "title": "Component Type",
-          "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component. Types include:\n\n* __application__ = A software application. Refer to [https://en.wikipedia.org/wiki/Application_software](https://en.wikipedia.org/wiki/Application_software) for information about applications.\n* __framework__ = A software framework. Refer to [https://en.wikipedia.org/wiki/Software_framework](https://en.wikipedia.org/wiki/Software_framework) for information on how frameworks vary slightly from libraries.\n* __library__ = A software library. Refer to [https://en.wikipedia.org/wiki/Library_(computing)](https://en.wikipedia.org/wiki/Library_(computing))\n for information about libraries. All third-party and open source reusable components will likely be a library. If the library also has key features of a framework, then it should be classified as a framework. If not, or is unknown, then specifying library is RECOMMENDED.\n* __container__ = A packaging and/or runtime format, not specific to any particular technology, which isolates software inside the container from software outside of a container through virtualization technology. Refer to [https://en.wikipedia.org/wiki/OS-level_virtualization](https://en.wikipedia.org/wiki/OS-level_virtualization)\n* __platform__ = A runtime environment which interprets or executes software. This may include runtimes such as those that execute bytecode or low-code/no-code application platforms.\n* __operating-system__ = A software operating system without regard to deployment model (i.e. installed on physical hardware, virtual machine, image, etc) Refer to [https://en.wikipedia.org/wiki/Operating_system](https://en.wikipedia.org/wiki/Operating_system)\n* __device__ = A hardware device such as a processor, or chip-set. A hardware device containing firmware SHOULD include a component for the physical hardware itself, and another component of type 'firmware' or 'operating-system' (whichever is relevant), describing information about the software running on the device.\n  See also the list of [known device properties](https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/device.md).\n* __device-driver__ = A special type of software that operates or controls a particular type of device. Refer to [https://en.wikipedia.org/wiki/Device_driver](https://en.wikipedia.org/wiki/Device_driver)\n* __firmware__ = A special type of software that provides low-level control over a devices hardware. Refer to [https://en.wikipedia.org/wiki/Firmware](https://en.wikipedia.org/wiki/Firmware)\n* __file__ = A computer file. Refer to [https://en.wikipedia.org/wiki/Computer_file](https://en.wikipedia.org/wiki/Computer_file) for information about files.\n* __machine-learning-model__ = A model based on training data that can make predictions or decisions without being explicitly programmed to do so.\n* __data__ = A collection of discrete values that convey information.",
           "examples": [
             "library"
           ]
@@ -538,7 +490,6 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "minLength": 1,
           "description": "An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
         },
         "supplier": {
@@ -607,19 +558,18 @@
         "hashes": {
           "type": "array",
           "title": "Component Hashes",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/hash"
           }
         },
         "licenses": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/licenseChoice"
-            },
-            {
-              "minItems": 1
-            }
-          ],
+          "type": "array",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/licenseChoice"
+          },
+          "minItems": 1,
           "title": "Component License(s)"
         },
         "copyright": {
@@ -653,19 +603,17 @@
         },
         "modified": {
           "type": "boolean",
-          "title": "Component Modified From Original",
-          "description": "[Deprecated] - DO NOT USE. This will be removed in a future version. Use the pedigree element instead to supply information on exactly how the component was modified. A boolean value indicating if the component has been modified from the original. A value of true indicates the component is a derivative of the original. A value of false indicates the component has not been modified from the original."
+          "title": "Component Modified From Original"
         },
         "pedigree": {
           "type": "object",
           "title": "Component Pedigree",
-          "description": "Component pedigree is a way to document complex supply chain scenarios where components are created, distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to document variants where the exact relation may not be known.",
           "additionalProperties": false,
           "properties": {
             "ancestors": {
               "type": "array",
               "title": "Ancestors",
-              "description": "Describes zero or more components in which a component is derived from. This is commonly used to describe forks from existing projects where the forked version contains a ancestor node containing the original component it was forked from. For example, Component A is the original component. Component B is the component being used and documented in the BOM. However, Component B contains a pedigree node with a single ancestor documenting Component A - the original component from which Component B is derived from.",
+              "additionalItems": false,
               "items": {
                 "$ref": "#/definitions/component"
               }
@@ -673,7 +621,7 @@
             "descendants": {
               "type": "array",
               "title": "Descendants",
-              "description": "Descendants are the exact opposite of ancestors. This provides a way to document all forks (and their forks) of an original or root component.",
+              "additionalItems": false,
               "items": {
                 "$ref": "#/definitions/component"
               }
@@ -681,7 +629,7 @@
             "variants": {
               "type": "array",
               "title": "Variants",
-              "description": "Variants describe relations where the relationship between the components are not known. For example, if Component A contains nearly identical code to Component B. They are both related, but it is unclear if one is derived from the other, or if they share a common ancestor.",
+              "additionalItems": false,
               "items": {
                 "$ref": "#/definitions/component"
               }
@@ -689,7 +637,7 @@
             "commits": {
               "type": "array",
               "title": "Commits",
-              "description": "A list of zero or more commits which provide a trail describing how the component deviates from an ancestor, descendant, or variant.",
+              "additionalItems": false,
               "items": {
                 "$ref": "#/definitions/commit"
               }
@@ -697,69 +645,64 @@
             "patches": {
               "type": "array",
               "title": "Patches",
-              "description": ">A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complimentary to commits or may be used in place of commits.",
+              "additionalItems": false,
               "items": {
                 "$ref": "#/definitions/patch"
               }
             },
             "notes": {
               "type": "string",
-              "title": "Notes",
-              "description": "Notes, observations, and other non-structured commentary describing the components pedigree."
+              "title": "Notes"
             }
           }
         },
         "externalReferences": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/externalReference"
           },
-          "title": "External References",
-          "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+          "title": "External References"
         },
         "components": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/component"
           },
           "uniqueItems": true,
-          "title": "Components",
-          "description": "A list of software and hardware components included in the parent component. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system &#8594; subsystem &#8594; parts assembly in physical supply chains."
+          "title": "Components"
         },
         "evidence": {
           "$ref": "#/definitions/componentEvidence",
-          "title": "Evidence",
-          "description": "Provides the ability to document evidence collected through various forms of extraction or analysis."
+          "title": "Evidence"
         },
         "releaseNotes": {
           "$ref": "#/definitions/releaseNotes",
-          "title": "Release notes",
-          "description": "Specifies optional release notes."
+          "title": "Release notes"
         },
         "modelCard": {
-          "$ref": "#/definitions/modelCard",
+          "type": "object",
           "title": "Machine Learning Model Card"
         },
         "data": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/componentData"
+            "type": "object"
           },
-          "title": "Data",
-          "description": "This object SHOULD be specified for any component of type `data` and MUST NOT be specified for other component types."
+          "title": "Data"
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/property"
           }
         },
         "signature": {
           "$ref": "#/definitions/signature",
-          "title": "Signature",
-          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+          "title": "Signature"
         }
       },
       "anyOf": [
@@ -1221,8 +1164,8 @@
         },
         "name": {
           "type": "string",
-          "title": "License Name",
           "minLength": 1,
+          "title": "License Name",
           "description": "If SPDX does not define the license used, this field may be used to provide the license name",
           "examples": [
             "Acme Software License"
@@ -1247,11 +1190,32 @@
           "title": "Licensing information",
           "description": "Licensing details describing the licensor/licensee, license type, renewal and expiration dates, and other important metadata",
           "additionalProperties": false,
+          "required": [
+            "licenseTypes"
+          ],
+          "if": {
+            "properties": {
+              "licenseTypes": {
+                "contains": {
+                  "not": {
+                    "const": "appliance"
+                  }
+                }
+              }
+            },
+            "required": [
+              "licenseTypes"
+            ]
+          },
+          "then": {
+            "required": [
+              "licensor"
+            ]
+          },
           "properties": {
             "altIds": {
               "type": "array",
               "title": "Alternate License Identifiers",
-              "description": "License identifiers that may be used to manage licenses and their lifecycle",
               "items": {
                 "type": "string"
               }
@@ -1294,12 +1258,10 @@
               "properties": {
                 "organization": {
                   "title": "Licensee (Organization)",
-                  "description": "The organization that was granted the license",
                   "$ref": "#/definitions/organizationalEntity"
                 },
                 "individual": {
                   "title": "Licensee (Individual)",
-                  "description": "The individual, not associated with an organization, that was granted the license",
                   "$ref": "#/definitions/organizationalContact"
                 }
               },
@@ -1324,12 +1286,10 @@
               "properties": {
                 "organization": {
                   "title": "Purchaser (Organization)",
-                  "description": "The organization that purchased the license",
                   "$ref": "#/definitions/organizationalEntity"
                 },
                 "individual": {
                   "title": "Purchaser (Individual)",
-                  "description": "The individual, not associated with an organization, that purchased the license",
                   "$ref": "#/definitions/organizationalContact"
                 }
               },
@@ -1348,13 +1308,11 @@
             },
             "purchaseOrder": {
               "type": "string",
-              "title": "Purchase Order",
-              "description": "The purchase order identifier the purchaser sent to a supplier or vendor to authorize a purchase"
+              "title": "Purchase Order"
             },
             "licenseTypes": {
               "type": "array",
               "title": "License Type",
-              "description": "The type of license(s) that was granted to the licensee\n\n* __academic__ = A license that grants use of software solely for the purpose of education or research.\n* __appliance__ = A license covering use of software embedded in a specific piece of hardware.\n* __client-access__ = A Client Access License (CAL) allows client computers to access services provided by server software.\n* __concurrent-user__ = A Concurrent User license (aka floating license) limits the number of licenses for a software application and licenses are shared among a larger number of users.\n* __core-points__ = A license where the core of a computer's processor is assigned a specific number of points.\n* __custom-metric__ = A license for which consumption is measured by non-standard metrics.\n* __device__ = A license that covers a defined number of installations on computers and other types of devices.\n* __evaluation__ = A license that grants permission to install and use software for trial purposes.\n* __named-user__ = A license that grants access to the software to one or more pre-defined users.\n* __node-locked__ = A license that grants access to the software on one or more pre-defined computers or devices.\n* __oem__ = An Original Equipment Manufacturer license that is delivered with hardware, cannot be transferred to other hardware, and is valid for the life of the hardware.\n* __perpetual__ = A license where the software is sold on a one-time basis and the licensee can use a copy of the software indefinitely.\n* __processor-points__ = A license where each installation consumes points per processor.\n* __subscription__ = A license where the licensee pays a fee to use the software or service.\n* __user__ = A license that grants access to the software or service by a specified number of users.\n* __other__ = Another license type.\n",
               "items": {
                 "type": "string",
                 "enum": [
@@ -1380,44 +1338,18 @@
             "lastRenewal": {
               "type": "string",
               "format": "date-time",
-              "title": "Last Renewal",
-              "description": "The timestamp indicating when the license was last renewed. For new purchases, this is often the purchase or acquisition date. For non-perpetual licenses or subscriptions, this is the timestamp of when the license was last renewed."
+              "title": "Last Renewal"
             },
             "expiration": {
               "type": "string",
               "format": "date-time",
-              "title": "Expiration",
-              "description": "The timestamp indicating when the current license expires (if applicable)."
+              "title": "Expiration"
             }
-          },
-          "allOf": [
-            {
-              "if": {
-                "properties": {
-                  "licenseTypes": {
-                    "contains": {
-                      "const": "appliance"
-                    }
-                  }
-                },
-                "required": [
-                  "licenseTypes"
-                ]
-              },
-              "then": {},
-              "else": {
-                "required": [
-                  "licenseTypes",
-                  "licensor"
-                ]
-              }
-            }
-          ]
+          }
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -1431,44 +1363,35 @@
       }
     },
     "licenseChoice": {
-      "title": "License Choice",
-      "description": "EITHER (list of SPDX licenses and/or named licenses) OR (tuple of one SPDX License Expression)",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "oneOf": [
-          {
-            "required": [
-              "license"
-            ]
-          },
-          {
-            "required": [
-              "expression"
-            ]
-          }
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "license": {
-            "$ref": "#/definitions/license"
-          },
-          "expression": {
-            "type": "string",
-            "title": "SPDX License Expression",
-            "minLength": 1,
-            "examples": [
-              "Apache-2.0 AND (MIT OR GPL-2.0-only)",
-              "GPL-3.0-only WITH Classpath-exception-2.0"
-            ]
-          },
-          "bom-ref": {
-            "$ref": "#/definitions/refType",
-            "title": "BOM Reference",
-            "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
-          }
+      "type": "object",
+      "title": "License(s)",
+      "additionalProperties": false,
+      "properties": {
+        "license": {
+          "$ref": "#/definitions/license"
+        },
+        "expression": {
+          "type": "string",
+          "minLength": 1,
+          "title": "SPDX License Expression",
+          "examples": [
+            "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+            "GPL-3.0-only WITH Classpath-exception-2.0"
+          ]
         }
-      }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "license"
+          ]
+        },
+        {
+          "required": [
+            "expression"
+          ]
+        }
+      ]
     },
     "commit": {
       "type": "object",
@@ -1478,29 +1401,24 @@
       "properties": {
         "uid": {
           "type": "string",
-          "title": "UID",
-          "description": "A unique identifier of the commit. This may be version control specific. For example, Subversion uses revision numbers whereas git uses commit hashes."
+          "title": "UID"
         },
         "url": {
           "type": "string",
           "title": "URL",
-          "description": "The URL to the commit. This URL will typically point to a commit in a version control system.",
           "format": "iri-reference"
         },
         "author": {
           "title": "Author",
-          "description": "The author who created the changes in the commit",
           "$ref": "#/definitions/identifiableAction"
         },
         "committer": {
           "title": "Committer",
-          "description": "The person who committed or pushed the commit",
           "$ref": "#/definitions/identifiableAction"
         },
         "message": {
           "type": "string",
-          "title": "Message",
-          "description": "The text description of the contents of the commit"
+          "title": "Message"
         }
       }
     },
@@ -1521,46 +1439,41 @@
             "backport",
             "cherry-pick"
           ],
-          "title": "Type",
-          "description": "Specifies the purpose for the patch including the resolution of defects, security issues, or new behavior or functionality.\n\n* __unofficial__ = A patch which is not developed by the creators or maintainers of the software being patched. Refer to [https://en.wikipedia.org/wiki/Unofficial_patch](https://en.wikipedia.org/wiki/Unofficial_patch)\n* __monkey__ = A patch which dynamically modifies runtime behavior. Refer to [https://en.wikipedia.org/wiki/Monkey_patch](https://en.wikipedia.org/wiki/Monkey_patch)\n* __backport__ = A patch which takes code from a newer version of software and applies it to older versions of the same software. Refer to [https://en.wikipedia.org/wiki/Backporting](https://en.wikipedia.org/wiki/Backporting)\n* __cherry-pick__ = A patch created by selectively applying commits from other versions or branches of the same software."
+          "title": "Type"
         },
         "diff": {
           "title": "Diff",
-          "description": "The patch file (or diff) that show changes. Refer to [https://en.wikipedia.org/wiki/Diff](https://en.wikipedia.org/wiki/Diff)",
           "$ref": "#/definitions/diff"
         },
         "resolves": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/issue"
           },
-          "title": "Resolves",
-          "description": "A collection of issues the patch resolves"
+          "title": "Resolves"
         }
       }
     },
     "diff": {
       "type": "object",
       "title": "Diff",
-      "description": "The patch file (or diff) that show changes. Refer to https://en.wikipedia.org/wiki/Diff",
       "additionalProperties": false,
       "properties": {
         "text": {
           "title": "Diff text",
-          "description": "Specifies the optional text of the diff",
           "$ref": "#/definitions/attachment"
         },
         "url": {
           "type": "string",
           "title": "URL",
-          "description": "Specifies the URL to the diff",
           "format": "iri-reference"
         }
       }
     },
     "issue": {
       "type": "object",
-      "title": "Diff",
+      "title": "Issue",
       "description": "An individual issue that has been resolved.",
       "required": [
         "type"
@@ -1574,39 +1487,32 @@
             "enhancement",
             "security"
           ],
-          "title": "Type",
-          "description": "Specifies the type of issue"
+          "title": "Type"
         },
         "id": {
           "type": "string",
-          "title": "ID",
-          "description": "The identifier of the issue assigned by the source of the issue"
+          "title": "ID"
         },
         "name": {
           "type": "string",
-          "title": "Name",
-          "description": "The name of the issue"
+          "title": "Name"
         },
         "description": {
           "type": "string",
-          "title": "Description",
-          "description": "A description of the issue"
+          "title": "Description"
         },
         "source": {
           "type": "object",
           "title": "Source",
-          "description": "The source of the issue where it is documented",
           "additionalProperties": false,
           "properties": {
             "name": {
               "type": "string",
-              "title": "Name",
-              "description": "The name of the source. For example 'National Vulnerability Database', 'NVD', and 'Apache'"
+              "title": "Name"
             },
             "url": {
               "type": "string",
               "title": "URL",
-              "description": "The url of the issue documentation as provided by the source",
               "format": "iri-reference"
             }
           }
@@ -1617,43 +1523,35 @@
             "type": "string",
             "format": "iri-reference"
           },
-          "title": "References",
-          "description": "A collection of URL's for reference. Multiple URLs are allowed.",
-          "examples": [
-            "https://example.com"
-          ]
+          "title": "References"
         }
       }
     },
     "identifiableAction": {
       "type": "object",
       "title": "Identifiable Action",
-      "description": "Specifies an individual commit",
       "additionalProperties": false,
       "properties": {
         "timestamp": {
           "type": "string",
           "format": "date-time",
-          "title": "Timestamp",
-          "description": "The timestamp in which the action occurred"
+          "title": "Timestamp"
         },
         "name": {
           "type": "string",
-          "title": "Name",
-          "description": "The name of the individual who performed the action"
+          "title": "Name"
         },
         "email": {
           "type": "string",
           "format": "idn-email",
-          "title": "E-mail",
-          "description": "The email address of the individual who performed the action"
+          "title": "E-mail"
         }
       }
     },
     "externalReference": {
       "type": "object",
       "title": "External Reference",
-      "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM.",
+      "description": "Specifies an individual external reference",
       "required": [
         "url",
         "type"
@@ -1661,30 +1559,18 @@
       "additionalProperties": false,
       "properties": {
         "url": {
-          "anyOf": [
-            {
-              "title": "URL",
-              "type": "string",
-              "format": "iri-reference",
-              "minLength": 1
-            },
-            {
-              "title": "BOM-Link",
-              "$ref": "#/definitions/bomLink"
-            }
-          ],
+          "type": "string",
           "title": "URL",
-          "description": "The URI (URL or URN) to the external reference. External references are URIs and therefore can accept any URL scheme including https ([RFC-7230](https://www.ietf.org/rfc/rfc7230.txt)), mailto ([RFC-2368](https://www.ietf.org/rfc/rfc2368.txt)), tel ([RFC-3966](https://www.ietf.org/rfc/rfc3966.txt)), and dns ([RFC-4501](https://www.ietf.org/rfc/rfc4501.txt)). External references may also include formally registered URNs such as [CycloneDX BOM-Link](https://cyclonedx.org/capabilities/bomlink/) to reference CycloneDX BOMs or any object within a BOM. BOM-Link transforms applicable external references into relationships that can be expressed in a BOM or across BOMs."
+          "format": "iri-reference",
+          "minLength": 1
         },
         "comment": {
           "type": "string",
-          "title": "Comment",
-          "description": "An optional comment describing the external reference"
+          "title": "Comment"
         },
         "type": {
           "type": "string",
           "title": "Type",
-          "description": "Specifies the type of external reference.\n\n* __vcs__ = Version Control System\n* __issue-tracker__ = Issue or defect tracking system, or an Application Lifecycle Management (ALM) system\n* __website__ = Website\n* __advisories__ = Security advisories\n* __bom__ = Bill of Materials (SBOM, OBOM, HBOM, SaaSBOM, etc)\n* __mailing-list__ = Mailing list or discussion group\n* __social__ = Social media account\n* __chat__ = Real-time chat platform\n* __documentation__ = Documentation, guides, or how-to instructions\n* __support__ = Community or commercial support\n* __distribution__ = Direct or repository download location\n* __distribution-intake__ = The location where a component was published to. This is often the same as \"distribution\" but may also include specialized publishing processes that act as an intermediary\n* __license__ = The URL to the license file. If a license URL has been defined in the license node, it should also be defined as an external reference for completeness\n* __build-meta__ = Build-system specific meta file (i.e. pom.xml, package.json, .nuspec, etc)\n* __build-system__ = URL to an automated build system\n* __release-notes__ = URL to release notes\n* __security-contact__ = Specifies a way to contact the maintainer, supplier, or provider in the event of a security incident. Common URIs include links to a disclosure procedure, a mailto (RFC-2368) that specifies an email address, a tel (RFC-3966) that specifies a phone number, or dns (RFC-4501) that specifies the records containing DNS Security TXT\n* __model-card__ = A model card describes the intended uses of a machine learning model, potential limitations, biases, ethical considerations, training parameters, datasets used to train the model, performance metrics, and other relevant data useful for ML transparency\n* __log__ = A record of events that occurred in a computer system or application, such as problems, errors, or information on current operations\n* __configuration__ = Parameters or settings that may be used by other components or services\n* __evidence__ = Information used to substantiate a claim\n* __formulation__ = Describes how a component or service was manufactured or deployed\n* __attestation__ = Human or machine-readable statements containing facts, evidence, or testimony\n* __threat-model__ = An enumeration of identified weaknesses, threats, and countermeasures, dataflow diagram (DFD), attack tree, and other supporting documentation in human-readable or machine-readable format\n* __adversary-model__ = The defined assumptions, goals, and capabilities of an adversary.\n* __risk-assessment__ = Identifies and analyzes the potential of future events that may negatively impact individuals, assets, and/or the environment. Risk assessments may also include judgments on the tolerability of each risk.\n* __vulnerability-assertion__ = A Vulnerability Disclosure Report (VDR) which asserts the known and previously unknown vulnerabilities that affect a component, service, or product including the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on a component, service, or product.\n* __exploitability-statement__ = A Vulnerability Exploitability eXchange (VEX) which asserts the known vulnerabilities that do not affect a product, product family, or organization, and optionally the ones that do. The VEX should include the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on the product, product family, or organization.\n* __pentest-report__ = Results from an authorized simulated cyberattack on a component or service, otherwise known as a penetration test\n* __static-analysis-report__ = SARIF or proprietary machine or human-readable report for which static analysis has identified code quality, security, and other potential issues with the source code\n* __dynamic-analysis-report__ = Dynamic analysis report that has identified issues such as vulnerabilities and misconfigurations\n* __runtime-analysis-report__ = Report generated by analyzing the call stack of a running application\n* __component-analysis-report__ = Report generated by Software Composition Analysis (SCA), container analysis, or other forms of component analysis\n* __maturity-report__ = Report containing a formal assessment of an organization, business unit, or team against a maturity model\n* __certification-report__ = Industry, regulatory, or other certification from an accredited (if applicable) certification body\n* __quality-metrics__ = Report or system in which quality metrics can be obtained\n* __codified-infrastructure__ = Code or configuration that defines and provisions virtualized infrastructure, commonly referred to as Infrastructure as Code (IaC)\n* __poam__ = Plans of Action and Milestones (POAM) compliment an \"attestation\" external reference. POAM is defined by NIST as a \"document that identifies tasks needing to be accomplished. It details resources required to accomplish the elements of the plan, any milestones in meeting the tasks and scheduled completion dates for the milestones\".\n* __other__ = Use this if no other types accurately describe the purpose of the external reference",
           "enum": [
             "vcs",
             "issue-tracker",
@@ -1697,68 +1583,43 @@
             "documentation",
             "support",
             "distribution",
-            "distribution-intake",
             "license",
             "build-meta",
             "build-system",
             "release-notes",
-            "security-contact",
-            "model-card",
-            "log",
-            "configuration",
-            "evidence",
-            "formulation",
-            "attestation",
-            "threat-model",
-            "adversary-model",
-            "risk-assessment",
-            "vulnerability-assertion",
-            "exploitability-statement",
-            "pentest-report",
-            "static-analysis-report",
-            "dynamic-analysis-report",
-            "runtime-analysis-report",
-            "component-analysis-report",
-            "maturity-report",
-            "certification-report",
-            "codified-infrastructure",
-            "quality-metrics",
-            "poam",
             "other"
           ]
         },
         "hashes": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/hash"
           },
-          "title": "Hashes",
-          "description": "The hashes of the external reference (if applicable)."
+          "title": "Hashes"
         }
       }
     },
     "dependency": {
       "type": "object",
       "title": "Dependency",
-      "description": "Defines the direct dependencies of a component or service. Components or services that do not have their own dependencies MUST be declared as empty elements within the graph. Components or services that are not represented in the dependency graph MAY have unknown dependencies. It is RECOMMENDED that implementations assume this to be opaque and not an indicator of a object being dependency-free. It is RECOMMENDED to leverage compositions to indicate unknown dependency graphs.",
       "required": [
         "ref"
       ],
       "additionalProperties": false,
       "properties": {
         "ref": {
-          "$ref": "#/definitions/refLinkType",
-          "title": "Reference",
-          "description": "References a component or service by its bom-ref attribute"
+          "$ref": "#/definitions/refType",
+          "title": "Reference"
         },
         "dependsOn": {
           "type": "array",
           "uniqueItems": true,
+          "additionalItems": false,
           "items": {
-            "$ref": "#/definitions/refLinkType"
+            "$ref": "#/definitions/refType"
           },
-          "title": "Depends On",
-          "description": "The bom-ref identifiers of the components or services that are dependencies of this dependency object."
+          "title": "Depends On"
         }
       }
     },
@@ -1772,42 +1633,27 @@
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the service elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+          "title": "BOM Reference"
         },
         "provider": {
           "title": "Provider",
-          "description": "The organization that provides the service.",
           "$ref": "#/definitions/organizationalEntity"
         },
         "group": {
           "type": "string",
-          "title": "Service Group",
-          "description": "The grouping name, namespace, or identifier. This will often be a shortened, single name of the company or project that produced the service or domain name. Whitespace and special characters should be avoided.",
-          "examples": [
-            "com.acme"
-          ]
+          "title": "Service Group"
         },
         "name": {
           "type": "string",
-          "title": "Service Name",
-          "description": "The name of the service. This will often be a shortened, single name of the service.",
-          "examples": [
-            "ticker-service"
-          ]
+          "title": "Service Name"
         },
         "version": {
           "type": "string",
-          "title": "Service Version",
-          "description": "The service version.",
-          "examples": [
-            "1.0.0"
-          ]
+          "title": "Service Version"
         },
         "description": {
           "type": "string",
-          "title": "Service Description",
-          "description": "Specifies a description for the service"
+          "title": "Service Description"
         },
         "endpoints": {
           "type": "array",
@@ -1815,79 +1661,70 @@
             "type": "string",
             "format": "iri-reference"
           },
-          "title": "Endpoints",
-          "description": "The endpoint URIs of the service. Multiple endpoints are allowed.",
-          "examples": [
-            "https://example.com/api/v1/ticker"
-          ]
+          "title": "Endpoints"
         },
         "authenticated": {
           "type": "boolean",
-          "title": "Authentication Required",
-          "description": "A boolean value indicating if the service requires authentication. A value of true indicates the service requires authentication prior to use. A value of false indicates the service does not require authentication."
+          "title": "Authentication Required"
         },
         "x-trust-boundary": {
           "type": "boolean",
-          "title": "Crosses Trust Boundary",
-          "description": "A boolean value indicating if use of the service crosses a trust zone or boundary. A value of true indicates that by using the service, a trust boundary is crossed. A value of false indicates that by using the service, a trust boundary is not crossed."
-        },
-        "trustZone": {
-          "type": "string",
-          "title": "Trust Zone",
-          "description": "The name of the trust zone the service resides in."
+          "title": "Crosses Trust Boundary"
         },
         "data": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/serviceData"
           },
-          "title": "Data",
-          "description": "Specifies information about the data including the directional flow of data and the data classification."
+          "title": "Data"
         },
         "licenses": {
-          "$ref": "#/definitions/licenseChoice",
+          "type": "array",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/licenseChoice"
+          },
           "title": "Component License(s)"
         },
         "externalReferences": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/externalReference"
           },
-          "title": "External References",
-          "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+          "title": "External References"
         },
         "services": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/service"
           },
           "uniqueItems": true,
-          "title": "Services",
-          "description": "A list of services included or deployed behind the parent service. This is not a dependency tree. It provides a way to specify a hierarchical representation of service assemblies."
+          "title": "Services"
         },
         "releaseNotes": {
           "$ref": "#/definitions/releaseNotes",
-          "title": "Release notes",
-          "description": "Specifies optional release notes."
+          "title": "Release notes"
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/property"
           }
         },
         "signature": {
           "$ref": "#/definitions/signature",
-          "title": "Signature",
-          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+          "title": "Signature"
         }
       }
     },
     "serviceData": {
       "type": "object",
-      "title": "Hash Objects",
+      "title": "Service Data",
       "required": [
         "flow",
         "classification"
@@ -1896,68 +1733,11 @@
       "properties": {
         "flow": {
           "$ref": "#/definitions/dataFlowDirection",
-          "title": "Directional Flow",
-          "description": "Specifies the flow direction of the data. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways, and unknown states that the direction is not known."
+          "title": "Directional Flow"
         },
         "classification": {
-          "$ref": "#/definitions/dataClassification"
-        },
-        "name": {
           "type": "string",
-          "title": "Name",
-          "description": "Name for the defined data",
-          "examples": [
-            "Credit card reporting"
-          ]
-        },
-        "description": {
-          "type": "string",
-          "title": "Description",
-          "description": "Short description of the data content and usage",
-          "examples": [
-            "Credit card information being exchanged in between the web app and the database"
-          ]
-        },
-        "governance": {
-          "type": "object",
-          "title": "Data Governance",
-          "$ref": "#/definitions/dataGovernance"
-        },
-        "source": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "title": "URL",
-                "type": "string",
-                "format": "iri-reference"
-              },
-              {
-                "title": "BOM-Link Element",
-                "$ref": "#/definitions/bomLinkElementType"
-              }
-            ]
-          },
-          "title": "Source",
-          "description": "The URI, URL, or BOM-Link of the components or services the data came in from"
-        },
-        "destination": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "title": "URL",
-                "type": "string",
-                "format": "iri-reference"
-              },
-              {
-                "title": "BOM-Link Element",
-                "$ref": "#/definitions/bomLinkElementType"
-              }
-            ]
-          },
-          "title": "Destination",
-          "description": "The URI, URL, or BOM-Link of the components or services the data is sent to"
+          "title": "Classification"
         }
       }
     },
@@ -1969,9 +1749,7 @@
         "bi-directional",
         "unknown"
       ],
-      "title": "Data flow direction",
-      "description": "Specifies the flow direction of the data. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways, and unknown states that the direction is not known.",
-      "additionalProperties": false
+      "title": "Data flow direction"
     },
     "copyright": {
       "type": "object",
@@ -1990,190 +1768,19 @@
     "componentEvidence": {
       "type": "object",
       "title": "Evidence",
-      "description": "Provides the ability to document evidence collected through various forms of extraction or analysis.",
       "additionalProperties": false,
       "properties": {
-        "identity": {
-          "type": "object",
-          "description": "Evidence that substantiates the identity of a component.",
-          "required": [
-            "field"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "field": {
-              "type": "string",
-              "enum": [
-                "group",
-                "name",
-                "version",
-                "purl",
-                "cpe",
-                "swid",
-                "hash"
-              ],
-              "title": "Field",
-              "description": "The identity field of the component which the evidence describes."
-            },
-            "confidence": {
-              "type": "number",
-              "minimum": 0,
-              "maximum": 1,
-              "title": "Confidence",
-              "description": "The overall confidence of the evidence from 0 - 1, where 1 is 100% confidence."
-            },
-            "methods": {
-              "type": "array",
-              "title": "Methods",
-              "description": "The methods used to extract and/or analyze the evidence.",
-              "items": {
-                "type": "object",
-                "required": [
-                  "technique",
-                  "confidence"
-                ],
-                "additionalProperties": false,
-                "properties": {
-                  "technique": {
-                    "title": "Technique",
-                    "description": "The technique used in this method of analysis.",
-                    "type": "string",
-                    "enum": [
-                      "source-code-analysis",
-                      "binary-analysis",
-                      "manifest-analysis",
-                      "ast-fingerprint",
-                      "hash-comparison",
-                      "instrumentation",
-                      "dynamic-analysis",
-                      "filename",
-                      "attestation",
-                      "other"
-                    ]
-                  },
-                  "confidence": {
-                    "type": "number",
-                    "minimum": 0,
-                    "maximum": 1,
-                    "title": "Confidence",
-                    "description": "The confidence of the evidence from 0 - 1, where 1 is 100% confidence. Confidence is specific to the technique used. Each technique of analysis can have independent confidence."
-                  },
-                  "value": {
-                    "type": "string",
-                    "title": "Value",
-                    "description": "The value or contents of the evidence."
-                  }
-                }
-              }
-            },
-            "tools": {
-              "type": "array",
-              "uniqueItems": true,
-              "items": {
-                "anyOf": [
-                  {
-                    "title": "Ref",
-                    "$ref": "#/definitions/refLinkType"
-                  },
-                  {
-                    "title": "BOM-Link Element",
-                    "$ref": "#/definitions/bomLinkElementType"
-                  }
-                ]
-              },
-              "title": "BOM References",
-              "description": "The object in the BOM identified by its bom-ref. This is often a component or service, but may be any object type supporting bom-refs. Tools used for analysis should already be defined in the BOM, either in the metadata/tools, components, or formulation."
-            }
-          }
-        },
-        "occurrences": {
-          "type": "array",
-          "title": "Occurrences",
-          "description": "Evidence of individual instances of a component spread across multiple locations.",
-          "items": {
-            "type": "object",
-            "required": [
-              "location"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "bom-ref": {
-                "$ref": "#/definitions/refType",
-                "title": "BOM Reference",
-                "description": "An optional identifier which can be used to reference the occurrence elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
-              },
-              "location": {
-                "type": "string",
-                "title": "Location",
-                "description": "The location or path to where the component was found."
-              }
-            }
-          }
-        },
-        "callstack": {
-          "type": "object",
-          "description": "Evidence of the components use through the callstack.",
-          "additionalProperties": false,
-          "properties": {
-            "frames": {
-              "type": "array",
-              "title": "Methods",
-              "items": {
-                "type": "object",
-                "required": [
-                  "module"
-                ],
-                "additionalProperties": false,
-                "properties": {
-                  "package": {
-                    "title": "Package",
-                    "description": "A package organizes modules into namespaces, providing a unique namespace for each type it contains.",
-                    "type": "string"
-                  },
-                  "module": {
-                    "title": "Module",
-                    "description": "A module or class that encloses functions/methods and other code.",
-                    "type": "string"
-                  },
-                  "function": {
-                    "title": "Function",
-                    "description": "A block of code designed to perform a particular task.",
-                    "type": "string"
-                  },
-                  "parameters": {
-                    "title": "Parameters",
-                    "description": "Optional arguments that are passed to the module or function.",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "line": {
-                    "title": "Line",
-                    "description": "The line number the code that is called resides on.",
-                    "type": "integer"
-                  },
-                  "column": {
-                    "title": "Column",
-                    "description": "The column the code that is called resides.",
-                    "type": "integer"
-                  },
-                  "fullFilename": {
-                    "title": "Full Filename",
-                    "description": "The full path and filename of the module.",
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
         "licenses": {
-          "$ref": "#/definitions/licenseChoice",
+          "type": "array",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/licenseChoice"
+          },
           "title": "Component License(s)"
         },
         "copyright": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/copyright"
           },
@@ -2192,31 +1799,19 @@
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the composition elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+          "title": "BOM Reference"
         },
         "aggregate": {
           "$ref": "#/definitions/aggregateType",
-          "title": "Aggregate",
-          "description": "Specifies an aggregate type that describe how complete a relationship is.\n\n* __complete__ = The relationship is complete. No further relationships including constituent components, services, or dependencies are known to exist.\n* __incomplete__ = The relationship is incomplete. Additional relationships exist and may include constituent components, services, or dependencies.\n* __incomplete&#95;first&#95;party&#95;only__ = The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented.\n* __incomplete&#95;first&#95;party&#95;proprietary&#95;only__ = The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.\n* __incomplete&#95;first&#95;party&#95;opensource&#95;only__ = The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are opensource.\n* __incomplete&#95;third&#95;party&#95;only__ = The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented.\n* __incomplete&#95;third&#95;party&#95;proprietary&#95;only__ = The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.\n* __incomplete&#95;third&#95;party&#95;opensource&#95;only__ = The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are opensource.\n* __unknown__ = The relationship may be complete or incomplete. This usually signifies a 'best-effort' to obtain constituent components, services, or dependencies but the completeness is inconclusive.\n* __not&#95;specified__ = The relationship completeness is not specified.\n"
+          "title": "Aggregate"
         },
         "assemblies": {
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "anyOf": [
-              {
-                "title": "Ref",
-                "$ref": "#/definitions/refLinkType"
-              },
-              {
-                "title": "BOM-Link Element",
-                "$ref": "#/definitions/bomLinkElementType"
-              }
-            ]
+            "type": "string"
           },
-          "title": "BOM references",
-          "description": "The bom-ref identifiers of the components or services being described. Assemblies refer to nested relationships whereby a constituent part may include other constituent parts. References do not cascade to child parts. References are explicit for the specified constituent part only."
+          "title": "BOM references"
         },
         "dependencies": {
           "type": "array",
@@ -2224,8 +1819,7 @@
           "items": {
             "type": "string"
           },
-          "title": "BOM references",
-          "description": "The bom-ref identifiers of the components or services being described. Dependencies refer to a relationship whereby an independent constituent part requires another independent constituent part. References do not cascade to transitive dependencies. References are explicit for the specified dependency only."
+          "title": "BOM references"
         },
         "vulnerabilities": {
           "type": "array",
@@ -2233,13 +1827,11 @@
           "items": {
             "type": "string"
           },
-          "title": "BOM references",
-          "description": "The bom-ref identifiers of the vulnerabilities being described."
+          "title": "Vulnerabilities"
         },
         "signature": {
           "$ref": "#/definitions/signature",
-          "title": "Signature",
-          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+          "title": "Signature"
         }
       }
     },
@@ -2250,11 +1842,7 @@
         "complete",
         "incomplete",
         "incomplete_first_party_only",
-        "incomplete_first_party_proprietary_only",
-        "incomplete_first_party_opensource_only",
         "incomplete_third_party_only",
-        "incomplete_third_party_proprietary_only",
-        "incomplete_third_party_opensource_only",
         "unknown",
         "not_specified"
       ],
@@ -2263,17 +1851,14 @@
     "property": {
       "type": "object",
       "title": "Lightweight name-value pair",
-      "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
       "properties": {
         "name": {
           "type": "string",
-          "title": "Name",
-          "description": "The name of the property. Duplicate names are allowed, each potentially having a different value."
+          "title": "Name"
         },
         "value": {
           "type": "string",
-          "title": "Value",
-          "description": "The value of the property."
+          "title": "Value"
         }
       },
       "additionalProperties": false
@@ -2282,7 +1867,6 @@
       "type": "string",
       "pattern": "^([a-z]{2})(-[A-Z]{2})?$",
       "title": "Locale",
-      "description": "Defines a syntax for representing two character language code (ISO-639) followed by an optional two character country code. The language code MUST be lower case. If the country code is specified, the country code MUST be upper case. The language code and country code MUST be separated by a minus sign. Examples: en, en-US, fr, fr-CA",
       "additionalProperties": false
     },
     "releaseType": {
@@ -2294,13 +1878,11 @@
         "pre-release",
         "internal"
       ],
-      "description": "The software versioning type. It is RECOMMENDED that the release type use one of 'major', 'minor', 'patch', 'pre-release', or 'internal'. Representing all possible software release types is not practical, so standardizing on the recommended values, whenever possible, is strongly encouraged.\n\n* __major__ = A major release may contain significant changes or may introduce breaking changes.\n* __minor__ = A minor release, also known as an update, may contain a smaller number of changes than major releases.\n* __patch__ = Patch releases are typically unplanned and may resolve defects or important security issues.\n* __pre-release__ = A pre-release may include alpha, beta, or release candidates and typically have limited support. They provide the ability to preview a release prior to its general availability.\n* __internal__ = Internal releases are not for public consumption and are intended to be used exclusively by the project or manufacturer that produced it.",
       "additionalProperties": false
     },
     "note": {
       "type": "object",
       "title": "Note",
-      "description": "A note containing the locale and content.",
       "required": [
         "text"
       ],
@@ -2308,12 +1890,10 @@
       "properties": {
         "locale": {
           "$ref": "#/definitions/localeType",
-          "title": "Locale",
-          "description": "The ISO-639 (or higher) language code and optional ISO-3166 (or higher) country code. Examples include: \"en\", \"en-US\", \"fr\" and \"fr-CA\""
+          "title": "Locale"
         },
         "text": {
           "title": "Release note content",
-          "description": "Specifies the full content of the release note.",
           "$ref": "#/definitions/attachment"
         }
       }
@@ -2328,73 +1908,65 @@
       "properties": {
         "type": {
           "$ref": "#/definitions/releaseType",
-          "title": "Type",
-          "description": "The software versioning type the release note describes."
+          "title": "Type"
         },
         "title": {
           "type": "string",
-          "title": "Title",
-          "description": "The title of the release."
+          "title": "Title"
         },
         "featuredImage": {
           "type": "string",
           "format": "iri-reference",
-          "title": "Featured image",
-          "description": "The URL to an image that may be prominently displayed with the release note."
+          "title": "Featured image"
         },
         "socialImage": {
           "type": "string",
           "format": "iri-reference",
-          "title": "Social image",
-          "description": "The URL to an image that may be used in messaging on social media platforms."
+          "title": "Social image"
         },
         "description": {
           "type": "string",
-          "title": "Description",
-          "description": "A short description of the release."
+          "title": "Description"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time",
-          "title": "Timestamp",
-          "description": "The date and time (timestamp) when the release note was created."
+          "title": "Timestamp"
         },
         "aliases": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "title": "Aliases",
-          "description": "One or more alternate names the release may be referred to. This may include unofficial terms used by development and marketing teams (e.g. code names)."
+          "title": "Aliases"
         },
         "tags": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "title": "Tags",
-          "description": "One or more tags that may aid in search or retrieval of the release note."
+          "title": "Tags"
         },
         "resolves": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/issue"
           },
-          "title": "Resolves",
-          "description": "A collection of issues that have been resolved."
+          "title": "Resolves"
         },
         "notes": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/note"
           },
-          "title": "Notes",
-          "description": "Zero or more release notes containing the locale and content. Multiple note objects may be specified to support release notes in a wide variety of languages."
+          "title": "Notes"
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -2404,7 +1976,6 @@
     "advisory": {
       "type": "object",
       "title": "Advisory",
-      "description": "Title and location where advisory information can be obtained. An advisory is a notification of a threat to a component, service, or system.",
       "required": [
         "url"
       ],
@@ -2412,14 +1983,12 @@
       "properties": {
         "title": {
           "type": "string",
-          "title": "Title",
-          "description": "An optional name of the advisory."
+          "title": "Title"
         },
         "url": {
           "type": "string",
           "title": "URL",
-          "format": "iri-reference",
-          "description": "Location where the advisory can be obtained."
+          "format": "iri-reference"
         }
       }
     },
@@ -2427,13 +1996,11 @@
       "type": "integer",
       "minimum": 1,
       "title": "CWE",
-      "description": "Integer representation of a Common Weaknesses Enumerations (CWE). For example 399 (of https://cwe.mitre.org/data/definitions/399.html)",
       "additionalProperties": false
     },
     "severity": {
       "type": "string",
       "title": "Severity",
-      "description": "Textual representation of the severity of the vulnerability adopted by the analysis method. If the analysis method uses values other than what is provided, the user is expected to translate appropriately.",
       "enum": [
         "critical",
         "high",
@@ -2448,14 +2015,11 @@
     "scoreMethod": {
       "type": "string",
       "title": "Method",
-      "description": "Specifies the severity or risk scoring methodology or standard used.\n\n* CVSSv2 - [Common Vulnerability Scoring System v2](https://www.first.org/cvss/v2/)\n* CVSSv3 - [Common Vulnerability Scoring System v3](https://www.first.org/cvss/v3-0/)\n* CVSSv31 - [Common Vulnerability Scoring System v3.1](https://www.first.org/cvss/v3-1/)\n* CVSSv4 - [Common Vulnerability Scoring System v4](https://www.first.org/cvss/v4-0/)\n* OWASP - [OWASP Risk Rating Methodology](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology)\n* SSVC - [Stakeholder Specific Vulnerability Categorization](https://github.com/CERTCC/SSVC) (all versions)",
       "enum": [
         "CVSSv2",
         "CVSSv3",
         "CVSSv31",
-        "CVSSv4",
         "OWASP",
-        "SSVC",
         "other"
       ],
       "additionalProperties": false
@@ -2463,7 +2027,6 @@
     "impactAnalysisState": {
       "type": "string",
       "title": "Impact Analysis State",
-      "description": "Declares the current state of an occurrence of a vulnerability, after automated or manual analysis. \n\n* __resolved__ = the vulnerability has been remediated. \n* __resolved\\_with\\_pedigree__ = the vulnerability has been remediated and evidence of the changes are provided in the affected components pedigree containing verifiable commit history and/or diff(s). \n* __exploitable__ = the vulnerability may be directly or indirectly exploitable. \n* __in\\_triage__ = the vulnerability is being investigated. \n* __false\\_positive__ = the vulnerability is not specific to the component or service and was falsely identified or associated. \n* __not\\_affected__ = the component or service is not affected by the vulnerability. Justification should be specified for all not_affected cases.",
       "enum": [
         "resolved",
         "resolved_with_pedigree",
@@ -2471,12 +2034,12 @@
         "in_triage",
         "false_positive",
         "not_affected"
-      ]
+      ],
+      "additionalProperties": false
     },
     "impactAnalysisJustification": {
       "type": "string",
       "title": "Impact Analysis Justification",
-      "description": "The rationale of why the impact analysis state was asserted. \n\n* __code\\_not\\_present__ = the code has been removed or tree-shaked. \n* __code\\_not\\_reachable__ = the vulnerable code is not invoked at runtime. \n* __requires\\_configuration__ = exploitability requires a configurable option to be set/unset. \n* __requires\\_dependency__ = exploitability requires a dependency that is not present. \n* __requires\\_environment__ = exploitability requires a certain environment which is not present. \n* __protected\\_by\\_compiler__ = exploitability requires a compiler flag to be set/unset. \n* __protected\\_at\\_runtime__ = exploits are prevented at runtime. \n* __protected\\_at\\_perimeter__ = attacks are blocked at physical, logical, or network perimeter. \n* __protected\\_by\\_mitigating\\_control__ = preventative measures have been implemented that reduce the likelihood and/or impact of the vulnerability.",
       "enum": [
         "code_not_present",
         "code_not_reachable",
@@ -2493,96 +2056,67 @@
     "rating": {
       "type": "object",
       "title": "Rating",
-      "description": "Defines the severity or risk ratings of a vulnerability.",
       "additionalProperties": false,
       "properties": {
         "source": {
-          "$ref": "#/definitions/vulnerabilitySource",
-          "description": "The source that calculated the severity or risk rating of the vulnerability."
+          "$ref": "#/definitions/vulnerabilitySource"
         },
         "score": {
           "type": "number",
-          "title": "Score",
-          "description": "The numerical score of the rating."
+          "title": "Score"
         },
         "severity": {
-          "$ref": "#/definitions/severity",
-          "description": "Textual representation of the severity that corresponds to the numerical score of the rating."
+          "$ref": "#/definitions/severity"
         },
         "method": {
           "$ref": "#/definitions/scoreMethod"
         },
         "vector": {
           "type": "string",
-          "title": "Vector",
-          "description": "Textual representation of the metric values used to score the vulnerability"
+          "title": "Vector"
         },
         "justification": {
           "type": "string",
-          "title": "Justification",
-          "description": "An optional reason for rating the vulnerability as it was"
+          "title": "Justification"
         }
       }
     },
     "vulnerabilitySource": {
       "type": "object",
       "title": "Source",
-      "description": "The source of vulnerability information. This is often the organization that published the vulnerability.",
       "additionalProperties": false,
       "properties": {
         "url": {
           "type": "string",
-          "title": "URL",
-          "description": "The url of the vulnerability documentation as provided by the source.",
-          "examples": [
-            "https://nvd.nist.gov/vuln/detail/CVE-2021-39182"
-          ]
+          "title": "URL"
         },
         "name": {
           "type": "string",
-          "title": "Name",
-          "description": "The name of the source.",
-          "examples": [
-            "NVD",
-            "National Vulnerability Database",
-            "OSS Index",
-            "VulnDB",
-            "GitHub Advisories"
-          ]
+          "title": "Name"
         }
       }
     },
     "vulnerability": {
       "type": "object",
       "title": "Vulnerability",
-      "description": "Defines a weakness in a component or service that could be exploited or triggered by a threat source.",
       "additionalProperties": false,
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the vulnerability elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+          "title": "BOM Reference"
         },
         "id": {
           "type": "string",
-          "title": "ID",
-          "description": "The identifier that uniquely identifies the vulnerability.",
-          "examples": [
-            "CVE-2021-39182",
-            "GHSA-35m5-8cvj-8783",
-            "SNYK-PYTHON-ENROCRYPT-1912876"
-          ]
+          "title": "ID"
         },
         "source": {
-          "$ref": "#/definitions/vulnerabilitySource",
-          "description": "The source that published the vulnerability."
+          "$ref": "#/definitions/vulnerabilitySource"
         },
         "references": {
           "type": "array",
           "title": "References",
-          "description": "Zero or more pointers to vulnerabilities that are the equivalent of the vulnerability specified. Often times, the same vulnerability may exist in multiple sources of vulnerability intelligence, but have different identifiers. References provide a way to correlate vulnerabilities across multiple sources of vulnerability intelligence.",
+          "additionalItems": false,
           "items": {
-            "type": "object",
             "required": [
               "id",
               "source"
@@ -2591,17 +2125,10 @@
             "properties": {
               "id": {
                 "type": "string",
-                "title": "ID",
-                "description": "An identifier that uniquely identifies the vulnerability.",
-                "examples": [
-                  "CVE-2021-39182",
-                  "GHSA-35m5-8cvj-8783",
-                  "SNYK-PYTHON-ENROCRYPT-1912876"
-                ]
+                "title": "ID"
               },
               "source": {
-                "$ref": "#/definitions/vulnerabilitySource",
-                "description": "The source that published the vulnerability."
+                "$ref": "#/definitions/vulnerabilitySource"
               }
             }
           }
@@ -2609,7 +2136,7 @@
         "ratings": {
           "type": "array",
           "title": "Ratings",
-          "description": "List of vulnerability ratings",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/rating"
           }
@@ -2617,63 +2144,27 @@
         "cwes": {
           "type": "array",
           "title": "CWEs",
-          "description": "List of Common Weaknesses Enumerations (CWEs) codes that describes this vulnerability. For example 399 (of https://cwe.mitre.org/data/definitions/399.html)",
-          "examples": [
-            399
-          ],
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/cwe"
           }
         },
         "description": {
           "type": "string",
-          "title": "Description",
-          "description": "A description of the vulnerability as provided by the source."
+          "title": "Description"
         },
         "detail": {
           "type": "string",
-          "title": "Details",
-          "description": "If available, an in-depth description of the vulnerability as provided by the source organization. Details often include information useful in understanding root cause."
+          "title": "Details"
         },
         "recommendation": {
           "type": "string",
-          "title": "Recommendation",
-          "description": "Recommendations of how the vulnerability can be remediated or mitigated."
-        },
-        "workaround": {
-          "type": "string",
-          "title": "Workarounds",
-          "description": "A bypass, usually temporary, of the vulnerability that reduces its likelihood and/or impact. Workarounds often involve changes to configuration or deployments."
-        },
-        "proofOfConcept": {
-          "type": "object",
-          "title": "Proof of Concept",
-          "description": "Evidence used to reproduce the vulnerability.",
-          "properties": {
-            "reproductionSteps": {
-              "type": "string",
-              "title": "Steps to Reproduce",
-              "description": "Precise steps to reproduce the vulnerability."
-            },
-            "environment": {
-              "type": "string",
-              "title": "Environment",
-              "description": "A description of the environment in which reproduction was possible."
-            },
-            "supportingMaterial": {
-              "type": "array",
-              "title": "Supporting Material",
-              "description": "Supporting material that helps in reproducing or understanding how reproduction is possible. This may include screenshots, payloads, and PoC exploit code.",
-              "items": {
-                "$ref": "#/definitions/attachment"
-              }
-            }
-          }
+          "title": "Recommendation"
         },
         "advisories": {
           "type": "array",
           "title": "Advisories",
-          "description": "Published advisories of the vulnerability if provided.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/advisory"
           }
@@ -2681,37 +2172,27 @@
         "created": {
           "type": "string",
           "format": "date-time",
-          "title": "Created",
-          "description": "The date and time (timestamp) when the vulnerability record was created in the vulnerability database."
+          "title": "Created"
         },
         "published": {
           "type": "string",
           "format": "date-time",
-          "title": "Published",
-          "description": "The date and time (timestamp) when the vulnerability record was first published."
+          "title": "Published"
         },
         "updated": {
           "type": "string",
           "format": "date-time",
-          "title": "Updated",
-          "description": "The date and time (timestamp) when the vulnerability record was last updated."
-        },
-        "rejected": {
-          "type": "string",
-          "format": "date-time",
-          "title": "Rejected",
-          "description": "The date and time (timestamp) when the vulnerability record was rejected (if applicable)."
+          "title": "Updated"
         },
         "credits": {
           "type": "object",
           "title": "Credits",
-          "description": "Individuals or organizations credited with the discovery of the vulnerability.",
           "additionalProperties": false,
           "properties": {
             "organizations": {
               "type": "array",
               "title": "Organizations",
-              "description": "The organizations credited with vulnerability discovery.",
+              "additionalItems": false,
               "items": {
                 "$ref": "#/definitions/organizationalEntity"
               }
@@ -2719,7 +2200,7 @@
             "individuals": {
               "type": "array",
               "title": "Individuals",
-              "description": "The individuals, not associated with organizations, that are credited with vulnerability discovery.",
+              "additionalItems": false,
               "items": {
                 "$ref": "#/definitions/organizationalContact"
               }
@@ -2727,47 +2208,16 @@
           }
         },
         "tools": {
-          "oneOf": [
-            {
-              "type": "object",
-              "title": "Tools",
-              "description": "The tool(s) used to identify, confirm, or score the vulnerability.",
-              "additionalProperties": false,
-              "properties": {
-                "components": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/tools_component"
-                  },
-                  "uniqueItems": true,
-                  "title": "Components",
-                  "description": "A list of software and hardware components used as tools"
-                },
-                "services": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/service"
-                  },
-                  "uniqueItems": true,
-                  "title": "Services",
-                  "description": "A list of services used as tools. This may include microservices, function-as-a-service, and other types of network or intra-process services."
-                }
-              }
-            },
-            {
-              "type": "array",
-              "title": "Tools (legacy)",
-              "description": "[Deprecated] The tool(s) used to identify, confirm, or score the vulnerability.",
-              "items": {
-                "$ref": "#/definitions/tool"
-              }
-            }
-          ]
+          "type": "array",
+          "title": "Creation Tools",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/tool"
+          }
         },
         "analysis": {
           "type": "object",
           "title": "Impact Analysis",
-          "description": "An assessment of the impact and exploitability of the vulnerability.",
           "additionalProperties": false,
           "properties": {
             "state": {
@@ -2779,7 +2229,7 @@
             "response": {
               "type": "array",
               "title": "Response",
-              "description": "A response to the vulnerability by the manufacturer, supplier, or project responsible for the affected component or service. More than one response is allowed. Responses are strongly encouraged for vulnerabilities where the analysis state is exploitable.",
+              "additionalItems": false,
               "items": {
                 "type": "string",
                 "enum": [
@@ -2793,53 +2243,29 @@
             },
             "detail": {
               "type": "string",
-              "title": "Detail",
-              "description": "Detailed description of the impact including methods used during assessment. If a vulnerability is not exploitable, this field should include specific details on why the component or service is not impacted by this vulnerability."
-            },
-            "firstIssued": {
-              "type": "string",
-              "format": "date-time",
-              "title": "First Issued",
-              "description": "The date and time (timestamp) when the analysis was first issued."
-            },
-            "lastUpdated": {
-              "type": "string",
-              "format": "date-time",
-              "title": "Last Updated",
-              "description": "The date and time (timestamp) when the analysis was last updated."
+              "title": "Detail"
             }
           }
         },
         "affects": {
           "type": "array",
           "uniqueItems": true,
+          "additionalItems": false,
           "items": {
-            "type": "object",
             "required": [
               "ref"
             ],
             "additionalProperties": false,
             "properties": {
               "ref": {
-                "anyOf": [
-                  {
-                    "title": "Ref",
-                    "$ref": "#/definitions/refLinkType"
-                  },
-                  {
-                    "title": "BOM-Link Element",
-                    "$ref": "#/definitions/bomLinkElementType"
-                  }
-                ],
-                "title": "Reference",
-                "description": "References a component or service by the objects bom-ref"
+                "$ref": "#/definitions/refType",
+                "title": "Reference"
               },
               "versions": {
                 "type": "array",
                 "title": "Versions",
-                "description": "Zero or more individual versions or range of versions.",
+                "additionalItems": false,
                 "items": {
-                  "type": "object",
                   "oneOf": [
                     {
                       "required": [
@@ -2855,15 +2281,12 @@
                   "additionalProperties": false,
                   "properties": {
                     "version": {
-                      "description": "A single version of a component or service.",
                       "$ref": "#/definitions/version"
                     },
                     "range": {
-                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst",
-                      "$ref": "#/definitions/range"
+                      "$ref": "#/definitions/version"
                     },
                     "status": {
-                      "description": "The vulnerability status for the version or range of versions.",
                       "$ref": "#/definitions/affectedStatus",
                       "default": "affected"
                     }
@@ -2872,13 +2295,12 @@
               }
             }
           },
-          "title": "Affects",
-          "description": "The components or services that are affected by the vulnerability."
+          "title": "Affects"
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -2886,7 +2308,6 @@
       }
     },
     "affectedStatus": {
-      "description": "The vulnerability status of a given version or range of versions of a product. The statuses 'affected' and 'unaffected' indicate that the version is affected or unaffected by the vulnerability. The status 'unknown' indicates that it is unknown or unspecified whether the given version is affected. There can be many reasons for an 'unknown' status, including that an investigation has not been undertaken or that a vendor has not disclosed the status.",
       "type": "string",
       "enum": [
         "affected",
@@ -2896,1795 +2317,21 @@
       "additionalProperties": false
     },
     "version": {
-      "description": "A single version of a component or service.",
       "type": "string",
       "minLength": 1,
       "maxLength": 1024,
       "additionalProperties": false
     },
     "range": {
-      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst",
       "type": "string",
       "minLength": 1,
       "maxLength": 1024,
       "additionalProperties": false
     },
-    "annotations": {
-      "type": "object",
-      "title": "Annotations",
-      "description": "A comment, note, explanation, or similar textual content which provides additional context to the object(s) being annotated.",
-      "required": [
-        "subjects",
-        "annotator",
-        "timestamp",
-        "text"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the annotation elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
-        },
-        "subjects": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "anyOf": [
-              {
-                "title": "Ref",
-                "$ref": "#/definitions/refLinkType"
-              },
-              {
-                "title": "BOM-Link Element",
-                "$ref": "#/definitions/bomLinkElementType"
-              }
-            ]
-          },
-          "title": "BOM References",
-          "description": "The object in the BOM identified by its bom-ref. This is often a component or service, but may be any object type supporting bom-refs."
-        },
-        "annotator": {
-          "type": "object",
-          "title": "Annotator",
-          "description": "The organization, person, component, or service which created the textual content of the annotation.",
-          "oneOf": [
-            {
-              "required": [
-                "organization"
-              ]
-            },
-            {
-              "required": [
-                "individual"
-              ]
-            },
-            {
-              "required": [
-                "component"
-              ]
-            },
-            {
-              "required": [
-                "service"
-              ]
-            }
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "organization": {
-              "description": "The organization that created the annotation",
-              "$ref": "#/definitions/organizationalEntity"
-            },
-            "individual": {
-              "description": "The person that created the annotation",
-              "$ref": "#/definitions/organizationalContact"
-            },
-            "component": {
-              "description": "The tool or component that created the annotation",
-              "$ref": "#/definitions/tools_component"
-            },
-            "service": {
-              "description": "The service that created the annotation",
-              "$ref": "#/definitions/service"
-            }
-          }
-        },
-        "timestamp": {
-          "type": "string",
-          "format": "date-time",
-          "title": "Timestamp",
-          "description": "The date and time (timestamp) when the annotation was created."
-        },
-        "text": {
-          "type": "string",
-          "title": "Text",
-          "description": "The textual content of the annotation."
-        },
-        "signature": {
-          "$ref": "#/definitions/signature",
-          "title": "Signature",
-          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
-        }
-      }
-    },
-    "modelCard": {
-      "$comment": "Model card support in CycloneDX is derived from TensorFlow Model Card Toolkit released under the Apache 2.0 license and available from https://github.com/tensorflow/model-card-toolkit/blob/main/model_card_toolkit/schema/v0.0.2/model_card.schema.json. In addition, CycloneDX model card support includes portions of VerifyML, also released under the Apache 2.0 license and available from https://github.com/cylynx/verifyml/blob/main/verifyml/model_card_toolkit/schema/v0.0.4/model_card.schema.json.",
-      "type": "object",
-      "title": "Model Card",
-      "description": "A model card describes the intended uses of a machine learning model and potential limitations, including biases and ethical considerations. Model cards typically contain the training parameters, which datasets were used to train the model, performance metrics, and other relevant data useful for ML transparency. This object SHOULD be specified for any component of type `machine-learning-model` and MUST NOT be specified for other component types.",
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the model card elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
-        },
-        "modelParameters": {
-          "type": "object",
-          "title": "Model Parameters",
-          "description": "Hyper-parameters for construction of the model.",
-          "additionalProperties": false,
-          "properties": {
-            "approach": {
-              "type": "object",
-              "title": "Approach",
-              "description": "The overall approach to learning used by the model for problem solving.",
-              "additionalProperties": false,
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "title": "Learning Type",
-                  "description": "Learning types describing the learning problem or hybrid learning problem.",
-                  "enum": [
-                    "supervised",
-                    "unsupervised",
-                    "reinforcement-learning",
-                    "semi-supervised",
-                    "self-supervised"
-                  ]
-                }
-              }
-            },
-            "task": {
-              "type": "string",
-              "title": "Task",
-              "description": "Directly influences the input and/or output. Examples include classification, regression, clustering, etc."
-            },
-            "architectureFamily": {
-              "type": "string",
-              "title": "Architecture Family",
-              "description": "The model architecture family such as transformer network, convolutional neural network, residual neural network, LSTM neural network, etc."
-            },
-            "modelArchitecture": {
-              "type": "string",
-              "title": "Model Architecture",
-              "description": "The specific architecture of the model such as GPT-1, ResNet-50, YOLOv3, etc."
-            },
-            "datasets": {
-              "type": "array",
-              "title": "Datasets",
-              "description": "The datasets used to train and evaluate the model.",
-              "items": {
-                "oneOf": [
-                  {
-                    "title": "Inline Component Data",
-                    "$ref": "#/definitions/componentData"
-                  },
-                  {
-                    "type": "object",
-                    "title": "Data Component Reference",
-                    "additionalProperties": false,
-                    "properties": {
-                      "ref": {
-                        "anyOf": [
-                          {
-                            "title": "Ref",
-                            "$ref": "#/definitions/refLinkType"
-                          },
-                          {
-                            "title": "BOM-Link Element",
-                            "$ref": "#/definitions/bomLinkElementType"
-                          }
-                        ],
-                        "title": "Reference",
-                        "description": "References a data component by the components bom-ref attribute"
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            "inputs": {
-              "type": "array",
-              "title": "Inputs",
-              "description": "The input format(s) of the model",
-              "items": {
-                "$ref": "#/definitions/inputOutputMLParameters"
-              }
-            },
-            "outputs": {
-              "type": "array",
-              "title": "Outputs",
-              "description": "The output format(s) from the model",
-              "items": {
-                "$ref": "#/definitions/inputOutputMLParameters"
-              }
-            }
-          }
-        },
-        "quantitativeAnalysis": {
-          "type": "object",
-          "title": "Quantitative Analysis",
-          "description": "A quantitative analysis of the model",
-          "additionalProperties": false,
-          "properties": {
-            "performanceMetrics": {
-              "type": "array",
-              "title": "Performance Metrics",
-              "description": "The model performance metrics being reported. Examples may include accuracy, F1 score, precision, top-3 error rates, MSC, etc.",
-              "items": {
-                "$ref": "#/definitions/performanceMetric"
-              }
-            },
-            "graphics": {
-              "$ref": "#/definitions/graphicsCollection"
-            }
-          }
-        },
-        "considerations": {
-          "type": "object",
-          "title": "Considerations",
-          "description": "What considerations should be taken into account regarding the model's construction, training, and application?",
-          "additionalProperties": false,
-          "properties": {
-            "users": {
-              "type": "array",
-              "title": "Users",
-              "description": "Who are the intended users of the model?",
-              "items": {
-                "type": "string"
-              }
-            },
-            "useCases": {
-              "type": "array",
-              "title": "Use Cases",
-              "description": "What are the intended use cases of the model?",
-              "items": {
-                "type": "string"
-              }
-            },
-            "technicalLimitations": {
-              "type": "array",
-              "title": "Technical Limitations",
-              "description": "What are the known technical limitations of the model? E.g. What kind(s) of data should the model be expected not to perform well on? What are the factors that might degrade model performance?",
-              "items": {
-                "type": "string"
-              }
-            },
-            "performanceTradeoffs": {
-              "type": "array",
-              "title": "Performance Tradeoffs",
-              "description": "What are the known tradeoffs in accuracy/performance of the model?",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ethicalConsiderations": {
-              "type": "array",
-              "title": "Ethical Considerations",
-              "description": "What are the ethical (or environmental) risks involved in the application of this model?",
-              "items": {
-                "$ref": "#/definitions/risk"
-              }
-            },
-            "fairnessAssessments": {
-              "type": "array",
-              "title": "Fairness Assessments",
-              "description": "How does the model affect groups at risk of being systematically disadvantaged? What are the harms and benefits to the various affected groups?",
-              "items": {
-                "$ref": "#/definitions/fairnessAssessment"
-              }
-            }
-          }
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "inputOutputMLParameters": {
-      "type": "object",
-      "title": "Input and Output Parameters",
-      "additionalProperties": false,
-      "properties": {
-        "format": {
-          "description": "The data format for input/output to the model. Example formats include string, image, time-series",
-          "type": "string"
-        }
-      }
-    },
-    "componentData": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "bom-ref": {
-          "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the dataset elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
-        },
-        "type": {
-          "type": "string",
-          "title": "Type of Data",
-          "description": "The general theme or subject matter of the data being specified.\n\n* __source-code__ = Any type of code, code snippet, or data-as-code.\n* __configuration__ = Parameters or settings that may be used by other components.\n* __dataset__ = A collection of data.\n* __definition__ = Data that can be used to create new instances of what the definition defines.\n* __other__ = Any other type of data that does not fit into existing definitions.",
-          "enum": [
-            "source-code",
-            "configuration",
-            "dataset",
-            "definition",
-            "other"
-          ]
-        },
-        "name": {
-          "description": "The name of the dataset.",
-          "type": "string"
-        },
-        "contents": {
-          "type": "object",
-          "title": "Data Contents",
-          "description": "The contents or references to the contents of the data being described.",
-          "additionalProperties": false,
-          "properties": {
-            "attachment": {
-              "title": "Data Attachment",
-              "description": "An optional way to include textual or encoded data.",
-              "$ref": "#/definitions/attachment"
-            },
-            "url": {
-              "type": "string",
-              "title": "Data URL",
-              "description": "The URL to where the data can be retrieved.",
-              "format": "iri-reference"
-            },
-            "properties": {
-              "type": "array",
-              "title": "Configuration Properties",
-              "description": "Provides the ability to document name-value parameters used for configuration.",
-              "items": {
-                "$ref": "#/definitions/property"
-              }
-            }
-          }
-        },
-        "classification": {
-          "$ref": "#/definitions/dataClassification"
-        },
-        "sensitiveData": {
-          "type": "array",
-          "description": "A description of any sensitive data in a dataset.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "graphics": {
-          "$ref": "#/definitions/graphicsCollection"
-        },
-        "description": {
-          "description": "A description of the dataset. Can describe size of dataset, whether it's used for source code, training, testing, or validation, etc.",
-          "type": "string"
-        },
-        "governance": {
-          "type": "object",
-          "title": "Data Governance",
-          "$ref": "#/definitions/dataGovernance"
-        }
-      }
-    },
-    "dataGovernance": {
-      "type": "object",
-      "title": "Data Governance",
-      "additionalProperties": false,
-      "properties": {
-        "custodians": {
-          "type": "array",
-          "title": "Data Custodians",
-          "description": "Data custodians are responsible for the safe custody, transport, and storage of data.",
-          "items": {
-            "$ref": "#/definitions/dataGovernanceResponsibleParty"
-          }
-        },
-        "stewards": {
-          "type": "array",
-          "title": "Data Stewards",
-          "description": "Data stewards are responsible for data content, context, and associated business rules.",
-          "items": {
-            "$ref": "#/definitions/dataGovernanceResponsibleParty"
-          }
-        },
-        "owners": {
-          "type": "array",
-          "title": "Data Owners",
-          "description": "Data owners are concerned with risk and appropriate access to data.",
-          "items": {
-            "$ref": "#/definitions/dataGovernanceResponsibleParty"
-          }
-        }
-      }
-    },
-    "dataGovernanceResponsibleParty": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "organization": {
-          "title": "Organization",
-          "$ref": "#/definitions/organizationalEntity"
-        },
-        "contact": {
-          "title": "Individual",
-          "$ref": "#/definitions/organizationalContact"
-        }
-      },
-      "oneOf": [
-        {
-          "required": [
-            "organization"
-          ]
-        },
-        {
-          "required": [
-            "contact"
-          ]
-        }
-      ]
-    },
-    "graphicsCollection": {
-      "type": "object",
-      "title": "Graphics Collection",
-      "description": "A collection of graphics that represent various measurements.",
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "description": "A description of this collection of graphics.",
-          "type": "string"
-        },
-        "collection": {
-          "description": "A collection of graphics.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/graphic"
-          }
-        }
-      }
-    },
-    "graphic": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "description": "The name of the graphic.",
-          "type": "string"
-        },
-        "image": {
-          "title": "Graphic Image",
-          "description": "The graphic (vector or raster). Base64 encoding MUST be specified for binary images.",
-          "$ref": "#/definitions/attachment"
-        }
-      }
-    },
-    "performanceMetric": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "description": "The type of performance metric.",
-          "type": "string"
-        },
-        "value": {
-          "description": "The value of the performance metric.",
-          "type": "string"
-        },
-        "slice": {
-          "description": "The name of the slice this metric was computed on. By default, assume this metric is not sliced.",
-          "type": "string"
-        },
-        "confidenceInterval": {
-          "description": "The confidence interval of the metric.",
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "lowerBound": {
-              "description": "The lower bound of the confidence interval.",
-              "type": "string"
-            },
-            "upperBound": {
-              "description": "The upper bound of the confidence interval.",
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
-    "risk": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "description": "The name of the risk.",
-          "type": "string"
-        },
-        "mitigationStrategy": {
-          "description": "Strategy used to address this risk.",
-          "type": "string"
-        }
-      }
-    },
-    "fairnessAssessment": {
-      "type": "object",
-      "title": "Fairness Assessment",
-      "description": "Information about the benefits and harms of the model to an identified at risk group.",
-      "additionalProperties": false,
-      "properties": {
-        "groupAtRisk": {
-          "type": "string",
-          "description": "The groups or individuals at risk of being systematically disadvantaged by the model."
-        },
-        "benefits": {
-          "type": "string",
-          "description": "Expected benefits to the identified groups."
-        },
-        "harms": {
-          "type": "string",
-          "description": "Expected harms to the identified groups."
-        },
-        "mitigationStrategy": {
-          "type": "string",
-          "description": "With respect to the benefits and harms outlined, please describe any mitigation strategy implemented."
-        }
-      }
-    },
-    "dataClassification": {
-      "type": "string",
-      "title": "Data Classification",
-      "description": "Data classification tags data according to its type, sensitivity, and value if altered, stolen, or destroyed."
-    },
-    "formula": {
-      "title": "Formula",
-      "description": "Describes workflows and resources that captures rules and other aspects of how the associated BOM component or service was formed.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the formula elsewhere in the BOM. Every bom-ref MUST be unique within the BOM.",
-          "$ref": "#/definitions/refType"
-        },
-        "components": {
-          "title": "Components",
-          "description": "Transient components that are used in tasks that constitute one or more of this formula's workflows",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/component"
-          },
-          "uniqueItems": true
-        },
-        "services": {
-          "title": "Services",
-          "description": "Transient services that are used in tasks that constitute one or more of this formula's workflows",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/service"
-          },
-          "uniqueItems": true
-        },
-        "workflows": {
-          "title": "Workflows",
-          "description": "List of workflows that can be declared to accomplish specific orchestrated goals and independently triggered.",
-          "$comment": "Different workflows can be designed to work together to perform end-to-end CI/CD builds and deployments.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/workflow"
-          },
-          "uniqueItems": true
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "workflow": {
-      "title": "Workflow",
-      "description": "A specialized orchestration task.",
-      "$comment": "Workflow are as task themselves and can trigger other workflow tasks.  These relationships can be modeled in the taskDependencies graph.",
-      "type": "object",
-      "required": [
-        "bom-ref",
-        "uid",
-        "taskTypes"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the workflow elsewhere in the BOM. Every bom-ref MUST be unique within the BOM.",
-          "$ref": "#/definitions/refType"
-        },
-        "uid": {
-          "title": "Unique Identifier (UID)",
-          "description": "The unique identifier for the resource instance within its deployment context.",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the resource instance.",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "description": "A description of the resource instance.",
-          "type": "string"
-        },
-        "resourceReferences": {
-          "title": "Resource references",
-          "description": "References to component or service resources that are used to realize the resource instance.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/resourceReferenceChoice"
-          }
-        },
-        "tasks": {
-          "title": "Tasks",
-          "description": "The tasks that comprise the workflow.",
-          "$comment": "Note that tasks can appear more than once as different instances (by name or UID).",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/task"
-          }
-        },
-        "taskDependencies": {
-          "title": "Task dependency graph",
-          "description": "The graph of dependencies between tasks within the workflow.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/dependency"
-          }
-        },
-        "taskTypes": {
-          "title": "Task types",
-          "description": "Indicates the types of activities performed by the set of workflow tasks.",
-          "$comment": "Currently, these types reflect common CI/CD actions.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/taskType"
-          }
-        },
-        "trigger": {
-          "title": "Trigger",
-          "description": "The trigger that initiated the task.",
-          "$ref": "#/definitions/trigger"
-        },
-        "steps": {
-          "title": "Steps",
-          "description": "The sequence of steps for the task.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/step"
-          },
-          "uniqueItems": true
-        },
-        "inputs": {
-          "title": "Inputs",
-          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
-          "examples": [
-            "a `configuration` file which was declared as a local `component` or `externalReference`"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/inputType"
-          },
-          "uniqueItems": true
-        },
-        "outputs": {
-          "title": "Outputs",
-          "description": "Represents resources and data output from a task at runtime by executor or task commands",
-          "examples": [
-            "a log file or metrics data produced by the task"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/outputType"
-          },
-          "uniqueItems": true
-        },
-        "timeStart": {
-          "title": "Time start",
-          "description": "The date and time (timestamp) when the task started.",
-          "type": "string",
-          "format": "date-time"
-        },
-        "timeEnd": {
-          "title": "Time end",
-          "description": "The date and time (timestamp) when the task ended.",
-          "type": "string",
-          "format": "date-time"
-        },
-        "workspaces": {
-          "title": "Workspaces",
-          "description": "A set of named filesystem or data resource shareable by workflow tasks.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/workspace"
-          }
-        },
-        "runtimeTopology": {
-          "title": "Runtime topology",
-          "description": "A graph of the component runtime topology for workflow's instance.",
-          "$comment": "A description of the runtime component and service topology.  This can describe a partial or complete topology used to host and execute the task (e.g., hardware, operating systems, configurations, etc.),",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/dependency"
-          }
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "task": {
-      "title": "Task",
-      "description": "Describes the inputs, sequence of steps and resources used to accomplish a task and its output.",
-      "$comment": "Tasks are building blocks for constructing assemble CI/CD workflows or pipelines.",
-      "type": "object",
-      "required": [
-        "bom-ref",
-        "uid",
-        "taskTypes"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the task elsewhere in the BOM. Every bom-ref MUST be unique within the BOM.",
-          "$ref": "#/definitions/refType"
-        },
-        "uid": {
-          "title": "Unique Identifier (UID)",
-          "description": "The unique identifier for the resource instance within its deployment context.",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the resource instance.",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "description": "A description of the resource instance.",
-          "type": "string"
-        },
-        "resourceReferences": {
-          "title": "Resource references",
-          "description": "References to component or service resources that are used to realize the resource instance.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/resourceReferenceChoice"
-          }
-        },
-        "taskTypes": {
-          "title": "Task types",
-          "description": "Indicates the types of activities performed by the set of workflow tasks.",
-          "$comment": "Currently, these types reflect common CI/CD actions.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/taskType"
-          }
-        },
-        "trigger": {
-          "title": "Trigger",
-          "description": "The trigger that initiated the task.",
-          "$ref": "#/definitions/trigger"
-        },
-        "steps": {
-          "title": "Steps",
-          "description": "The sequence of steps for the task.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/step"
-          },
-          "uniqueItems": true
-        },
-        "inputs": {
-          "title": "Inputs",
-          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
-          "examples": [
-            "a `configuration` file which was declared as a local `component` or `externalReference`"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/inputType"
-          },
-          "uniqueItems": true
-        },
-        "outputs": {
-          "title": "Outputs",
-          "description": "Represents resources and data output from a task at runtime by executor or task commands",
-          "examples": [
-            "a log file or metrics data produced by the task"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/outputType"
-          },
-          "uniqueItems": true
-        },
-        "timeStart": {
-          "title": "Time start",
-          "description": "The date and time (timestamp) when the task started.",
-          "type": "string",
-          "format": "date-time"
-        },
-        "timeEnd": {
-          "title": "Time end",
-          "description": "The date and time (timestamp) when the task ended.",
-          "type": "string",
-          "format": "date-time"
-        },
-        "workspaces": {
-          "title": "Workspaces",
-          "description": "A set of named filesystem or data resource shareable by workflow tasks.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/workspace"
-          },
-          "uniqueItems": true
-        },
-        "runtimeTopology": {
-          "title": "Runtime topology",
-          "description": "A graph of the component runtime topology for task's instance.",
-          "$comment": "A description of the runtime component and service topology.  This can describe a partial or complete topology used to host and execute the task (e.g., hardware, operating systems, configurations, etc.),",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/dependency"
-          },
-          "uniqueItems": true
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "step": {
-      "type": "object",
-      "description": "Executes specific commands or tools in order to accomplish its owning task as part of a sequence.",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "title": "Name",
-          "description": "A name for the step.",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "description": "A description of the step.",
-          "type": "string"
-        },
-        "commands": {
-          "title": "Commands",
-          "description": "Ordered list of commands or directives for the step",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/command"
-          }
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "command": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "executed": {
-          "title": "Executed",
-          "description": "A text representation of the executed command.",
-          "type": "string"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "workspace": {
-      "title": "Workspace",
-      "description": "A named filesystem or data resource shareable by workflow tasks.",
-      "type": "object",
-      "required": [
-        "bom-ref",
-        "uid"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the workspace elsewhere in the BOM. Every bom-ref MUST be unique within the BOM.",
-          "$ref": "#/definitions/refType"
-        },
-        "uid": {
-          "title": "Unique Identifier (UID)",
-          "description": "The unique identifier for the resource instance within its deployment context.",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the resource instance.",
-          "type": "string"
-        },
-        "aliases": {
-          "title": "Aliases",
-          "description": "The names for the workspace as referenced by other workflow tasks. Effectively, a name mapping so other tasks can use their own local name in their steps.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "description": {
-          "title": "Description",
-          "description": "A description of the resource instance.",
-          "type": "string"
-        },
-        "resourceReferences": {
-          "title": "Resource references",
-          "description": "References to component or service resources that are used to realize the resource instance.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/resourceReferenceChoice"
-          }
-        },
-        "accessMode": {
-          "title": "Access mode",
-          "description": "Describes the read-write access control for the workspace relative to the owning resource instance.",
-          "type": "string",
-          "enum": [
-            "read-only",
-            "read-write",
-            "read-write-once",
-            "write-once",
-            "write-only"
-          ]
-        },
-        "mountPath": {
-          "title": "Mount path",
-          "description": "A path to a location on disk where the workspace will be available to the associated task's steps.",
-          "type": "string"
-        },
-        "managedDataType": {
-          "title": "Managed data type",
-          "description": "The name of a domain-specific data type the workspace represents.",
-          "$comment": "This property is for CI/CD frameworks that are able to provide access to structured, managed data at a more granular level than a filesystem.",
-          "examples": [
-            "ConfigMap",
-            "Secret"
-          ],
-          "type": "string"
-        },
-        "volumeRequest": {
-          "title": "Volume request",
-          "description": "Identifies the reference to the request for a specific volume type and parameters.",
-          "examples": [
-            "a kubernetes Persistent Volume Claim (PVC) name"
-          ],
-          "type": "string"
-        },
-        "volume": {
-          "title": "Volume",
-          "description": "Information about the actual volume instance allocated to the workspace.",
-          "$comment": "The actual volume allocated may be different than the request.",
-          "examples": [
-            "see https://kubernetes.io/docs/concepts/storage/persistent-volumes/"
-          ],
-          "$ref": "#/definitions/volume"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "volume": {
-      "title": "Volume",
-      "description": "An identifiable, logical unit of data storage tied to a physical device.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "uid": {
-          "title": "Unique Identifier (UID)",
-          "description": "The unique identifier for the volume instance within its deployment context.",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the volume instance",
-          "type": "string"
-        },
-        "mode": {
-          "title": "Mode",
-          "description": "The mode for the volume instance.",
-          "type": "string",
-          "enum": [
-            "filesystem",
-            "block"
-          ],
-          "default": "filesystem"
-        },
-        "path": {
-          "title": "Path",
-          "description": "The underlying path created from the actual volume.",
-          "type": "string"
-        },
-        "sizeAllocated": {
-          "title": "Size allocated",
-          "description": "The allocated size of the volume accessible to the associated workspace. This should include the scalar size as well as IEC standard unit in either decimal or binary form.",
-          "examples": [
-            "10GB",
-            "2Ti",
-            "1Pi"
-          ],
-          "type": "string"
-        },
-        "persistent": {
-          "title": "Persistent",
-          "description": "Indicates if the volume persists beyond the life of the resource it is associated with.",
-          "type": "boolean"
-        },
-        "remote": {
-          "title": "Remote",
-          "description": "Indicates if the volume is remotely (i.e., network) attached.",
-          "type": "boolean"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "trigger": {
-      "title": "Trigger",
-      "description": "Represents a resource that can conditionally activate (or fire) tasks based upon associated events and their data.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "type",
-        "bom-ref",
-        "uid"
-      ],
-      "properties": {
-        "bom-ref": {
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the trigger elsewhere in the BOM. Every bom-ref MUST be unique within the BOM.",
-          "$ref": "#/definitions/refType"
-        },
-        "uid": {
-          "title": "Unique Identifier (UID)",
-          "description": "The unique identifier for the resource instance within its deployment context.",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the resource instance.",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "description": "A description of the resource instance.",
-          "type": "string"
-        },
-        "resourceReferences": {
-          "title": "Resource references",
-          "description": "References to component or service resources that are used to realize the resource instance.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/resourceReferenceChoice"
-          }
-        },
-        "type": {
-          "title": "Type",
-          "description": "The source type of event which caused the trigger to fire.",
-          "type": "string",
-          "enum": [
-            "manual",
-            "api",
-            "webhook",
-            "scheduled"
-          ]
-        },
-        "event": {
-          "title": "Event",
-          "description": "The event data that caused the associated trigger to activate.",
-          "$ref": "#/definitions/event"
-        },
-        "conditions": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/condition"
-          }
-        },
-        "timeActivated": {
-          "title": "Time activated",
-          "description": "The date and time (timestamp) when the trigger was activated.",
-          "type": "string",
-          "format": "date-time"
-        },
-        "inputs": {
-          "title": "Inputs",
-          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
-          "examples": [
-            "a `configuration` file which was declared as a local `component` or `externalReference`"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/inputType"
-          },
-          "uniqueItems": true
-        },
-        "outputs": {
-          "title": "Outputs",
-          "description": "Represents resources and data output from a task at runtime by executor or task commands",
-          "examples": [
-            "a log file or metrics data produced by the task"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/outputType"
-          },
-          "uniqueItems": true
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "event": {
-      "title": "Event",
-      "description": "Represents something that happened that may trigger a response.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "uid": {
-          "title": "Unique Identifier (UID)",
-          "description": "The unique identifier of the event.",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "description": "A description of the event.",
-          "type": "string"
-        },
-        "timeReceived": {
-          "title": "Time Received",
-          "description": "The date and time (timestamp) when the event was received.",
-          "type": "string",
-          "format": "date-time"
-        },
-        "data": {
-          "title": "Data",
-          "description": "Encoding of the raw event data.",
-          "$ref": "#/definitions/attachment"
-        },
-        "source": {
-          "title": "Source",
-          "description": "References the component or service that was the source of the event",
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "target": {
-          "title": "Target",
-          "description": "References the component or service that was the target of the event",
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "inputType": {
-      "title": "Input type",
-      "description": "Type that represents various input data types and formats.",
-      "type": "object",
-      "oneOf": [
-        {
-          "required": [
-            "resource"
-          ]
-        },
-        {
-          "required": [
-            "parameters"
-          ]
-        },
-        {
-          "required": [
-            "environmentVars"
-          ]
-        },
-        {
-          "required": [
-            "data"
-          ]
-        }
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "source": {
-          "title": "Source",
-          "description": "A references to the component or service that provided the input to the task (e.g., reference to a service with data flow value of `inbound`)",
-          "examples": [
-            "source code repository",
-            "database"
-          ],
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "target": {
-          "title": "Target",
-          "description": "A reference to the component or service that received or stored the input if not the task itself (e.g., a local, named storage workspace)",
-          "examples": [
-            "workspace",
-            "directory"
-          ],
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "resource": {
-          "title": "Resource",
-          "description": "A reference to an independent resource provided as an input to a task by the workflow runtime.",
-          "examples": [
-            "reference to a configuration file in a repository (i.e., a bom-ref)",
-            "reference to a scanning service used in a task (i.e., a bom-ref)"
-          ],
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "parameters": {
-          "title": "Parameters",
-          "description": "Inputs that have the form of parameters with names and values.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/parameter"
-          }
-        },
-        "environmentVars": {
-          "title": "Environment variables",
-          "description": "Inputs that have the form of parameters with names and values.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/property"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          }
-        },
-        "data": {
-          "title": "Data",
-          "description": "Inputs that have the form of data.",
-          "$ref": "#/definitions/attachment"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "outputType": {
-      "type": "object",
-      "oneOf": [
-        {
-          "required": [
-            "resource"
-          ]
-        },
-        {
-          "required": [
-            "environmentVars"
-          ]
-        },
-        {
-          "required": [
-            "data"
-          ]
-        }
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "title": "Type",
-          "description": "Describes the type of data output.",
-          "type": "string",
-          "enum": [
-            "artifact",
-            "attestation",
-            "log",
-            "evidence",
-            "metrics",
-            "other"
-          ]
-        },
-        "source": {
-          "title": "Source",
-          "description": "Component or service that generated or provided the output from the task (e.g., a build tool)",
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "target": {
-          "title": "Target",
-          "description": "Component or service that received the output from the task (e.g., reference to an artifactory service with data flow value of `outbound`)",
-          "examples": [
-            "a log file described as an `externalReference` within its target domain."
-          ],
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "resource": {
-          "title": "Resource",
-          "description": "A reference to an independent resource generated as output by the task.",
-          "examples": [
-            "configuration file",
-            "source code",
-            "scanning service"
-          ],
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "data": {
-          "title": "Data",
-          "description": "Outputs that have the form of data.",
-          "$ref": "#/definitions/attachment"
-        },
-        "environmentVars": {
-          "title": "Environment variables",
-          "description": "Outputs that have the form of environment variables.",
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/property"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "uniqueItems": true
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "resourceReferenceChoice": {
-      "title": "Resource reference choice",
-      "description": "A reference to a locally defined resource (e.g., a bom-ref) or an externally accessible resource.",
-      "$comment": "Enables reference to a resource that participates in a workflow; using either internal (bom-ref) or external (externalReference) types.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "ref": {
-          "title": "BOM Reference",
-          "description": "References an object by its bom-ref attribute",
-          "anyOf": [
-            {
-              "title": "Ref",
-              "$ref": "#/definitions/refLinkType"
-            },
-            {
-              "title": "BOM-Link Element",
-              "$ref": "#/definitions/bomLinkElementType"
-            }
-          ]
-        },
-        "externalReference": {
-          "title": "External reference",
-          "description": "Reference to an externally accessible resource.",
-          "$ref": "#/definitions/externalReference"
-        }
-      },
-      "oneOf": [
-        {
-          "required": [
-            "ref"
-          ]
-        },
-        {
-          "required": [
-            "externalReference"
-          ]
-        }
-      ]
-    },
-    "condition": {
-      "title": "Condition",
-      "description": "A condition that was used to determine a trigger should be activated.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "title": "Description",
-          "description": "Describes the set of conditions which cause the trigger to activate.",
-          "type": "string"
-        },
-        "expression": {
-          "title": "Expression",
-          "description": "The logical expression that was evaluated that determined the trigger should be fired.",
-          "type": "string"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "taskType": {
-      "type": "string",
-      "enum": [
-        "copy",
-        "clone",
-        "lint",
-        "scan",
-        "merge",
-        "build",
-        "test",
-        "deliver",
-        "deploy",
-        "release",
-        "clean",
-        "other"
-      ]
-    },
-    "parameter": {
-      "title": "Parameter",
-      "description": "A representation of a functional parameter.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "title": "Name",
-          "description": "The name of the parameter.",
-          "type": "string"
-        },
-        "value": {
-          "title": "Value",
-          "description": "The value of the parameter.",
-          "type": "string"
-        },
-        "dataType": {
-          "title": "Data type",
-          "description": "The data type of the parameter.",
-          "type": "string"
-        }
-      }
-    },
     "signature": {
       "$ref": "jsf-0.82.schema.json#/definitions/signature",
       "title": "Signature",
-      "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html).",
       "additionalProperties": false
-    },
-    "tools_component": {
-      "type": "object",
-      "title": "Component Object",
-      "required": [
-        "type",
-        "name"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "application",
-            "framework",
-            "library",
-            "container",
-            "platform",
-            "operating-system",
-            "device",
-            "device-driver",
-            "firmware",
-            "file",
-            "machine-learning-model",
-            "data"
-          ],
-          "title": "Component Type",
-          "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component. Types include:\n\n* __application__ = A software application. Refer to [https://en.wikipedia.org/wiki/Application_software](https://en.wikipedia.org/wiki/Application_software) for information about applications.\n* __framework__ = A software framework. Refer to [https://en.wikipedia.org/wiki/Software_framework](https://en.wikipedia.org/wiki/Software_framework) for information on how frameworks vary slightly from libraries.\n* __library__ = A software library. Refer to [https://en.wikipedia.org/wiki/Library_(computing)](https://en.wikipedia.org/wiki/Library_(computing))\n for information about libraries. All third-party and open source reusable components will likely be a library. If the library also has key features of a framework, then it should be classified as a framework. If not, or is unknown, then specifying library is RECOMMENDED.\n* __container__ = A packaging and/or runtime format, not specific to any particular technology, which isolates software inside the container from software outside of a container through virtualization technology. Refer to [https://en.wikipedia.org/wiki/OS-level_virtualization](https://en.wikipedia.org/wiki/OS-level_virtualization)\n* __platform__ = A runtime environment which interprets or executes software. This may include runtimes such as those that execute bytecode or low-code/no-code application platforms.\n* __operating-system__ = A software operating system without regard to deployment model (i.e. installed on physical hardware, virtual machine, image, etc) Refer to [https://en.wikipedia.org/wiki/Operating_system](https://en.wikipedia.org/wiki/Operating_system)\n* __device__ = A hardware device such as a processor, or chip-set. A hardware device containing firmware SHOULD include a component for the physical hardware itself, and another component of type 'firmware' or 'operating-system' (whichever is relevant), describing information about the software running on the device.\n  See also the list of [known device properties](https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/device.md).\n* __device-driver__ = A special type of software that operates or controls a particular type of device. Refer to [https://en.wikipedia.org/wiki/Device_driver](https://en.wikipedia.org/wiki/Device_driver)\n* __firmware__ = A special type of software that provides low-level control over a devices hardware. Refer to [https://en.wikipedia.org/wiki/Firmware](https://en.wikipedia.org/wiki/Firmware)\n* __file__ = A computer file. Refer to [https://en.wikipedia.org/wiki/Computer_file](https://en.wikipedia.org/wiki/Computer_file) for information about files.\n* __machine-learning-model__ = A model based on training data that can make predictions or decisions without being explicitly programmed to do so.\n* __data__ = A collection of discrete values that convey information.",
-          "examples": [
-            "library"
-          ]
-        },
-        "mime-type": {
-          "type": "string",
-          "title": "Mime-Type",
-          "description": "The optional mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
-          "examples": [
-            "image/jpeg"
-          ],
-          "pattern": "^[-+a-z0-9.]+/[-+a-z0-9.]+$"
-        },
-        "bom-ref": {
-          "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
-        },
-        "supplier": {
-          "title": "Component Supplier",
-          "description": " The organization that supplied the component. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
-          "$ref": "#/definitions/organizationalEntity"
-        },
-        "author": {
-          "type": "string",
-          "title": "Component Author",
-          "description": "The person(s) or organization(s) that authored the component",
-          "examples": [
-            "Acme Inc"
-          ]
-        },
-        "publisher": {
-          "type": "string",
-          "title": "Component Publisher",
-          "description": "The person(s) or organization(s) that published the component",
-          "examples": [
-            "Acme Inc"
-          ]
-        },
-        "group": {
-          "type": "string",
-          "title": "Component Group",
-          "description": "The grouping name or identifier. This will often be a shortened, single name of the company or project that produced the component, or the source package or domain name. Whitespace and special characters should be avoided. Examples include: apache, org.apache.commons, and apache.org.",
-          "examples": [
-            "com.acme"
-          ]
-        },
-        "name": {
-          "type": "string",
-          "title": "Component Name",
-          "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
-          "examples": [
-            "tomcat-catalina"
-          ]
-        },
-        "version": {
-          "type": "string",
-          "title": "Component Version",
-          "description": "The component version. The version should ideally comply with semantic versioning but is not enforced.",
-          "examples": [
-            "9.0.14"
-          ]
-        },
-        "description": {
-          "type": "string",
-          "title": "Component Description",
-          "description": "Specifies a description for the component"
-        },
-        "scope": {
-          "type": "string",
-          "enum": [
-            "required",
-            "optional",
-            "excluded"
-          ],
-          "title": "Component Scope",
-          "description": "Specifies the scope of the component. If scope is not specified, 'required' scope SHOULD be assumed by the consumer of the BOM.",
-          "default": "required"
-        },
-        "hashes": {
-          "type": "array",
-          "title": "Component Hashes",
-          "items": {
-            "$ref": "#/definitions/hash"
-          }
-        },
-        "licenses": {
-          "$ref": "#/definitions/licenseChoice",
-          "title": "Component License(s)"
-        },
-        "copyright": {
-          "type": "string",
-          "title": "Component Copyright",
-          "description": "A copyright notice informing users of the underlying claims to copyright ownership in a published work.",
-          "examples": [
-            "Acme Inc"
-          ]
-        },
-        "cpe": {
-          "type": "string",
-          "title": "Component Common Platform Enumeration (CPE)",
-          "description": "Specifies a well-formed CPE name that conforms to the CPE 2.2 or 2.3 specification. See [https://nvd.nist.gov/products/cpe](https://nvd.nist.gov/products/cpe)",
-          "examples": [
-            "cpe:2.3:a:acme:component_framework:-:*:*:*:*:*:*:*"
-          ]
-        },
-        "purl": {
-          "type": "string",
-          "title": "Component Package URL (purl)",
-          "description": "Specifies the package-url (purl). The purl, if specified, MUST be valid and conform to the specification defined at: [https://github.com/package-url/purl-spec](https://github.com/package-url/purl-spec)",
-          "examples": [
-            "pkg:maven/com.acme/tomcat-catalina@9.0.14?packaging=jar"
-          ]
-        },
-        "swid": {
-          "$ref": "#/definitions/swid",
-          "title": "SWID Tag",
-          "description": "Specifies metadata and content for [ISO-IEC 19770-2 Software Identification (SWID) Tags](https://www.iso.org/standard/65666.html)."
-        },
-        "modified": {
-          "type": "boolean",
-          "title": "Component Modified From Original",
-          "description": "[Deprecated] - DO NOT USE. This will be removed in a future version. Use the pedigree element instead to supply information on exactly how the component was modified. A boolean value indicating if the component has been modified from the original. A value of true indicates the component is a derivative of the original. A value of false indicates the component has not been modified from the original."
-        },
-        "pedigree": {
-          "type": "object",
-          "title": "Component Pedigree",
-          "description": "Component pedigree is a way to document complex supply chain scenarios where components are created, distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to document variants where the exact relation may not be known.",
-          "additionalProperties": false,
-          "properties": {
-            "ancestors": {
-              "type": "array",
-              "title": "Ancestors",
-              "description": "Describes zero or more components in which a component is derived from. This is commonly used to describe forks from existing projects where the forked version contains a ancestor node containing the original component it was forked from. For example, Component A is the original component. Component B is the component being used and documented in the BOM. However, Component B contains a pedigree node with a single ancestor documenting Component A - the original component from which Component B is derived from.",
-              "items": {
-                "$ref": "#/definitions/component"
-              }
-            },
-            "descendants": {
-              "type": "array",
-              "title": "Descendants",
-              "description": "Descendants are the exact opposite of ancestors. This provides a way to document all forks (and their forks) of an original or root component.",
-              "items": {
-                "$ref": "#/definitions/component"
-              }
-            },
-            "variants": {
-              "type": "array",
-              "title": "Variants",
-              "description": "Variants describe relations where the relationship between the components are not known. For example, if Component A contains nearly identical code to Component B. They are both related, but it is unclear if one is derived from the other, or if they share a common ancestor.",
-              "items": {
-                "$ref": "#/definitions/component"
-              }
-            },
-            "commits": {
-              "type": "array",
-              "title": "Commits",
-              "description": "A list of zero or more commits which provide a trail describing how the component deviates from an ancestor, descendant, or variant.",
-              "items": {
-                "$ref": "#/definitions/commit"
-              }
-            },
-            "patches": {
-              "type": "array",
-              "title": "Patches",
-              "description": ">A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complimentary to commits or may be used in place of commits.",
-              "items": {
-                "$ref": "#/definitions/patch"
-              }
-            },
-            "notes": {
-              "type": "string",
-              "title": "Notes",
-              "description": "Notes, observations, and other non-structured commentary describing the components pedigree."
-            }
-          }
-        },
-        "externalReferences": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/externalReference"
-          },
-          "title": "External References",
-          "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
-        },
-        "components": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/component"
-          },
-          "uniqueItems": true,
-          "title": "Components",
-          "description": "A list of software and hardware components included in the parent component. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system &#8594; subsystem &#8594; parts assembly in physical supply chains."
-        },
-        "evidence": {
-          "$ref": "#/definitions/componentEvidence",
-          "title": "Evidence",
-          "description": "Provides the ability to document evidence collected through various forms of extraction or analysis."
-        },
-        "releaseNotes": {
-          "$ref": "#/definitions/releaseNotes",
-          "title": "Release notes",
-          "description": "Specifies optional release notes."
-        },
-        "modelCard": {
-          "$ref": "#/definitions/modelCard",
-          "title": "Machine Learning Model Card"
-        },
-        "data": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/componentData"
-          },
-          "title": "Data",
-          "description": "This object SHOULD be specified for any component of type `data` and MUST NOT be specified for other component types."
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        },
-        "signature": {
-          "$ref": "#/definitions/signature",
-          "title": "Signature",
-          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
-        }
-      }
     }
   }
 }

--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -330,13 +330,15 @@
           "$ref": "#/definitions/organizationalEntity"
         },
         "licenses": {
-          "type": "array",
-          "additionalItems": false,
-          "items": {
-            "$ref": "#/definitions/licenseChoice"
-          },
-          "title": "Component License(s)",
-          "minItems": 1
+          "allOf": [
+            {
+              "$ref": "#/definitions/licenseChoice"
+            },
+            {
+              "minItems": 1
+            }
+          ],
+          "title": "Component License(s)"
         },
         "properties": {
           "type": "array",
@@ -610,12 +612,14 @@
           }
         },
         "licenses": {
-          "type": "array",
-          "additionalItems": false,
-          "items": {
-            "$ref": "#/definitions/licenseChoice"
-          },
-          "minItems": 1,
+          "allOf": [
+            {
+              "$ref": "#/definitions/licenseChoice"
+            },
+            {
+              "minItems": 1
+            }
+          ],
           "title": "Component License(s)"
         },
         "copyright": {
@@ -1427,35 +1431,44 @@
       }
     },
     "licenseChoice": {
-      "type": "object",
-      "title": "License(s)",
-      "additionalProperties": false,
-      "properties": {
-        "license": {
-          "$ref": "#/definitions/license"
-        },
-        "expression": {
-          "type": "string",
-          "minLength": 1,
-          "title": "SPDX License Expression",
-          "examples": [
-            "Apache-2.0 AND (MIT OR GPL-2.0-only)",
-            "GPL-3.0-only WITH Classpath-exception-2.0"
-          ]
+      "title": "License Choice",
+      "description": "EITHER (list of SPDX licenses and/or named licenses) OR (tuple of one SPDX License Expression)",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "oneOf": [
+          {
+            "required": [
+              "license"
+            ]
+          },
+          {
+            "required": [
+              "expression"
+            ]
+          }
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "license": {
+            "$ref": "#/definitions/license"
+          },
+          "expression": {
+            "type": "string",
+            "title": "SPDX License Expression",
+            "minLength": 1,
+            "examples": [
+              "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+              "GPL-3.0-only WITH Classpath-exception-2.0"
+            ]
+          },
+          "bom-ref": {
+            "$ref": "#/definitions/refType",
+            "title": "BOM Reference",
+            "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+          }
         }
-      },
-      "oneOf": [
-        {
-          "required": [
-            "license"
-          ]
-        },
-        {
-          "required": [
-            "expression"
-          ]
-        }
-      ]
+      }
     },
     "commit": {
       "type": "object",

--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -330,8 +330,8 @@
           "$ref": "#/definitions/organizationalEntity"
         },
         "licenses": {
-          "$ref": "#/definitions/licenseChoice",
-          "title": "Component License(s)"
+          "title": "BOM License(s)",
+          "$ref": "#/definitions/licenseChoice"
         },
         "properties": {
           "type": "array",

--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -1427,32 +1427,58 @@
       }
     },
     "licenseChoice": {
-      "type": "object",
-      "title": "License(s)",
-      "additionalProperties": false,
-      "properties": {
-        "license": {
-          "$ref": "#/definitions/license"
-        },
-        "expression": {
-          "type": "string",
-          "minLength": 1,
-          "title": "SPDX License Expression",
-          "examples": [
-            "Apache-2.0 AND (MIT OR GPL-2.0-only)",
-            "GPL-3.0-only WITH Classpath-exception-2.0"
-          ]
-        }
-      },
+      "title": "License Choice",
+      "description": "EITHER (list of SPDX licenses and/or named licenses) OR (tuple of one SPDX License Expression)",
+      "type": "array",
       "oneOf": [
         {
-          "required": [
-            "license"
-          ]
+          "title": "Multiple licenses",
+          "description": "A list of SPDX licenses and/or named licenses.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "license"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "license": {
+                "$ref": "#/definitions/license"
+              }
+            }
+          }
         },
         {
-          "required": [
-            "expression"
+          "title": "SPDX License Expression",
+          "description": "A tuple of exactly one SPDX License Expression.",
+          "type": "array",
+          "additionalItems": false,
+          "minItems": 1,
+          "maxItems": 1,
+          "items": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string",
+                  "title": "SPDX License Expression",
+                  "minLength": 1,
+                  "examples": [
+                    "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+                    "GPL-3.0-only WITH Classpath-exception-2.0"
+                  ]
+                },
+                "bom-ref": {
+                  "$ref": "#/definitions/refType",
+                  "title": "BOM Reference",
+                  "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+                }
+              }
+            }
           ]
         }
       ]
@@ -1832,11 +1858,7 @@
           "description": "Specifies information about the data including the directional flow of data and the data classification."
         },
         "licenses": {
-          "type": "array",
-          "additionalItems": false,
-          "items": {
-            "$ref": "#/definitions/licenseChoice"
-          },
+          "$ref": "#/definitions/licenseChoice",
           "title": "Component License(s)"
         },
         "externalReferences": {
@@ -2160,11 +2182,7 @@
           }
         },
         "licenses": {
-          "type": "array",
-          "additionalItems": false,
-          "items": {
-            "$ref": "#/definitions/licenseChoice"
-          },
+          "$ref": "#/definitions/licenseChoice",
           "title": "Component License(s)"
         },
         "copyright": {

--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -1427,58 +1427,32 @@
       }
     },
     "licenseChoice": {
-      "title": "License Choice",
-      "description": "EITHER (list of SPDX licenses and/or named licenses) OR (tuple of one SPDX License Expression)",
-      "type": "array",
+      "type": "object",
+      "title": "License(s)",
+      "additionalProperties": false,
+      "properties": {
+        "license": {
+          "$ref": "#/definitions/license"
+        },
+        "expression": {
+          "type": "string",
+          "minLength": 1,
+          "title": "SPDX License Expression",
+          "examples": [
+            "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+            "GPL-3.0-only WITH Classpath-exception-2.0"
+          ]
+        }
+      },
       "oneOf": [
         {
-          "title": "Multiple licenses",
-          "description": "A list of SPDX licenses and/or named licenses.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "license"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "license": {
-                "$ref": "#/definitions/license"
-              }
-            }
-          }
+          "required": [
+            "license"
+          ]
         },
         {
-          "title": "SPDX License Expression",
-          "description": "A tuple of exactly one SPDX License Expression.",
-          "type": "array",
-          "additionalItems": false,
-          "minItems": 1,
-          "maxItems": 1,
-          "items": [
-            {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "expression"
-              ],
-              "properties": {
-                "expression": {
-                  "type": "string",
-                  "title": "SPDX License Expression",
-                  "minLength": 1,
-                  "examples": [
-                    "Apache-2.0 AND (MIT OR GPL-2.0-only)",
-                    "GPL-3.0-only WITH Classpath-exception-2.0"
-                  ]
-                },
-                "bom-ref": {
-                  "$ref": "#/definitions/refType",
-                  "title": "BOM Reference",
-                  "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
-                }
-              }
-            }
+          "required": [
+            "expression"
           ]
         }
       ]

--- a/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5-custom.schema.json
@@ -4,6 +4,30 @@
   "type": "object",
   "title": "CycloneDX Software Bill of Materials Standard",
   "$comment": "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
+  "if": {
+    "required": [
+      "components"
+    ]
+  },
+  "then": {
+    "required": [
+      "bomFormat",
+      "specVersion",
+      "version",
+      "metadata",
+      "compositions",
+      "dependencies"
+    ]
+  },
+  "else": {
+    "required": [
+      "bomFormat",
+      "specVersion",
+      "version",
+      "metadata",
+      "compositions"
+    ]
+  },
   "additionalProperties": false,
   "properties": {
     "$schema": {
@@ -141,6 +165,7 @@
     "refType": {
       "description": "Identifier for referable and therefore interlink-able elements.",
       "type": "string",
+      "additionalProperties": false,
       "minLength": 1,
       "$comment": "value SHOULD not start with the BOM-Link intro 'urn:cdx:'"
     },
@@ -254,10 +279,7 @@
                 "components": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "required": [
-                      "type"
-                    ]
+                    "$ref": "#/definitions/tools_component"
                   },
                   "uniqueItems": true,
                   "title": "Components",
@@ -266,7 +288,7 @@
                 "services": {
                   "type": "array",
                   "items": {
-                    "type": "object"
+                    "$ref": "#/definitions/service"
                   },
                   "uniqueItems": true,
                   "title": "Services",
@@ -308,12 +330,8 @@
           "$ref": "#/definitions/organizationalEntity"
         },
         "licenses": {
-          "title": "BOM License(s)",
-          "minItems": 1,
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/licenseChoice"
-          }
+          "$ref": "#/definitions/licenseChoice",
+          "title": "Component License(s)"
         },
         "properties": {
           "type": "array",
@@ -383,11 +401,11 @@
         "name": {
           "type": "string",
           "title": "Name",
+          "minLength": 1,
           "description": "The name of the organization",
           "examples": [
             "Example Inc."
-          ],
-          "minLength": 1
+          ]
         },
         "url": {
           "type": "array",
@@ -513,6 +531,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
+          "minLength": 1,
           "description": "An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
         },
         "supplier": {
@@ -546,21 +565,21 @@
         },
         "name": {
           "type": "string",
+          "minLength": 1,
           "title": "Component Name",
           "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
           "examples": [
             "tomcat-catalina"
-          ],
-          "minLength": 1
+          ]
         },
         "version": {
           "type": "string",
           "title": "Component Version",
+          "minLength": 1,
           "description": "The component version. The version should ideally comply with semantic versioning but is not enforced.",
           "examples": [
             "9.0.14"
-          ],
-          "minLength": 1
+          ]
         },
         "description": {
           "type": "string",
@@ -586,12 +605,8 @@
           }
         },
         "licenses": {
-          "title": "Component License(s)",
-          "minItems": 1,
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/licenseChoice"
-          }
+          "$ref": "#/definitions/licenseChoice",
+          "title": "Component License(s)"
         },
         "copyright": {
           "type": "string",
@@ -1110,8 +1125,8 @@
         "content": {
           "type": "string",
           "title": "Attachment Text",
-          "description": "The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text.",
-          "minLength": 1
+          "minLength": 1,
+          "description": "The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text."
         }
       }
     },
@@ -1148,7 +1163,8 @@
         "BLAKE2b-512",
         "BLAKE3"
       ],
-      "title": "Hash Algorithm"
+      "title": "Hash Algorithm",
+      "additionalProperties": false
     },
     "hash-content": {
       "type": "string",
@@ -1156,7 +1172,8 @@
       "examples": [
         "3942447fac867ae5cdb3229b658f4d48"
       ],
-      "pattern": "^([a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$"
+      "pattern": "^([a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$",
+      "additionalProperties": false
     },
     "license": {
       "type": "object",
@@ -1191,11 +1208,11 @@
         "name": {
           "type": "string",
           "title": "License Name",
+          "minLength": 1,
           "description": "If SPDX does not define the license used, this field may be used to provide the license name",
           "examples": [
             "Acme Software License"
-          ],
-          "minLength": 1
+          ]
         },
         "text": {
           "title": "License text",
@@ -1359,28 +1376,29 @@
               "description": "The timestamp indicating when the current license expires (if applicable)."
             }
           },
-          "required": [
-            "licenseTypes"
-          ],
-          "if": {
-            "properties": {
-              "licenseTypes": {
-                "contains": {
-                  "not": {
-                    "const": "appliance"
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "licenseTypes": {
+                    "contains": {
+                      "const": "appliance"
+                    }
                   }
-                }
+                },
+                "required": [
+                  "licenseTypes"
+                ]
+              },
+              "then": {},
+              "else": {
+                "required": [
+                  "licenseTypes",
+                  "licensor"
+                ]
               }
-            },
-            "required": [
-              "licenseTypes"
-            ]
-          },
-          "then": {
-            "required": [
-              "licensor"
-            ]
-          }
+            }
+          ]
         },
         "properties": {
           "type": "array",
@@ -1399,32 +1417,59 @@
       }
     },
     "licenseChoice": {
-      "type": "object",
-      "title": "License(s)",
-      "additionalProperties": false,
-      "properties": {
-        "license": {
-          "$ref": "#/definitions/license"
-        },
-        "expression": {
-          "type": "string",
-          "minLength": 1,
-          "title": "SPDX License Expression",
-          "examples": [
-            "Apache-2.0 AND (MIT OR GPL-2.0-only)",
-            "GPL-3.0-only WITH Classpath-exception-2.0"
-          ]
-        }
-      },
+      "title": "License Choice",
+      "description": "EITHER (list of SPDX licenses and/or named licenses) OR (tuple of one SPDX License Expression)",
+      "type": "array",
+      "minItems": 1,
       "oneOf": [
         {
-          "required": [
-            "license"
-          ]
+          "title": "Multiple licenses",
+          "description": "A list of SPDX licenses and/or named licenses.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "license"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "license": {
+                "$ref": "#/definitions/license"
+              }
+            }
+          }
         },
         {
-          "required": [
-            "expression"
+          "title": "SPDX License Expression",
+          "description": "A tuple of exactly one SPDX License Expression.",
+          "type": "array",
+          "additionalItems": false,
+          "minItems": 1,
+          "maxItems": 1,
+          "items": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "SPDX License Expression",
+                  "examples": [
+                    "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+                    "GPL-3.0-only WITH Classpath-exception-2.0"
+                  ]
+                },
+                "bom-ref": {
+                  "$ref": "#/definitions/refType",
+                  "title": "BOM Reference",
+                  "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+                }
+              }
+            }
           ]
         }
       ]
@@ -1624,7 +1669,8 @@
             {
               "title": "URL",
               "type": "string",
-              "format": "iri-reference"
+              "format": "iri-reference",
+              "minLength": 1
             },
             {
               "title": "BOM-Link",
@@ -1632,8 +1678,7 @@
             }
           ],
           "title": "URL",
-          "description": "The URI (URL or URN) to the external reference. External references are URIs and therefore can accept any URL scheme including https ([RFC-7230](https://www.ietf.org/rfc/rfc7230.txt)), mailto ([RFC-2368](https://www.ietf.org/rfc/rfc2368.txt)), tel ([RFC-3966](https://www.ietf.org/rfc/rfc3966.txt)), and dns ([RFC-4501](https://www.ietf.org/rfc/rfc4501.txt)). External references may also include formally registered URNs such as [CycloneDX BOM-Link](https://cyclonedx.org/capabilities/bomlink/) to reference CycloneDX BOMs or any object within a BOM. BOM-Link transforms applicable external references into relationships that can be expressed in a BOM or across BOMs.",
-          "minLength": 1
+          "description": "The URI (URL or URN) to the external reference. External references are URIs and therefore can accept any URL scheme including https ([RFC-7230](https://www.ietf.org/rfc/rfc7230.txt)), mailto ([RFC-2368](https://www.ietf.org/rfc/rfc2368.txt)), tel ([RFC-3966](https://www.ietf.org/rfc/rfc3966.txt)), and dns ([RFC-4501](https://www.ietf.org/rfc/rfc4501.txt)). External references may also include formally registered URNs such as [CycloneDX BOM-Link](https://cyclonedx.org/capabilities/bomlink/) to reference CycloneDX BOMs or any object within a BOM. BOM-Link transforms applicable external references into relationships that can be expressed in a BOM or across BOMs."
         },
         "comment": {
           "type": "string",
@@ -1804,11 +1849,8 @@
           "description": "Specifies information about the data including the directional flow of data and the data classification."
         },
         "licenses": {
-          "title": "Component License(s)",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/licenseChoice"
-          }
+          "$ref": "#/definitions/licenseChoice",
+          "title": "Component License(s)"
         },
         "externalReferences": {
           "type": "array",
@@ -1932,7 +1974,8 @@
         "unknown"
       ],
       "title": "Data flow direction",
-      "description": "Specifies the flow direction of the data. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways, and unknown states that the direction is not known."
+      "description": "Specifies the flow direction of the data. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways, and unknown states that the direction is not known.",
+      "additionalProperties": false
     },
     "copyright": {
       "type": "object",
@@ -2130,11 +2173,8 @@
           }
         },
         "licenses": {
-          "title": "Component License(s)",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/licenseChoice"
-          }
+          "$ref": "#/definitions/licenseChoice",
+          "title": "Component License(s)"
         },
         "copyright": {
           "type": "array",
@@ -2221,7 +2261,8 @@
         "incomplete_third_party_opensource_only",
         "unknown",
         "not_specified"
-      ]
+      ],
+      "additionalProperties": false
     },
     "property": {
       "type": "object",
@@ -2238,13 +2279,15 @@
           "title": "Value",
           "description": "The value of the property."
         }
-      }
+      },
+      "additionalProperties": false
     },
     "localeType": {
       "type": "string",
       "pattern": "^([a-z]{2})(-[A-Z]{2})?$",
       "title": "Locale",
-      "description": "Defines a syntax for representing two character language code (ISO-639) followed by an optional two character country code. The language code MUST be lower case. If the country code is specified, the country code MUST be upper case. The language code and country code MUST be separated by a minus sign. Examples: en, en-US, fr, fr-CA"
+      "description": "Defines a syntax for representing two character language code (ISO-639) followed by an optional two character country code. The language code MUST be lower case. If the country code is specified, the country code MUST be upper case. The language code and country code MUST be separated by a minus sign. Examples: en, en-US, fr, fr-CA",
+      "additionalProperties": false
     },
     "releaseType": {
       "type": "string",
@@ -2255,7 +2298,8 @@
         "pre-release",
         "internal"
       ],
-      "description": "The software versioning type. It is RECOMMENDED that the release type use one of 'major', 'minor', 'patch', 'pre-release', or 'internal'. Representing all possible software release types is not practical, so standardizing on the recommended values, whenever possible, is strongly encouraged.\n\n* __major__ = A major release may contain significant changes or may introduce breaking changes.\n* __minor__ = A minor release, also known as an update, may contain a smaller number of changes than major releases.\n* __patch__ = Patch releases are typically unplanned and may resolve defects or important security issues.\n* __pre-release__ = A pre-release may include alpha, beta, or release candidates and typically have limited support. They provide the ability to preview a release prior to its general availability.\n* __internal__ = Internal releases are not for public consumption and are intended to be used exclusively by the project or manufacturer that produced it."
+      "description": "The software versioning type. It is RECOMMENDED that the release type use one of 'major', 'minor', 'patch', 'pre-release', or 'internal'. Representing all possible software release types is not practical, so standardizing on the recommended values, whenever possible, is strongly encouraged.\n\n* __major__ = A major release may contain significant changes or may introduce breaking changes.\n* __minor__ = A minor release, also known as an update, may contain a smaller number of changes than major releases.\n* __patch__ = Patch releases are typically unplanned and may resolve defects or important security issues.\n* __pre-release__ = A pre-release may include alpha, beta, or release candidates and typically have limited support. They provide the ability to preview a release prior to its general availability.\n* __internal__ = Internal releases are not for public consumption and are intended to be used exclusively by the project or manufacturer that produced it.",
+      "additionalProperties": false
     },
     "note": {
       "type": "object",
@@ -2387,7 +2431,8 @@
       "type": "integer",
       "minimum": 1,
       "title": "CWE",
-      "description": "Integer representation of a Common Weaknesses Enumerations (CWE). For example 399 (of https://cwe.mitre.org/data/definitions/399.html)"
+      "description": "Integer representation of a Common Weaknesses Enumerations (CWE). For example 399 (of https://cwe.mitre.org/data/definitions/399.html)",
+      "additionalProperties": false
     },
     "severity": {
       "type": "string",
@@ -2401,7 +2446,8 @@
         "info",
         "none",
         "unknown"
-      ]
+      ],
+      "additionalProperties": false
     },
     "scoreMethod": {
       "type": "string",
@@ -2415,7 +2461,8 @@
         "OWASP",
         "SSVC",
         "other"
-      ]
+      ],
+      "additionalProperties": false
     },
     "impactAnalysisState": {
       "type": "string",
@@ -2444,7 +2491,8 @@
         "protected_at_runtime",
         "protected_at_perimeter",
         "protected_by_mitigating_control"
-      ]
+      ],
+      "additionalProperties": false
     },
     "rating": {
       "type": "object",
@@ -2693,7 +2741,7 @@
                 "components": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/component"
+                    "$ref": "#/definitions/tools_component"
                   },
                   "uniqueItems": true,
                   "title": "Components",
@@ -2848,19 +2896,22 @@
         "affected",
         "unaffected",
         "unknown"
-      ]
+      ],
+      "additionalProperties": false
     },
     "version": {
       "description": "A single version of a component or service.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 1024
+      "maxLength": 1024,
+      "additionalProperties": false
     },
     "range": {
       "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst",
       "type": "string",
       "minLength": 1,
-      "maxLength": 1024
+      "maxLength": 1024,
+      "additionalProperties": false
     },
     "annotations": {
       "type": "object",
@@ -2935,7 +2986,7 @@
             },
             "component": {
               "description": "The tool or component that created the annotation",
-              "$ref": "#/definitions/component"
+              "$ref": "#/definitions/tools_component"
             },
             "service": {
               "description": "The service that created the annotation",
@@ -4378,31 +4429,266 @@
     "signature": {
       "$ref": "jsf-0.82.schema.json#/definitions/signature",
       "title": "Signature",
-      "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+      "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html).",
+      "additionalProperties": false
+    },
+    "tools_component": {
+      "type": "object",
+      "title": "Component Object",
+      "required": [
+        "type",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "application",
+            "framework",
+            "library",
+            "container",
+            "platform",
+            "operating-system",
+            "device",
+            "device-driver",
+            "firmware",
+            "file",
+            "machine-learning-model",
+            "data"
+          ],
+          "title": "Component Type",
+          "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component. Types include:\n\n* __application__ = A software application. Refer to [https://en.wikipedia.org/wiki/Application_software](https://en.wikipedia.org/wiki/Application_software) for information about applications.\n* __framework__ = A software framework. Refer to [https://en.wikipedia.org/wiki/Software_framework](https://en.wikipedia.org/wiki/Software_framework) for information on how frameworks vary slightly from libraries.\n* __library__ = A software library. Refer to [https://en.wikipedia.org/wiki/Library_(computing)](https://en.wikipedia.org/wiki/Library_(computing))\n for information about libraries. All third-party and open source reusable components will likely be a library. If the library also has key features of a framework, then it should be classified as a framework. If not, or is unknown, then specifying library is RECOMMENDED.\n* __container__ = A packaging and/or runtime format, not specific to any particular technology, which isolates software inside the container from software outside of a container through virtualization technology. Refer to [https://en.wikipedia.org/wiki/OS-level_virtualization](https://en.wikipedia.org/wiki/OS-level_virtualization)\n* __platform__ = A runtime environment which interprets or executes software. This may include runtimes such as those that execute bytecode or low-code/no-code application platforms.\n* __operating-system__ = A software operating system without regard to deployment model (i.e. installed on physical hardware, virtual machine, image, etc) Refer to [https://en.wikipedia.org/wiki/Operating_system](https://en.wikipedia.org/wiki/Operating_system)\n* __device__ = A hardware device such as a processor, or chip-set. A hardware device containing firmware SHOULD include a component for the physical hardware itself, and another component of type 'firmware' or 'operating-system' (whichever is relevant), describing information about the software running on the device.\n  See also the list of [known device properties](https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/device.md).\n* __device-driver__ = A special type of software that operates or controls a particular type of device. Refer to [https://en.wikipedia.org/wiki/Device_driver](https://en.wikipedia.org/wiki/Device_driver)\n* __firmware__ = A special type of software that provides low-level control over a devices hardware. Refer to [https://en.wikipedia.org/wiki/Firmware](https://en.wikipedia.org/wiki/Firmware)\n* __file__ = A computer file. Refer to [https://en.wikipedia.org/wiki/Computer_file](https://en.wikipedia.org/wiki/Computer_file) for information about files.\n* __machine-learning-model__ = A model based on training data that can make predictions or decisions without being explicitly programmed to do so.\n* __data__ = A collection of discrete values that convey information.",
+          "examples": [
+            "library"
+          ]
+        },
+        "mime-type": {
+          "type": "string",
+          "title": "Mime-Type",
+          "description": "The optional mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
+          "examples": [
+            "image/jpeg"
+          ],
+          "pattern": "^[-+a-z0-9.]+/[-+a-z0-9.]+$"
+        },
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+        },
+        "supplier": {
+          "title": "Component Supplier",
+          "description": " The organization that supplied the component. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "author": {
+          "type": "string",
+          "title": "Component Author",
+          "description": "The person(s) or organization(s) that authored the component",
+          "examples": [
+            "Acme Inc"
+          ]
+        },
+        "publisher": {
+          "type": "string",
+          "title": "Component Publisher",
+          "description": "The person(s) or organization(s) that published the component",
+          "examples": [
+            "Acme Inc"
+          ]
+        },
+        "group": {
+          "type": "string",
+          "title": "Component Group",
+          "description": "The grouping name or identifier. This will often be a shortened, single name of the company or project that produced the component, or the source package or domain name. Whitespace and special characters should be avoided. Examples include: apache, org.apache.commons, and apache.org.",
+          "examples": [
+            "com.acme"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "title": "Component Name",
+          "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
+          "examples": [
+            "tomcat-catalina"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "title": "Component Version",
+          "description": "The component version. The version should ideally comply with semantic versioning but is not enforced.",
+          "examples": [
+            "9.0.14"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "title": "Component Description",
+          "description": "Specifies a description for the component"
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "required",
+            "optional",
+            "excluded"
+          ],
+          "title": "Component Scope",
+          "description": "Specifies the scope of the component. If scope is not specified, 'required' scope SHOULD be assumed by the consumer of the BOM.",
+          "default": "required"
+        },
+        "hashes": {
+          "type": "array",
+          "title": "Component Hashes",
+          "items": {
+            "$ref": "#/definitions/hash"
+          }
+        },
+        "licenses": {
+          "$ref": "#/definitions/licenseChoice",
+          "title": "Component License(s)"
+        },
+        "copyright": {
+          "type": "string",
+          "title": "Component Copyright",
+          "description": "A copyright notice informing users of the underlying claims to copyright ownership in a published work.",
+          "examples": [
+            "Acme Inc"
+          ]
+        },
+        "cpe": {
+          "type": "string",
+          "title": "Component Common Platform Enumeration (CPE)",
+          "description": "Specifies a well-formed CPE name that conforms to the CPE 2.2 or 2.3 specification. See [https://nvd.nist.gov/products/cpe](https://nvd.nist.gov/products/cpe)",
+          "examples": [
+            "cpe:2.3:a:acme:component_framework:-:*:*:*:*:*:*:*"
+          ]
+        },
+        "purl": {
+          "type": "string",
+          "title": "Component Package URL (purl)",
+          "description": "Specifies the package-url (purl). The purl, if specified, MUST be valid and conform to the specification defined at: [https://github.com/package-url/purl-spec](https://github.com/package-url/purl-spec)",
+          "examples": [
+            "pkg:maven/com.acme/tomcat-catalina@9.0.14?packaging=jar"
+          ]
+        },
+        "swid": {
+          "$ref": "#/definitions/swid",
+          "title": "SWID Tag",
+          "description": "Specifies metadata and content for [ISO-IEC 19770-2 Software Identification (SWID) Tags](https://www.iso.org/standard/65666.html)."
+        },
+        "modified": {
+          "type": "boolean",
+          "title": "Component Modified From Original",
+          "description": "[Deprecated] - DO NOT USE. This will be removed in a future version. Use the pedigree element instead to supply information on exactly how the component was modified. A boolean value indicating if the component has been modified from the original. A value of true indicates the component is a derivative of the original. A value of false indicates the component has not been modified from the original."
+        },
+        "pedigree": {
+          "type": "object",
+          "title": "Component Pedigree",
+          "description": "Component pedigree is a way to document complex supply chain scenarios where components are created, distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to document variants where the exact relation may not be known.",
+          "additionalProperties": false,
+          "properties": {
+            "ancestors": {
+              "type": "array",
+              "title": "Ancestors",
+              "description": "Describes zero or more components in which a component is derived from. This is commonly used to describe forks from existing projects where the forked version contains a ancestor node containing the original component it was forked from. For example, Component A is the original component. Component B is the component being used and documented in the BOM. However, Component B contains a pedigree node with a single ancestor documenting Component A - the original component from which Component B is derived from.",
+              "items": {
+                "$ref": "#/definitions/component"
+              }
+            },
+            "descendants": {
+              "type": "array",
+              "title": "Descendants",
+              "description": "Descendants are the exact opposite of ancestors. This provides a way to document all forks (and their forks) of an original or root component.",
+              "items": {
+                "$ref": "#/definitions/component"
+              }
+            },
+            "variants": {
+              "type": "array",
+              "title": "Variants",
+              "description": "Variants describe relations where the relationship between the components are not known. For example, if Component A contains nearly identical code to Component B. They are both related, but it is unclear if one is derived from the other, or if they share a common ancestor.",
+              "items": {
+                "$ref": "#/definitions/component"
+              }
+            },
+            "commits": {
+              "type": "array",
+              "title": "Commits",
+              "description": "A list of zero or more commits which provide a trail describing how the component deviates from an ancestor, descendant, or variant.",
+              "items": {
+                "$ref": "#/definitions/commit"
+              }
+            },
+            "patches": {
+              "type": "array",
+              "title": "Patches",
+              "description": ">A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complimentary to commits or may be used in place of commits.",
+              "items": {
+                "$ref": "#/definitions/patch"
+              }
+            },
+            "notes": {
+              "type": "string",
+              "title": "Notes",
+              "description": "Notes, observations, and other non-structured commentary describing the components pedigree."
+            }
+          }
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/externalReference"
+          },
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+        },
+        "components": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/component"
+          },
+          "uniqueItems": true,
+          "title": "Components",
+          "description": "A list of software and hardware components included in the parent component. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system &#8594; subsystem &#8594; parts assembly in physical supply chains."
+        },
+        "evidence": {
+          "$ref": "#/definitions/componentEvidence",
+          "title": "Evidence",
+          "description": "Provides the ability to document evidence collected through various forms of extraction or analysis."
+        },
+        "releaseNotes": {
+          "$ref": "#/definitions/releaseNotes",
+          "title": "Release notes",
+          "description": "Specifies optional release notes."
+        },
+        "modelCard": {
+          "$ref": "#/definitions/modelCard",
+          "title": "Machine Learning Model Card"
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/componentData"
+          },
+          "title": "Data",
+          "description": "This object SHOULD be specified for any component of type `data` and MUST NOT be specified for other component types."
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is OPTIONAL.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
     }
-  },
-  "if": {
-    "required": [
-      "components"
-    ]
-  },
-  "then": {
-    "required": [
-      "bomFormat",
-      "specVersion",
-      "version",
-      "metadata",
-      "compositions",
-      "dependencies"
-    ]
-  },
-  "else": {
-    "required": [
-      "bomFormat",
-      "specVersion",
-      "version",
-      "metadata",
-      "compositions"
-    ]
   }
 }

--- a/cdxev/auxiliary/schema/bom-1.5.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.5.schema.json
@@ -6,8 +6,7 @@
   "$comment": "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
   "required": [
     "bomFormat",
-    "specVersion",
-    "version"
+    "specVersion"
   ],
   "additionalProperties": false,
   "properties": {

--- a/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
@@ -1993,63 +1993,41 @@
       }
     },
     "licenseChoice": {
-      "title": "License Choice",
-      "description": "EITHER (list of SPDX licenses and/or named licenses) OR (tuple of one SPDX License Expression)",
-      "type": "array",
+      "type": "object",
+      "title": "License(s)",
+      "additionalProperties": false,
+      "properties": {
+        "license": {
+          "$ref": "#/definitions/license"
+        },
+        "expression": {
+          "type": "string",
+          "minLength": 1,
+          "title": "SPDX License Expression",
+          "description": "A valid SPDX license expression.\nRefer to https://spdx.org/specifications for syntax requirements",
+          "examples": [
+            "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+            "GPL-3.0-only WITH Classpath-exception-2.0"
+          ]
+        },
+        "acknowledgement": {
+          "$ref": "#/definitions/licenseAcknowledgementEnumeration"
+        },
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        }
+      },
       "oneOf": [
         {
-          "title": "Multiple licenses",
-          "description": "A list of SPDX licenses and/or named licenses.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "title": "License",
-            "required": [
-              "license"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "license": {
-                "$ref": "#/definitions/license"
-              }
-            }
-          }
+          "required": [
+            "license"
+          ]
         },
         {
-          "title": "SPDX License Expression",
-          "description": "A tuple of exactly one SPDX License Expression.",
-          "type": "array",
-          "additionalItems": false,
-          "minItems": 1,
-          "maxItems": 1,
-          "items": [
-            {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "expression"
-              ],
-              "properties": {
-                "expression": {
-                  "type": "string",
-                  "title": "SPDX License Expression",
-                  "description": "A valid SPDX license expression.\nRefer to https://spdx.org/specifications for syntax requirements",
-                  "minLength": 1,
-                  "examples": [
-                    "Apache-2.0 AND (MIT OR GPL-2.0-only)",
-                    "GPL-3.0-only WITH Classpath-exception-2.0"
-                  ]
-                },
-                "acknowledgement": {
-                  "$ref": "#/definitions/licenseAcknowledgementEnumeration"
-                },
-                "bom-ref": {
-                  "$ref": "#/definitions/refType",
-                  "title": "BOM Reference",
-                  "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
-                }
-              }
-            }
+          "required": [
+            "expression"
           ]
         }
       ]

--- a/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
@@ -4,28 +4,16 @@
   "type": "object",
   "title": "CycloneDX Bill of Materials Standard",
   "$comment": "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
-  "if": {
-    "required": [
-      "components"
-    ]
-  },
-  "then": {
-    "required": [
-      "bomFormat",
-      "specVersion",
-      "version",
-      "metadata",
-      "compositions",
+  "required": [
+    "bomFormat",
+    "specVersion",
+    "version",
+    "metadata",
+    "compositions"
+  ],
+  "dependencies": {
+    "components": [
       "dependencies"
-    ]
-  },
-  "else": {
-    "required": [
-      "bomFormat",
-      "specVersion",
-      "version",
-      "metadata",
-      "compositions"
     ]
   },
   "additionalProperties": false,

--- a/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
@@ -46,13 +46,13 @@
       "title": "CycloneDX Specification Version",
       "description": "The version of the CycloneDX specification the BOM conforms to.",
       "examples": [
-        "1.6"
+        "1.6.1"
       ]
     },
     "serialNumber": {
       "type": "string",
       "title": "BOM Serial Number",
-      "description": "Every BOM generated SHOULD have a unique serial number, even if the contents of the BOM have not changed over time. If specified, the serial number must conform to RFC-4122. Use of serial numbers is recommended.",
+      "description": "Every BOM generated SHOULD have a unique serial number, even if the contents of the BOM have not changed over time. If specified, the serial number must conform to [RFC 4122](https://www.ietf.org/rfc/rfc4122.html). Use of serial numbers is recommended.",
       "examples": [
         "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
       ],
@@ -785,8 +785,9 @@
           "$ref": "#/definitions/organizationalEntity"
         },
         "licenses": {
-          "$ref": "#/definitions/licenseChoice",
-          "title": "Component License(s)"
+          "title": "BOM License(s)",
+          "description": "The license information for the BOM document.\nThis may be different from the license(s) of the component(s) that the BOM describes.",
+          "$ref": "#/definitions/licenseChoice"
         },
         "properties": {
           "type": "array",
@@ -1137,7 +1138,7 @@
         },
         "swhid": {
           "type": "array",
-          "title": "SoftWare Heritage Identifier",
+          "title": "Software Heritage Identifier",
           "description": "Asserts the identity of the component using the Software Heritage persistent identifier (SWHID). The SWHID, if specified, must be valid and conform to the specification defined at: [https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html](https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
           "items": {
             "type": "string"

--- a/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
@@ -2,44 +2,17 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "./bom-1.6-custom.schema.json",
   "type": "object",
-  "title": "CycloneDX Software Bill of Materials Standard",
+  "title": "CycloneDX Bill of Materials Standard",
   "$comment": "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
-  "if": {
-    "required": [
-      "components"
-    ]
-  },
-  "then": {
-    "required": [
-      "bomFormat",
-      "specVersion",
-      "version",
-      "metadata",
-      "compositions",
-      "dependencies"
-    ]
-  },
-  "else": {
-    "required": [
-      "bomFormat",
-      "specVersion",
-      "version",
-      "metadata",
-      "compositions"
-    ]
-  },
   "additionalProperties": false,
   "properties": {
     "$schema": {
-      "type": "string",
-      "enum": [
-        "./bom-1.6-custom.schema.json"
-      ]
+      "type": "string"
     },
     "bomFormat": {
       "type": "string",
       "title": "BOM Format",
-      "description": "Specifies the format of the BOM. This helps to identify the file as CycloneDX since BOMs do not have a filename convention nor does JSON schema support namespaces. This value MUST be \"CycloneDX\".",
+      "description": "Specifies the format of the BOM. This helps to identify the file as CycloneDX since BOMs do not have a filename convention, nor does JSON schema support namespaces. This value must be \"CycloneDX\".",
       "enum": [
         "CycloneDX"
       ]
@@ -47,15 +20,15 @@
     "specVersion": {
       "type": "string",
       "title": "CycloneDX Specification Version",
-      "description": "The version of the CycloneDX specification a BOM conforms to (starting at version 1.2).",
+      "description": "The version of the CycloneDX specification the BOM conforms to.",
       "examples": [
-        "1.6"
+        "1.6.1"
       ]
     },
     "serialNumber": {
       "type": "string",
       "title": "BOM Serial Number",
-      "description": "Every BOM generated SHOULD have a unique serial number, even if the contents of the BOM have not changed over time. If specified, the serial number MUST conform to RFC-4122. Use of serial numbers are RECOMMENDED.",
+      "description": "Every BOM generated SHOULD have a unique serial number, even if the contents of the BOM have not changed over time. If specified, the serial number must conform to [RFC 4122](https://www.ietf.org/rfc/rfc4122.html). Use of serial numbers is recommended.",
       "examples": [
         "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
       ],
@@ -65,6 +38,7 @@
       "type": "integer",
       "title": "BOM Version",
       "description": "Whenever an existing BOM is modified, either manually or through automated processes, the version of the BOM SHOULD be incremented by 1. When a system is presented with multiple BOMs with identical serial numbers, the system SHOULD use the most recent version of the BOM. The default version is '1'.",
+      "minimum": 1,
       "default": 1,
       "examples": [
         1
@@ -77,7 +51,6 @@
     },
     "components": {
       "type": "array",
-      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/component"
       },
@@ -87,7 +60,6 @@
     },
     "services": {
       "type": "array",
-      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/service"
       },
@@ -97,36 +69,32 @@
     },
     "externalReferences": {
       "type": "array",
-      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/externalReference"
       },
       "title": "External References",
-      "description": "External references provide a way to document systems, sites, and information that may be relevant but which are not included with the BOM."
+      "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
     },
     "dependencies": {
       "type": "array",
-      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/dependency"
       },
       "uniqueItems": true,
       "title": "Dependencies",
-      "description": "Provides the ability to document dependency relationships."
+      "description": "Provides the ability to document dependency relationships including provided & implemented components."
     },
     "compositions": {
       "type": "array",
-      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/compositions"
       },
       "uniqueItems": true,
       "title": "Compositions",
-      "description": "Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness."
+      "description": "Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness. The completeness of vulnerabilities expressed in a BOM may also be described."
     },
     "vulnerabilities": {
       "type": "array",
-      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/vulnerability"
       },
@@ -136,36 +104,468 @@
     },
     "annotations": {
       "type": "array",
-      "additionalItems": false,
       "items": {
-        "type": "object"
+        "$ref": "#/definitions/annotations"
       },
+      "uniqueItems": true,
       "title": "Annotations",
-      "description": "Comments made by people, organizations, or tools about any object with a bom-ref."
+      "description": "Comments made by people, organizations, or tools about any object with a bom-ref, such as components, services, vulnerabilities, or the BOM itself. Unlike inventory information, annotations may contain opinions or commentary from various stakeholders. Annotations may be inline (with inventory) or externalized via BOM-Link and may optionally be signed."
     },
     "formulation": {
       "type": "array",
-      "additionalItems": false,
       "items": {
-        "type": "object"
+        "$ref": "#/definitions/formula"
       },
+      "uniqueItems": true,
       "title": "Formulation",
-      "description": "Describes how a component or service was manufactured or deployed."
+      "description": "Describes how a component or service was manufactured or deployed. This is achieved through the use of formulas, workflows, tasks, and steps, which declare the precise steps to reproduce along with the observed formulas describing the steps which transpired in the manufacturing process."
     },
     "declarations": {
       "type": "object",
       "title": "Declarations",
-      "description": "The list of declarations which describe the conformance to standards."
+      "description": "The list of declarations which describe the conformance to standards. Each declaration may include attestations, claims, and evidence.",
+      "additionalProperties": false,
+      "properties": {
+        "assessors": {
+          "type": "array",
+          "title": "Assessors",
+          "description": "The list of assessors evaluating claims and determining conformance to requirements and confidence in that assessment.",
+          "items": {
+            "type": "object",
+            "title": "Assessor",
+            "description": "The assessor who evaluates claims and determines conformance to requirements and confidence in that assessment.",
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+              },
+              "thirdParty": {
+                "type": "boolean",
+                "title": "Third Party",
+                "description": "The boolean indicating if the assessor is outside the organization generating claims. A value of false indicates a self assessor."
+              },
+              "organization": {
+                "$ref": "#/definitions/organizationalEntity",
+                "title": "Organization",
+                "description": "The entity issuing the assessment."
+              }
+            }
+          }
+        },
+        "attestations": {
+          "type": "array",
+          "title": "Attestations",
+          "description": "The list of attestations asserted by an assessor that maps requirements to claims.",
+          "items": {
+            "type": "object",
+            "title": "Attestation",
+            "additionalProperties": false,
+            "properties": {
+              "summary": {
+                "type": "string",
+                "title": "Summary",
+                "description": "The short description explaining the main points of the attestation."
+              },
+              "assessor": {
+                "$ref": "#/definitions/refLinkType",
+                "title": "Assessor",
+                "description": "The `bom-ref` to the assessor asserting the attestation."
+              },
+              "map": {
+                "type": "array",
+                "title": "Map",
+                "description": "The grouping of requirements to claims and the attestors declared conformance and confidence thereof.",
+                "items": {
+                  "type": "object",
+                  "title": "Map",
+                  "additionalProperties": false,
+                  "properties": {
+                    "requirement": {
+                      "$ref": "#/definitions/refLinkType",
+                      "title": "Requirement",
+                      "description": "The `bom-ref` to the requirement being attested to."
+                    },
+                    "claims": {
+                      "type": "array",
+                      "title": "Claims",
+                      "description": "The list of `bom-ref` to the claims being attested to.",
+                      "items": {
+                        "$ref": "#/definitions/refLinkType"
+                      }
+                    },
+                    "counterClaims": {
+                      "type": "array",
+                      "title": "Counter Claims",
+                      "description": "The list of  `bom-ref` to the counter claims being attested to.",
+                      "items": {
+                        "$ref": "#/definitions/refLinkType"
+                      }
+                    },
+                    "conformance": {
+                      "type": "object",
+                      "title": "Conformance",
+                      "description": "The conformance of the claim meeting a requirement.",
+                      "additionalProperties": false,
+                      "properties": {
+                        "score": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1,
+                          "title": "Score",
+                          "description": "The conformance of the claim between and inclusive of 0 and 1, where 1 is 100% conformance."
+                        },
+                        "rationale": {
+                          "type": "string",
+                          "title": "Rationale",
+                          "description": "The rationale for the conformance score."
+                        },
+                        "mitigationStrategies": {
+                          "type": "array",
+                          "title": "Mitigation Strategies",
+                          "description": "The list of  `bom-ref` to the evidence provided describing the mitigation strategies.",
+                          "items": {
+                            "$ref": "#/definitions/refLinkType"
+                          }
+                        }
+                      }
+                    },
+                    "confidence": {
+                      "type": "object",
+                      "title": "Confidence",
+                      "description": "The confidence of the claim meeting the requirement.",
+                      "additionalProperties": false,
+                      "properties": {
+                        "score": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1,
+                          "title": "Score",
+                          "description": "The confidence of the claim between and inclusive of 0 and 1, where 1 is 100% confidence."
+                        },
+                        "rationale": {
+                          "type": "string",
+                          "title": "Rationale",
+                          "description": "The rationale for the confidence score."
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "signature": {
+                "$ref": "#/definitions/signature",
+                "title": "Signature",
+                "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+              }
+            }
+          }
+        },
+        "claims": {
+          "type": "array",
+          "title": "Claims",
+          "description": "The list of claims.",
+          "items": {
+            "type": "object",
+            "title": "Claim",
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+              },
+              "target": {
+                "$ref": "#/definitions/refLinkType",
+                "title": "Target",
+                "description": "The `bom-ref` to a target representing a specific system, application, API, module, team, person, process, business unit, company, etc...  that this claim is being applied to."
+              },
+              "predicate": {
+                "type": "string",
+                "title": "Predicate",
+                "description": "The specific statement or assertion about the target."
+              },
+              "mitigationStrategies": {
+                "type": "array",
+                "title": "Mitigation Strategies",
+                "description": "The list of  `bom-ref` to the evidence provided describing the mitigation strategies. Each mitigation strategy should include an explanation of how any weaknesses in the evidence will be mitigated.",
+                "items": {
+                  "$ref": "#/definitions/refLinkType"
+                }
+              },
+              "reasoning": {
+                "type": "string",
+                "title": "Reasoning",
+                "description": "The written explanation of why the evidence provided substantiates the claim."
+              },
+              "evidence": {
+                "type": "array",
+                "title": "Evidence",
+                "description": "The list of `bom-ref` to evidence that supports this claim.",
+                "items": {
+                  "$ref": "#/definitions/refLinkType"
+                }
+              },
+              "counterEvidence": {
+                "type": "array",
+                "title": "Counter Evidence",
+                "description": "The list of `bom-ref` to counterEvidence that supports this claim.",
+                "items": {
+                  "$ref": "#/definitions/refLinkType"
+                }
+              },
+              "externalReferences": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/externalReference"
+                },
+                "title": "External References",
+                "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+              },
+              "signature": {
+                "$ref": "#/definitions/signature",
+                "title": "Signature",
+                "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+              }
+            }
+          }
+        },
+        "evidence": {
+          "type": "array",
+          "title": "Evidence",
+          "description": "The list of evidence",
+          "items": {
+            "type": "object",
+            "title": "Evidence",
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+              },
+              "propertyName": {
+                "type": "string",
+                "title": "Property Name",
+                "description": "The reference to the property name as defined in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy/)."
+              },
+              "description": {
+                "type": "string",
+                "title": "Description",
+                "description": "The written description of what this evidence is and how it was created."
+              },
+              "data": {
+                "type": "array",
+                "title": "Data",
+                "description": "The output or analysis that supports claims.",
+                "items": {
+                  "type": "object",
+                  "title": "Data",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "title": "Data Name",
+                      "description": "The name of the data.",
+                      "type": "string"
+                    },
+                    "contents": {
+                      "type": "object",
+                      "title": "Data Contents",
+                      "description": "The contents or references to the contents of the data being described.",
+                      "additionalProperties": false,
+                      "properties": {
+                        "attachment": {
+                          "title": "Data Attachment",
+                          "description": "An optional way to include textual or encoded data.",
+                          "$ref": "#/definitions/attachment"
+                        },
+                        "url": {
+                          "type": "string",
+                          "title": "Data URL",
+                          "description": "The URL to where the data can be retrieved.",
+                          "format": "iri-reference"
+                        }
+                      }
+                    },
+                    "classification": {
+                      "$ref": "#/definitions/dataClassification"
+                    },
+                    "sensitiveData": {
+                      "type": "array",
+                      "title": "Sensitive Data",
+                      "description": "A description of any sensitive data included.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "governance": {
+                      "title": "Data Governance",
+                      "$ref": "#/definitions/dataGovernance"
+                    }
+                  }
+                }
+              },
+              "created": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Created",
+                "description": "The date and time (timestamp) when the evidence was created."
+              },
+              "expires": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Expires",
+                "description": "The optional date and time (timestamp) when the evidence is no longer valid."
+              },
+              "author": {
+                "$ref": "#/definitions/organizationalContact",
+                "title": "Author",
+                "description": "The author of the evidence."
+              },
+              "reviewer": {
+                "$ref": "#/definitions/organizationalContact",
+                "title": "Reviewer",
+                "description": "The reviewer of the evidence."
+              },
+              "signature": {
+                "$ref": "#/definitions/signature",
+                "title": "Signature",
+                "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+              }
+            }
+          }
+        },
+        "targets": {
+          "type": "object",
+          "title": "Targets",
+          "description": "The list of targets which claims are made against.",
+          "additionalProperties": false,
+          "properties": {
+            "organizations": {
+              "type": "array",
+              "title": "Organizations",
+              "description": "The list of organizations which claims are made against.",
+              "items": {
+                "$ref": "#/definitions/organizationalEntity"
+              }
+            },
+            "components": {
+              "type": "array",
+              "title": "Components",
+              "description": "The list of components which claims are made against.",
+              "items": {
+                "$ref": "#/definitions/component"
+              }
+            },
+            "services": {
+              "type": "array",
+              "title": "Services",
+              "description": "The list of services which claims are made against.",
+              "items": {
+                "$ref": "#/definitions/service"
+              }
+            }
+          }
+        },
+        "affirmation": {
+          "type": "object",
+          "title": "Affirmation",
+          "description": "A concise statement affirmed by an individual regarding all declarations, often used for third-party auditor acceptance or recipient acknowledgment. It includes a list of authorized signatories who assert the validity of the document on behalf of the organization.",
+          "additionalProperties": false,
+          "properties": {
+            "statement": {
+              "type": "string",
+              "title": "Statement",
+              "description": "The brief statement affirmed by an individual regarding all declarations.\n*- Notes This could be an affirmation of acceptance by a third-party auditor or receiving individual of a file.",
+              "examples": [
+                "I certify, to the best of my knowledge, that all information is correct."
+              ]
+            },
+            "signatories": {
+              "type": "array",
+              "title": "Signatories",
+              "description": "The list of signatories authorized on behalf of an organization to assert validity of this document.",
+              "items": {
+                "type": "object",
+                "title": "Signatory",
+                "additionalProperties": false,
+                "oneOf": [
+                  {
+                    "required": [
+                      "signature"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "externalReference",
+                      "organization"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The signatory's name."
+                  },
+                  "role": {
+                    "type": "string",
+                    "title": "Role",
+                    "description": "The signatory's role within an organization."
+                  },
+                  "signature": {
+                    "$ref": "#/definitions/signature",
+                    "title": "Signature",
+                    "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+                  },
+                  "organization": {
+                    "$ref": "#/definitions/organizationalEntity",
+                    "title": "Organization",
+                    "description": "The signatory's organization."
+                  },
+                  "externalReference": {
+                    "$ref": "#/definitions/externalReference",
+                    "title": "External Reference",
+                    "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+                  }
+                }
+              }
+            },
+            "signature": {
+              "$ref": "#/definitions/signature",
+              "title": "Signature",
+              "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+            }
+          }
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
     },
     "definitions": {
       "type": "object",
       "title": "Definitions",
-      "description": "A collection of reusable objects that are defined and may be used elsewhere in the BOM."
+      "description": "A collection of reusable objects that are defined and may be used elsewhere in the BOM.",
+      "additionalProperties": false,
+      "properties": {
+        "standards": {
+          "type": "array",
+          "title": "Standards",
+          "description": "The list of standards which may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.",
+          "items": {
+            "$ref": "#/definitions/standard"
+          }
+        }
+      }
     },
     "properties": {
       "type": "array",
       "title": "Properties",
-      "additionalItems": false,
+      "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
       "items": {
         "$ref": "#/definitions/property"
       }
@@ -178,33 +578,33 @@
   },
   "definitions": {
     "refType": {
-      "$comment": "Identifier-DataType for interlinked elements.",
+      "description": "Identifier for referable and therefore interlinkable elements.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
       "type": "string",
-      "additionalProperties": false
+      "minLength": 1,
+      "$comment": "TODO (breaking change): add a format constraint that prevents the value from staring with 'urn:cdx:'"
     },
     "refLinkType": {
-      "description": "Descriptor for an element identified by the attribute 'bom-ref' in the same BOM document.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/refType"
-        }
-      ]
+      "description": "Descriptor for an element identified by the attribute 'bom-ref' in the same BOM document.\nIn contrast to `bomLinkElementType`.",
+      "$ref": "#/definitions/refType"
     },
     "bomLinkDocumentType": {
       "title": "BOM-Link Document",
-      "description": "Descriptor for another BOM document.",
+      "description": "Descriptor for another BOM document. See https://cyclonedx.org/capabilities/bomlink/",
       "type": "string",
       "format": "iri-reference",
-      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*$"
+      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*$",
+      "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
     },
     "bomLinkElementType": {
       "title": "BOM-Link Element",
-      "description": "Descriptor for an element in a BOM document.",
+      "description": "Descriptor for an element in a BOM document. See https://cyclonedx.org/capabilities/bomlink/",
       "type": "string",
       "format": "iri-reference",
-      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*#.+$"
+      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*#.+$",
+      "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
     },
     "bomLink": {
+      "title": "BOM-Link",
       "anyOf": [
         {
           "title": "BOM-Link Document",
@@ -218,7 +618,7 @@
     },
     "metadata": {
       "type": "object",
-      "title": "BOM Metadata Object",
+      "title": "BOM Metadata",
       "additionalProperties": false,
       "properties": {
         "timestamp": {
@@ -230,15 +630,74 @@
         "lifecycles": {
           "type": "array",
           "title": "Lifecycles",
+          "description": "Lifecycles communicate the stage(s) in which data in the BOM was captured. Different types of data may be available at various phases of a lifecycle, such as the Software Development Lifecycle (SDLC), IT Asset Management (ITAM), and Software Asset Management (SAM). Thus, a BOM may include data specific to or only obtainable in a given lifecycle.",
           "items": {
-            "type": "object"
+            "type": "object",
+            "title": "Lifecycle",
+            "description": "The product lifecycle(s) that this BOM represents.",
+            "oneOf": [
+              {
+                "title": "Pre-Defined Phase",
+                "required": [
+                  "phase"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "phase": {
+                    "type": "string",
+                    "title": "Phase",
+                    "description": "A pre-defined phase in the product lifecycle.",
+                    "enum": [
+                      "design",
+                      "pre-build",
+                      "build",
+                      "post-build",
+                      "operations",
+                      "discovery",
+                      "decommission"
+                    ],
+                    "meta:enum": {
+                      "design": "BOM produced early in the development lifecycle containing an inventory of components and services that are proposed or planned to be used. The inventory may need to be procured, retrieved, or resourced prior to use.",
+                      "pre-build": "BOM consisting of information obtained prior to a build process and may contain source files and development artifacts and manifests. The inventory may need to be resolved and retrieved prior to use.",
+                      "build": "BOM consisting of information obtained during a build process where component inventory is available for use. The precise versions of resolved components are usually available at this time as well as the provenance of where the components were retrieved from.",
+                      "post-build": "BOM consisting of information obtained after a build process has completed and the resulting components(s) are available for further analysis. Built components may exist as the result of a CI/CD process, may have been installed or deployed to a system or device, and may need to be retrieved or extracted from the system or device.",
+                      "operations": "BOM produced that represents inventory that is running and operational. This may include staging or production environments and will generally encompass multiple SBOMs describing the applications and operating system, along with HBOMs describing the hardware that makes up the system. Operations Bill of Materials (OBOM) can provide full-stack inventory of runtime environments, configurations, and additional dependencies.",
+                      "discovery": "BOM consisting of information observed through network discovery providing point-in-time enumeration of embedded, on-premise, and cloud-native services such as server applications, connected devices, microservices, and serverless functions.",
+                      "decommission": "BOM containing inventory that will be, or has been retired from operations."
+                    }
+                  }
+                }
+              },
+              {
+                "title": "Custom Phase",
+                "required": [
+                  "name"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the lifecycle phase"
+                  },
+                  "description": {
+                    "type": "string",
+                    "title": "Description",
+                    "description": "The description of the lifecycle phase"
+                  }
+                }
+              }
+            ]
           }
         },
         "tools": {
+          "title": "Tools",
+          "description": "The tool(s) used in the creation, enrichment, and validation of the BOM.",
           "oneOf": [
             {
               "type": "object",
-              "title": "Creation Tools",
+              "title": "Tools",
+              "description": "The tool(s) used in the creation, enrichment, and validation of the BOM.",
               "additionalProperties": false,
               "properties": {
                 "components": {
@@ -248,30 +707,41 @@
                     "required": [
                       "type"
                     ]
-                  }
+                  },
+                  "uniqueItems": true,
+                  "title": "Components",
+                  "description": "A list of software and hardware components used as tools."
                 },
                 "services": {
                   "type": "array",
                   "items": {
                     "type": "object"
-                  }
+                  },
+                  "uniqueItems": true,
+                  "title": "Services",
+                  "description": "A list of services used as tools. This may include microservices, function-as-a-service, and other types of network or intra-process services."
                 }
               }
             },
             {
               "type": "array",
-              "title": "Creation Tools (legacy)",
+              "title": "Tools (legacy)",
+              "description": "[Deprecated] The tool(s) used in the creation, enrichment, and validation of the BOM.",
               "items": {
                 "$ref": "#/definitions/tool"
               }
             }
           ]
         },
+        "manufacturer": {
+          "title": "BOM Manufacturer",
+          "description": "The organization that created the BOM.\nManufacturer is common in BOMs created through automated processes. BOMs created through manual means may have `@.authors` instead.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
         "authors": {
           "type": "array",
-          "title": "Authors",
-          "description": "The person(s) who created the BOM. Authors are common in BOMs created through manual processes. BOMs created through automated means may not have authors.",
-          "additionalItems": false,
+          "title": "BOM Authors",
+          "description": "The person(s) who created the BOM.\nAuthors are common in BOMs created through manual processes. BOMs created through automated means may have `@.manufacturer` instead.",
           "items": {
             "$ref": "#/definitions/organizationalContact"
           }
@@ -282,8 +752,9 @@
           "$ref": "#/definitions/component"
         },
         "manufacture": {
-          "title": "Manufacture",
-          "description": "The organization that manufactured the component that the BOM describes.",
+          "deprecated": true,
+          "title": "Component Manufacture (legacy)",
+          "description": "[Deprecated] This will be removed in a future version. Use the `@.component.manufacturer` instead.\nThe organization that manufactured the component that the BOM describes.",
           "$ref": "#/definitions/organizationalEntity"
         },
         "supplier": {
@@ -292,10 +763,10 @@
           "$ref": "#/definitions/organizationalEntity"
         },
         "licenses": {
-          "type": "array",
           "title": "BOM License(s)",
+          "description": "The license information for the BOM document.\nThis may be different from the license(s) of the component(s) that the BOM describes.",
           "minItems": 1,
-          "additionalItems": false,
+          "type": "array",
           "items": {
             "$ref": "#/definitions/licenseChoice"
           }
@@ -303,7 +774,7 @@
         "properties": {
           "type": "array",
           "title": "Properties",
-          "additionalItems": false,
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -318,7 +789,7 @@
     "tool": {
       "type": "object",
       "title": "Tool",
-      "description": "Information about the automated or manual tool used",
+      "description": "[Deprecated] This will be removed in a future version. Use component or service instead. Information about the automated or manual tool used",
       "additionalProperties": false,
       "properties": {
         "vendor": {
@@ -332,13 +803,12 @@
           "description": "The name of the tool"
         },
         "version": {
-          "type": "string",
+          "$ref": "#/definitions/version",
           "title": "Tool Version",
           "description": "The version of the tool"
         },
         "hashes": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/hash"
           },
@@ -347,34 +817,37 @@
         },
         "externalReferences": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/externalReference"
           },
           "title": "External References",
-          "description": "External references provide a way to document systems, sites, and information that may be relevant but which are not included with the BOM."
+          "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
         }
       }
     },
     "organizationalEntity": {
       "type": "object",
-      "title": "Organizational Entity Object",
-      "description": "",
+      "title": "Organizational Entity",
       "additionalProperties": false,
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "name": {
           "type": "string",
-          "title": "Name",
-          "minLength": 1,
+          "title": "Organization Name",
           "description": "The name of the organization",
           "examples": [
             "Example Inc."
-          ]
+          ],
+          "minLength": 1
+        },
+        "address": {
+          "$ref": "#/definitions/postalAddress",
+          "title": "Organization Address",
+          "description": "The physical address (location) of the organization"
         },
         "url": {
           "type": "array",
@@ -382,7 +855,7 @@
             "type": "string",
             "format": "iri-reference"
           },
-          "title": "URL",
+          "title": "Organization URL(s)",
           "description": "The URL of the organization. Multiple URLs are allowed.",
           "examples": [
             "https://example.com"
@@ -390,9 +863,8 @@
         },
         "contact": {
           "type": "array",
-          "title": "Contact",
+          "title": "Organizational Contact",
           "description": "A contact at the organization. Multiple contacts are allowed.",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/organizationalContact"
           }
@@ -418,14 +890,13 @@
     },
     "organizationalContact": {
       "type": "object",
-      "title": "Organizational Contact Object",
-      "description": "",
+      "title": "Organizational Contact",
       "additionalProperties": false,
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "name": {
           "type": "string",
@@ -459,7 +930,7 @@
     },
     "component": {
       "type": "object",
-      "title": "Component Object",
+      "title": "Component",
       "required": [
         "type",
         "name",
@@ -484,7 +955,23 @@
             "data",
             "cryptographic-asset"
           ],
+          "meta:enum": {
+            "application": "A software application. Refer to [https://en.wikipedia.org/wiki/Application_software](https://en.wikipedia.org/wiki/Application_software) for information about applications.",
+            "framework": "A software framework. Refer to [https://en.wikipedia.org/wiki/Software_framework](https://en.wikipedia.org/wiki/Software_framework) for information on how frameworks vary slightly from libraries.",
+            "library": "A software library. Refer to [https://en.wikipedia.org/wiki/Library_(computing)](https://en.wikipedia.org/wiki/Library_(computing)) for information about libraries. All third-party and open source reusable components will likely be a library. If the library also has key features of a framework, then it should be classified as a framework. If not, or is unknown, then specifying library is recommended.",
+            "container": "A packaging and/or runtime format, not specific to any particular technology, which isolates software inside the container from software outside of a container through virtualization technology. Refer to [https://en.wikipedia.org/wiki/OS-level_virtualization](https://en.wikipedia.org/wiki/OS-level_virtualization).",
+            "platform": "A runtime environment which interprets or executes software. This may include runtimes such as those that execute bytecode or low-code/no-code application platforms.",
+            "operating-system": "A software operating system without regard to deployment model (i.e. installed on physical hardware, virtual machine, image, etc) Refer to [https://en.wikipedia.org/wiki/Operating_system](https://en.wikipedia.org/wiki/Operating_system).",
+            "device": "A hardware device such as a processor or chip-set. A hardware device containing firmware SHOULD include a component for the physical hardware itself and another component of type 'firmware' or 'operating-system' (whichever is relevant), describing information about the software running on the device. See also the list of [known device properties](https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/device.md).",
+            "device-driver": "A special type of software that operates or controls a particular type of device. Refer to [https://en.wikipedia.org/wiki/Device_driver](https://en.wikipedia.org/wiki/Device_driver).",
+            "firmware": "A special type of software that provides low-level control over a device's hardware. Refer to [https://en.wikipedia.org/wiki/Firmware](https://en.wikipedia.org/wiki/Firmware).",
+            "file": "A computer file. Refer to [https://en.wikipedia.org/wiki/Computer_file](https://en.wikipedia.org/wiki/Computer_file) for information about files.",
+            "machine-learning-model": "A model based on training data that can make predictions or decisions without being explicitly programmed to do so.",
+            "data": "A collection of discrete values that convey information.",
+            "cryptographic-asset": "A cryptographic asset including algorithms, protocols, certificates, keys, tokens, and secrets."
+          },
           "title": "Component Type",
+          "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component.",
           "examples": [
             "library"
           ]
@@ -492,7 +979,7 @@
         "mime-type": {
           "type": "string",
           "title": "Mime-Type",
-          "description": "The optional mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
+          "description": "The optional mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented, such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
           "examples": [
             "image/jpeg"
           ],
@@ -501,17 +988,31 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+          "description": "An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "supplier": {
           "title": "Component Supplier",
           "description": " The organization that supplied the component. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
           "$ref": "#/definitions/organizationalEntity"
         },
+        "manufacturer": {
+          "title": "Component Manufacturer",
+          "description": "The organization that created the component.\nManufacturer is common in components created through automated processes. Components created through manual means may have `@.authors` instead.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "authors": {
+          "type": "array",
+          "title": "Component Authors",
+          "description": "The person(s) who created the component.\nAuthors are common in components created through manual processes. Components created through automated means may have `@.manufacturer` instead.",
+          "items": {
+            "$ref": "#/definitions/organizationalContact"
+          }
+        },
         "author": {
+          "deprecated": true,
           "type": "string",
-          "title": "Component Author",
-          "description": "The person(s) or organization(s) that authored the component",
+          "title": "Component Author (legacy)",
+          "description": "[Deprecated] This will be removed in a future version. Use `@.authors` or `@.manufacturer` instead.\nThe person(s) or organization(s) that authored the component",
           "examples": [
             "Acme Inc"
           ]
@@ -534,21 +1035,17 @@
         },
         "name": {
           "type": "string",
-          "minLength": 1,
           "title": "Component Name",
           "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
           "examples": [
             "tomcat-catalina"
-          ]
+          ],
+          "minLength": 1
         },
         "version": {
-          "type": "string",
+          "$ref": "#/definitions/version",
           "title": "Component Version",
-          "minLength": 1,
-          "description": "The component version. The version should ideally comply with semantic versioning but is not enforced.",
-          "examples": [
-            "9.0.14"
-          ]
+          "description": "The component version. The version should ideally comply with semantic versioning but is not enforced."
         },
         "description": {
           "type": "string",
@@ -562,6 +1059,11 @@
             "optional",
             "excluded"
           ],
+          "meta:enum": {
+            "required": "The component is required for runtime",
+            "optional": "The component is optional at runtime. Optional components are components that are not capable of being called due to them not being installed or otherwise accessible by any means. Components that are installed but due to configuration or other restrictions are prohibited from being called must be scoped as 'required'.",
+            "excluded": "Components that are excluded provide the ability to document component usage for test and other non-runtime purposes. Excluded components are not reachable within a call graph at runtime."
+          },
           "title": "Component Scope",
           "description": "Specifies the scope of the component. If scope is not specified, 'required' scope SHOULD be assumed by the consumer of the BOM.",
           "default": "required"
@@ -569,19 +1071,18 @@
         "hashes": {
           "type": "array",
           "title": "Component Hashes",
-          "additionalItems": false,
+          "description": "The hashes of the component.",
           "items": {
             "$ref": "#/definitions/hash"
           }
         },
         "licenses": {
+          "title": "Component License(s)",
+          "minItems": 1,
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/licenseChoice"
-          },
-          "minItems": 1,
-          "title": "Component License(s)"
+          }
         },
         "copyright": {
           "type": "string",
@@ -593,38 +1094,63 @@
         },
         "cpe": {
           "type": "string",
-          "title": "Component Common Platform Enumeration (CPE)",
-          "description": "Specifies a well-formed CPE name that conforms to the CPE 2.2 or 2.3 specification. See [https://nvd.nist.gov/products/cpe](https://nvd.nist.gov/products/cpe)",
+          "title": "Common Platform Enumeration (CPE)",
+          "description": "Asserts the identity of the component using CPE. The CPE must conform to the CPE 2.2 or 2.3 specification. See [https://nvd.nist.gov/products/cpe](https://nvd.nist.gov/products/cpe). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
           "examples": [
             "cpe:2.3:a:acme:component_framework:-:*:*:*:*:*:*:*"
           ]
         },
         "purl": {
           "type": "string",
-          "title": "Component Package URL (purl)",
-          "description": "Specifies the package-url (purl). The purl, if specified, MUST be valid and conform to the specification defined at: [https://github.com/package-url/purl-spec](https://github.com/package-url/purl-spec)",
+          "title": "Package URL (purl)",
+          "description": "Asserts the identity of the component using package-url (purl). The purl, if specified, must be valid and conform to the specification defined at: [https://github.com/package-url/purl-spec](https://github.com/package-url/purl-spec). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
           "examples": [
             "pkg:maven/com.acme/tomcat-catalina@9.0.14?packaging=jar"
+          ]
+        },
+        "omniborId": {
+          "type": "array",
+          "title": "OmniBOR Artifact Identifier (gitoid)",
+          "description": "Asserts the identity of the component using the OmniBOR Artifact ID. The OmniBOR, if specified, must be valid and conform to the specification defined at: [https://www.iana.org/assignments/uri-schemes/prov/gitoid](https://www.iana.org/assignments/uri-schemes/prov/gitoid). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            "gitoid:blob:sha1:a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+            "gitoid:blob:sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+          ]
+        },
+        "swhid": {
+          "type": "array",
+          "title": "Software Heritage Identifier",
+          "description": "Asserts the identity of the component using the Software Heritage persistent identifier (SWHID). The SWHID, if specified, must be valid and conform to the specification defined at: [https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html](https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            "swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2"
           ]
         },
         "swid": {
           "$ref": "#/definitions/swid",
           "title": "SWID Tag",
-          "description": "Specifies metadata and content for [ISO-IEC 19770-2 Software Identification (SWID) Tags](https://www.iso.org/standard/65666.html)."
+          "description": "Asserts the identity of the component using [ISO-IEC 19770-2 Software Identification (SWID) Tags](https://www.iso.org/standard/65666.html). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity."
         },
         "modified": {
           "type": "boolean",
-          "title": "Component Modified From Original"
+          "title": "Component Modified From Original",
+          "description": "[Deprecated] This will be removed in a future version. Use the pedigree element instead to supply information on exactly how the component was modified. A boolean value indicating if the component has been modified from the original. A value of true indicates the component is a derivative of the original. A value of false indicates the component has not been modified from the original."
         },
         "pedigree": {
           "type": "object",
           "title": "Component Pedigree",
+          "description": "Component pedigree is a way to document complex supply chain scenarios where components are created, distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to document variants where the exact relation may not be known.",
           "additionalProperties": false,
           "properties": {
             "ancestors": {
               "type": "array",
               "title": "Ancestors",
-              "additionalItems": false,
+              "description": "Describes zero or more components in which a component is derived from. This is commonly used to describe forks from existing projects where the forked version contains a ancestor node containing the original component it was forked from. For example, Component A is the original component. Component B is the component being used and documented in the BOM. However, Component B contains a pedigree node with a single ancestor documenting Component A - the original component from which Component B is derived from.",
               "items": {
                 "$ref": "#/definitions/component"
               }
@@ -632,7 +1158,7 @@
             "descendants": {
               "type": "array",
               "title": "Descendants",
-              "additionalItems": false,
+              "description": "Descendants are the exact opposite of ancestors. This provides a way to document all forks (and their forks) of an original or root component.",
               "items": {
                 "$ref": "#/definitions/component"
               }
@@ -640,7 +1166,7 @@
             "variants": {
               "type": "array",
               "title": "Variants",
-              "additionalItems": false,
+              "description": "Variants describe relations where the relationship between the components is not known. For example, if Component A contains nearly identical code to Component B. They are both related, but it is unclear if one is derived from the other, or if they share a common ancestor.",
               "items": {
                 "$ref": "#/definitions/component"
               }
@@ -648,7 +1174,7 @@
             "commits": {
               "type": "array",
               "title": "Commits",
-              "additionalItems": false,
+              "description": "A list of zero or more commits which provide a trail describing how the component deviates from an ancestor, descendant, or variant.",
               "items": {
                 "$ref": "#/definitions/commit"
               }
@@ -656,64 +1182,77 @@
             "patches": {
               "type": "array",
               "title": "Patches",
-              "additionalItems": false,
+              "description": ">A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complementary to commits or may be used in place of commits.",
               "items": {
                 "$ref": "#/definitions/patch"
               }
             },
             "notes": {
               "type": "string",
-              "title": "Notes"
+              "title": "Notes",
+              "description": "Notes, observations, and other non-structured commentary describing the components pedigree."
             }
           }
         },
         "externalReferences": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/externalReference"
           },
-          "title": "External References"
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
         },
         "components": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/component"
           },
           "uniqueItems": true,
-          "title": "Components"
+          "title": "Components",
+          "description": "A list of software and hardware components included in the parent component. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system &#8594; subsystem &#8594; parts assembly in physical supply chains."
         },
         "evidence": {
           "$ref": "#/definitions/componentEvidence",
-          "title": "Evidence"
+          "title": "Evidence",
+          "description": "Provides the ability to document evidence collected through various forms of extraction or analysis."
         },
         "releaseNotes": {
           "$ref": "#/definitions/releaseNotes",
-          "title": "Release notes"
+          "title": "Release notes",
+          "description": "Specifies optional release notes."
         },
         "modelCard": {
-          "type": "object",
-          "title": "Machine Learning Model Card"
+          "$ref": "#/definitions/modelCard",
+          "title": "AI/ML Model Card"
         },
         "data": {
           "type": "array",
           "items": {
-            "type": "object"
+            "$ref": "#/definitions/componentData"
           },
-          "title": "Data"
+          "title": "Data",
+          "description": "This object SHOULD be specified for any component of type `data` and must not be specified for other component types."
+        },
+        "cryptoProperties": {
+          "$ref": "#/definitions/cryptoProperties",
+          "title": "Cryptographic Properties"
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "additionalItems": false,
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
           "items": {
             "$ref": "#/definitions/property"
           }
         },
+        "tags": {
+          "$ref": "#/definitions/tags",
+          "title": "Tags"
+        },
         "signature": {
           "$ref": "#/definitions/signature",
-          "title": "Signature"
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
         }
       },
       "anyOf": [
@@ -1079,8 +1618,13 @@
         "contentType": {
           "type": "string",
           "title": "Content-Type",
-          "description": "Specifies the content type of the text. Defaults to text/plain if not specified.",
-          "default": "text/plain"
+          "description": "Specifies the format and nature of the data being attached, helping systems correctly interpret and process the content. Common content type examples include `application/json` for JSON data and `text/plain` for plan text documents.\n [RFC 2045 section 5.1](https://www.ietf.org/rfc/rfc2045.html#section-5.1) outlines the structure and use of content types. For a comprehensive list of registered content types, refer to the [IANA media types registry](https://www.iana.org/assignments/media-types/media-types.xhtml).",
+          "default": "text/plain",
+          "examples": [
+            "text/plain",
+            "application/json",
+            "image/png"
+          ]
         },
         "encoding": {
           "type": "string",
@@ -1088,19 +1632,22 @@
           "description": "Specifies the optional encoding the text is represented in.",
           "enum": [
             "base64"
-          ]
+          ],
+          "meta:enum": {
+            "base64": "Base64 is a binary-to-text encoding scheme that represents binary data in an ASCII string."
+          }
         },
         "content": {
           "type": "string",
           "title": "Attachment Text",
-          "minLength": 1,
-          "description": "The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text."
+          "description": "The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text.",
+          "minLength": 1
         }
       }
     },
     "hash": {
       "type": "object",
-      "title": "Hash Objects",
+      "title": "Hash",
       "required": [
         "alg",
         "content"
@@ -1117,6 +1664,8 @@
     },
     "hash-alg": {
       "type": "string",
+      "title": "Hash Algorithm",
+      "description": "The algorithm that generated the hash value.",
       "enum": [
         "MD5",
         "SHA-1",
@@ -1130,22 +1679,21 @@
         "BLAKE2b-384",
         "BLAKE2b-512",
         "BLAKE3"
-      ],
-      "title": "Hash Algorithm",
-      "additionalProperties": false
+      ]
     },
     "hash-content": {
       "type": "string",
-      "title": "Hash Content (value)",
+      "title": "Hash Value",
+      "description": "The value of the hash.",
       "examples": [
         "3942447fac867ae5cdb3229b658f4d48"
       ],
-      "pattern": "^([a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$",
-      "additionalProperties": false
+      "pattern": "^([a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$"
     },
     "license": {
       "type": "object",
-      "title": "License Object",
+      "title": "License",
+      "description": "Specifies the details and attributes related to a software license. It can either include a valid SPDX license identifier or a named license, along with additional properties such as license acknowledgment, comprehensive commercial licensing information, and the full text of the license.",
       "oneOf": [
         {
           "required": [
@@ -1163,24 +1711,27 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
+          "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "id": {
           "$ref": "spdx.schema.json",
           "title": "License ID (SPDX)",
-          "description": "A valid SPDX license ID",
+          "description": "A valid SPDX license identifier. If specified, this value must be one of the enumeration of valid SPDX license identifiers defined in the spdx.schema.json (or spdx.xml) subschema which is synchronized with the official SPDX license list.",
           "examples": [
             "Apache-2.0"
           ]
         },
         "name": {
           "type": "string",
-          "minLength": 1,
           "title": "License Name",
-          "description": "If SPDX does not define the license used, this field may be used to provide the license name",
+          "description": "The name of the license. This may include the name of a commercial or proprietary license or an open source license that may not be defined by SPDX.",
           "examples": [
             "Acme Software License"
-          ]
+          ],
+          "minLength": 1
+        },
+        "acknowledgement": {
+          "$ref": "#/definitions/licenseAcknowledgementEnumeration"
         },
         "text": {
           "title": "License text",
@@ -1201,32 +1752,11 @@
           "title": "Licensing information",
           "description": "Licensing details describing the licensor/licensee, license type, renewal and expiration dates, and other important metadata",
           "additionalProperties": false,
-          "required": [
-            "licenseTypes"
-          ],
-          "if": {
-            "properties": {
-              "licenseTypes": {
-                "contains": {
-                  "not": {
-                    "const": "appliance"
-                  }
-                }
-              }
-            },
-            "required": [
-              "licenseTypes"
-            ]
-          },
-          "then": {
-            "required": [
-              "licensor"
-            ]
-          },
           "properties": {
             "altIds": {
               "type": "array",
               "title": "Alternate License Identifiers",
+              "description": "License identifiers that may be used to manage licenses and their lifecycle",
               "items": {
                 "type": "string"
               }
@@ -1269,10 +1799,12 @@
               "properties": {
                 "organization": {
                   "title": "Licensee (Organization)",
+                  "description": "The organization that was granted the license",
                   "$ref": "#/definitions/organizationalEntity"
                 },
                 "individual": {
                   "title": "Licensee (Individual)",
+                  "description": "The individual, not associated with an organization, that was granted the license",
                   "$ref": "#/definitions/organizationalContact"
                 }
               },
@@ -1297,10 +1829,12 @@
               "properties": {
                 "organization": {
                   "title": "Purchaser (Organization)",
+                  "description": "The organization that purchased the license",
                   "$ref": "#/definitions/organizationalEntity"
                 },
                 "individual": {
                   "title": "Purchaser (Individual)",
+                  "description": "The individual, not associated with an organization, that purchased the license",
                   "$ref": "#/definitions/organizationalContact"
                 }
               },
@@ -1319,11 +1853,13 @@
             },
             "purchaseOrder": {
               "type": "string",
-              "title": "Purchase Order"
+              "title": "Purchase Order",
+              "description": "The purchase order identifier the purchaser sent to a supplier or vendor to authorize a purchase"
             },
             "licenseTypes": {
               "type": "array",
               "title": "License Type",
+              "description": "The type of license(s) that was granted to the licensee.",
               "items": {
                 "type": "string",
                 "enum": [
@@ -1343,24 +1879,67 @@
                   "subscription",
                   "user",
                   "other"
-                ]
+                ],
+                "meta:enum": {
+                  "academic": "A license that grants use of software solely for the purpose of education or research.",
+                  "appliance": "A license covering use of software embedded in a specific piece of hardware.",
+                  "client-access": "A Client Access License (CAL) allows client computers to access services provided by server software.",
+                  "concurrent-user": "A Concurrent User license (aka floating license) limits the number of licenses for a software application and licenses are shared among a larger number of users.",
+                  "core-points": "A license where the core of a computer's processor is assigned a specific number of points.",
+                  "custom-metric": "A license for which consumption is measured by non-standard metrics.",
+                  "device": "A license that covers a defined number of installations on computers and other types of devices.",
+                  "evaluation": "A license that grants permission to install and use software for trial purposes.",
+                  "named-user": "A license that grants access to the software to one or more pre-defined users.",
+                  "node-locked": "A license that grants access to the software on one or more pre-defined computers or devices.",
+                  "oem": "An Original Equipment Manufacturer license that is delivered with hardware, cannot be transferred to other hardware, and is valid for the life of the hardware.",
+                  "perpetual": "A license where the software is sold on a one-time basis and the licensee can use a copy of the software indefinitely.",
+                  "processor-points": "A license where each installation consumes points per processor.",
+                  "subscription": "A license where the licensee pays a fee to use the software or service.",
+                  "user": "A license that grants access to the software or service by a specified number of users.",
+                  "other": "Another license type."
+                }
               }
             },
             "lastRenewal": {
               "type": "string",
               "format": "date-time",
-              "title": "Last Renewal"
+              "title": "Last Renewal",
+              "description": "The timestamp indicating when the license was last renewed. For new purchases, this is often the purchase or acquisition date. For non-perpetual licenses or subscriptions, this is the timestamp of when the license was last renewed."
             },
             "expiration": {
               "type": "string",
               "format": "date-time",
-              "title": "Expiration"
+              "title": "Expiration",
+              "description": "The timestamp indicating when the current license expires (if applicable)."
             }
+          },
+          "required": [
+            "licenseTypes"
+          ],
+          "if": {
+            "properties": {
+              "licenseTypes": {
+                "contains": {
+                  "not": {
+                    "const": "appliance"
+                  }
+                }
+              }
+            },
+            "required": [
+              "licenseTypes"
+            ]
+          },
+          "then": {
+            "required": [
+              "licensor"
+            ]
           }
         },
         "properties": {
           "type": "array",
           "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -1371,6 +1950,19 @@
           "text",
           "licensing"
         ]
+      }
+    },
+    "licenseAcknowledgementEnumeration": {
+      "title": "License Acknowledgement",
+      "description": "Declared licenses and concluded licenses represent two different stages in the licensing process within software development. Declared licenses refer to the initial intention of the software authors regarding the licensing terms under which their code is released. On the other hand, concluded licenses are the result of a comprehensive analysis of the project's codebase to identify and confirm the actual licenses of the components used, which may differ from the initially declared licenses. While declared licenses provide an upfront indication of the licensing intentions, concluded licenses offer a more thorough understanding of the actual licensing within a project, facilitating proper compliance and risk management. Observed licenses are defined in `@.evidence.licenses`. Observed licenses form the evidence necessary to substantiate a concluded license.",
+      "type": "string",
+      "enum": [
+        "declared",
+        "concluded"
+      ],
+      "meta:enum": {
+        "declared": "Declared licenses represent the initial intentions of authors regarding the licensing terms of their code.",
+        "concluded": "Concluded licenses are verified and confirmed."
       }
     },
     "licenseChoice": {
@@ -1412,24 +2004,29 @@
       "properties": {
         "uid": {
           "type": "string",
-          "title": "UID"
+          "title": "UID",
+          "description": "A unique identifier of the commit. This may be version control specific. For example, Subversion uses revision numbers whereas git uses commit hashes."
         },
         "url": {
           "type": "string",
           "title": "URL",
+          "description": "The URL to the commit. This URL will typically point to a commit in a version control system.",
           "format": "iri-reference"
         },
         "author": {
           "title": "Author",
+          "description": "The author who created the changes in the commit",
           "$ref": "#/definitions/identifiableAction"
         },
         "committer": {
           "title": "Committer",
+          "description": "The person who committed or pushed the commit",
           "$ref": "#/definitions/identifiableAction"
         },
         "message": {
           "type": "string",
-          "title": "Message"
+          "title": "Message",
+          "description": "The text description of the contents of the commit"
         }
       }
     },
@@ -1450,34 +2047,45 @@
             "backport",
             "cherry-pick"
           ],
-          "title": "Type"
+          "meta:enum": {
+            "unofficial": "A patch which is not developed by the creators or maintainers of the software being patched. Refer to [https://en.wikipedia.org/wiki/Unofficial_patch](https://en.wikipedia.org/wiki/Unofficial_patch).",
+            "monkey": "A patch which dynamically modifies runtime behavior. Refer to [https://en.wikipedia.org/wiki/Monkey_patch](https://en.wikipedia.org/wiki/Monkey_patch).",
+            "backport": "A patch which takes code from a newer version of the software and applies it to older versions of the same software. Refer to [https://en.wikipedia.org/wiki/Backporting](https://en.wikipedia.org/wiki/Backporting).",
+            "cherry-pick": "A patch created by selectively applying commits from other versions or branches of the same software."
+          },
+          "title": "Patch Type",
+          "description": "Specifies the purpose for the patch including the resolution of defects, security issues, or new behavior or functionality."
         },
         "diff": {
           "title": "Diff",
+          "description": "The patch file (or diff) that shows changes. Refer to [https://en.wikipedia.org/wiki/Diff](https://en.wikipedia.org/wiki/Diff)",
           "$ref": "#/definitions/diff"
         },
         "resolves": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/issue"
           },
-          "title": "Resolves"
+          "title": "Resolves",
+          "description": "A collection of issues the patch resolves"
         }
       }
     },
     "diff": {
       "type": "object",
       "title": "Diff",
+      "description": "The patch file (or diff) that shows changes. Refer to https://en.wikipedia.org/wiki/Diff",
       "additionalProperties": false,
       "properties": {
         "text": {
           "title": "Diff text",
+          "description": "Specifies the optional text of the diff",
           "$ref": "#/definitions/attachment"
         },
         "url": {
           "type": "string",
           "title": "URL",
+          "description": "Specifies the URL to the diff",
           "format": "iri-reference"
         }
       }
@@ -1498,32 +2106,49 @@
             "enhancement",
             "security"
           ],
-          "title": "Type"
+          "meta:enum": {
+            "defect": "A fault, flaw, or bug in software.",
+            "enhancement": "A new feature or behavior in software.",
+            "security": "A special type of defect which impacts security."
+          },
+          "title": "Issue Type",
+          "description": "Specifies the type of issue"
         },
         "id": {
           "type": "string",
-          "title": "ID"
+          "title": "Issue ID",
+          "description": "The identifier of the issue assigned by the source of the issue"
         },
         "name": {
           "type": "string",
-          "title": "Name"
+          "title": "Issue Name",
+          "description": "The name of the issue"
         },
         "description": {
           "type": "string",
-          "title": "Description"
+          "title": "Issue Description",
+          "description": "A description of the issue"
         },
         "source": {
           "type": "object",
           "title": "Source",
+          "description": "The source of the issue where it is documented",
           "additionalProperties": false,
           "properties": {
             "name": {
               "type": "string",
-              "title": "Name"
+              "title": "Name",
+              "description": "The name of the source.",
+              "examples": [
+                "National Vulnerability Database",
+                "NVD",
+                "Apache"
+              ]
             },
             "url": {
               "type": "string",
               "title": "URL",
+              "description": "The url of the issue documentation as provided by the source",
               "format": "iri-reference"
             }
           }
@@ -1534,35 +2159,43 @@
             "type": "string",
             "format": "iri-reference"
           },
-          "title": "References"
+          "title": "References",
+          "description": "A collection of URL's for reference. Multiple URLs are allowed.",
+          "examples": [
+            "https://example.com"
+          ]
         }
       }
     },
     "identifiableAction": {
       "type": "object",
       "title": "Identifiable Action",
+      "description": "Specifies an individual commit",
       "additionalProperties": false,
       "properties": {
         "timestamp": {
           "type": "string",
           "format": "date-time",
-          "title": "Timestamp"
+          "title": "Timestamp",
+          "description": "The timestamp in which the action occurred"
         },
         "name": {
           "type": "string",
-          "title": "Name"
+          "title": "Name",
+          "description": "The name of the individual who performed the action"
         },
         "email": {
           "type": "string",
           "format": "idn-email",
-          "title": "E-mail"
+          "title": "E-mail",
+          "description": "The email address of the individual who performed the action"
         }
       }
     },
     "externalReference": {
       "type": "object",
       "title": "External Reference",
-      "description": "Specifies an individual external reference",
+      "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM.",
       "required": [
         "url",
         "type"
@@ -1570,18 +2203,30 @@
       "additionalProperties": false,
       "properties": {
         "url": {
-          "type": "string",
+          "anyOf": [
+            {
+              "title": "URL",
+              "type": "string",
+              "format": "iri-reference"
+            },
+            {
+              "title": "BOM-Link",
+              "$ref": "#/definitions/bomLink"
+            }
+          ],
           "title": "URL",
-          "format": "iri-reference",
+          "description": "The URI (URL or URN) to the external reference. External references are URIs and therefore can accept any URL scheme including https ([RFC-7230](https://www.ietf.org/rfc/rfc7230.txt)), mailto ([RFC-2368](https://www.ietf.org/rfc/rfc2368.txt)), tel ([RFC-3966](https://www.ietf.org/rfc/rfc3966.txt)), and dns ([RFC-4501](https://www.ietf.org/rfc/rfc4501.txt)). External references may also include formally registered URNs such as [CycloneDX BOM-Link](https://cyclonedx.org/capabilities/bomlink/) to reference CycloneDX BOMs or any object within a BOM. BOM-Link transforms applicable external references into relationships that can be expressed in a BOM or across BOMs.",
           "minLength": 1
         },
         "comment": {
           "type": "string",
-          "title": "Comment"
+          "title": "Comment",
+          "description": "An optional comment describing the external reference"
         },
         "type": {
           "type": "string",
           "title": "Type",
+          "description": "Specifies the type of external reference.",
           "enum": [
             "vcs",
             "issue-tracker",
@@ -1593,50 +2238,133 @@
             "chat",
             "documentation",
             "support",
+            "source-distribution",
             "distribution",
+            "distribution-intake",
             "license",
             "build-meta",
             "build-system",
             "release-notes",
+            "security-contact",
+            "model-card",
+            "log",
+            "configuration",
+            "evidence",
+            "formulation",
+            "attestation",
+            "threat-model",
+            "adversary-model",
+            "risk-assessment",
+            "vulnerability-assertion",
+            "exploitability-statement",
+            "pentest-report",
+            "static-analysis-report",
+            "dynamic-analysis-report",
+            "runtime-analysis-report",
+            "component-analysis-report",
+            "maturity-report",
+            "certification-report",
+            "codified-infrastructure",
+            "quality-metrics",
+            "poam",
+            "electronic-signature",
+            "digital-signature",
+            "rfc-9116",
             "other"
-          ]
+          ],
+          "meta:enum": {
+            "vcs": "Version Control System",
+            "issue-tracker": "Issue or defect tracking system, or an Application Lifecycle Management (ALM) system",
+            "website": "Website",
+            "advisories": "Security advisories",
+            "bom": "Bill of Materials (SBOM, OBOM, HBOM, SaaSBOM, etc)",
+            "mailing-list": "Mailing list or discussion group",
+            "social": "Social media account",
+            "chat": "Real-time chat platform",
+            "documentation": "Documentation, guides, or how-to instructions",
+            "support": "Community or commercial support",
+            "source-distribution": "The location where the source code distributable can be obtained. This is often an archive format such as zip or tgz. The source-distribution type complements use of the version control (vcs) type.",
+            "distribution": "Direct or repository download location",
+            "distribution-intake": "The location where a component was published to. This is often the same as \"distribution\" but may also include specialized publishing processes that act as an intermediary.",
+            "license": "The reference to the license file. If a license URL has been defined in the license node, it should also be defined as an external reference for completeness.",
+            "build-meta": "Build-system specific meta file (i.e. pom.xml, package.json, .nuspec, etc)",
+            "build-system": "Reference to an automated build system",
+            "release-notes": "Reference to release notes",
+            "security-contact": "Specifies a way to contact the maintainer, supplier, or provider in the event of a security incident. Common URIs include links to a disclosure procedure, a mailto (RFC-2368) that specifies an email address, a tel (RFC-3966) that specifies a phone number, or dns (RFC-4501) that specifies the records containing DNS Security TXT.",
+            "model-card": "A model card describes the intended uses of a machine learning model, potential limitations, biases, ethical considerations, training parameters, datasets used to train the model, performance metrics, and other relevant data useful for ML transparency.",
+            "log": "A record of events that occurred in a computer system or application, such as problems, errors, or information on current operations.",
+            "configuration": "Parameters or settings that may be used by other components or services.",
+            "evidence": "Information used to substantiate a claim.",
+            "formulation": "Describes how a component or service was manufactured or deployed.",
+            "attestation": "Human or machine-readable statements containing facts, evidence, or testimony.",
+            "threat-model": "An enumeration of identified weaknesses, threats, and countermeasures, dataflow diagram (DFD), attack tree, and other supporting documentation in human-readable or machine-readable format.",
+            "adversary-model": "The defined assumptions, goals, and capabilities of an adversary.",
+            "risk-assessment": "Identifies and analyzes the potential of future events that may negatively impact individuals, assets, and/or the environment. Risk assessments may also include judgments on the tolerability of each risk.",
+            "vulnerability-assertion": "A Vulnerability Disclosure Report (VDR) which asserts the known and previously unknown vulnerabilities that affect a component, service, or product including the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on a component, service, or product.",
+            "exploitability-statement": "A Vulnerability Exploitability eXchange (VEX) which asserts the known vulnerabilities that do not affect a product, product family, or organization, and optionally the ones that do. The VEX should include the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on the product, product family, or organization.",
+            "pentest-report": "Results from an authorized simulated cyberattack on a component or service, otherwise known as a penetration test.",
+            "static-analysis-report": "SARIF or proprietary machine or human-readable report for which static analysis has identified code quality, security, and other potential issues with the source code.",
+            "dynamic-analysis-report": "Dynamic analysis report that has identified issues such as vulnerabilities and misconfigurations.",
+            "runtime-analysis-report": "Report generated by analyzing the call stack of a running application.",
+            "component-analysis-report": "Report generated by Software Composition Analysis (SCA), container analysis, or other forms of component analysis.",
+            "maturity-report": "Report containing a formal assessment of an organization, business unit, or team against a maturity model.",
+            "certification-report": "Industry, regulatory, or other certification from an accredited (if applicable) certification body.",
+            "codified-infrastructure": "Code or configuration that defines and provisions virtualized infrastructure, commonly referred to as Infrastructure as Code (IaC).",
+            "quality-metrics": "Report or system in which quality metrics can be obtained.",
+            "poam": "Plans of Action and Milestones (POA&M) complement an \"attestation\" external reference. POA&M is defined by NIST as a \"document that identifies tasks needing to be accomplished. It details resources required to accomplish the elements of the plan, any milestones in meeting the tasks and scheduled completion dates for the milestones\".",
+            "electronic-signature": "An e-signature is commonly a scanned representation of a written signature or a stylized script of the person's name.",
+            "digital-signature": "A signature that leverages cryptography, typically public/private key pairs, which provides strong authenticity verification.",
+            "rfc-9116": "Document that complies with [RFC 9116](https://www.ietf.org/rfc/rfc9116.html) (A File Format to Aid in Security Vulnerability Disclosure)",
+            "other": "Use this if no other types accurately describe the purpose of the external reference."
+          }
         },
         "hashes": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/hash"
           },
-          "title": "Hashes"
+          "title": "Hashes",
+          "description": "The hashes of the external reference (if applicable)."
         }
       }
     },
     "dependency": {
       "type": "object",
       "title": "Dependency",
+      "description": "Defines the direct dependencies of a component, service, or the components provided/implemented by a given component. Components or services that do not have their own dependencies must be declared as empty elements within the graph. Components or services that are not represented in the dependency graph may have unknown dependencies. It is recommended that implementations assume this to be opaque and not an indicator of an object being dependency-free. It is recommended to leverage compositions to indicate unknown dependency graphs.",
       "required": [
         "ref"
       ],
       "additionalProperties": false,
       "properties": {
         "ref": {
-          "$ref": "#/definitions/refType",
-          "title": "Reference"
+          "$ref": "#/definitions/refLinkType",
+          "title": "Reference",
+          "description": "References a component or service by its bom-ref attribute"
         },
         "dependsOn": {
           "type": "array",
           "uniqueItems": true,
-          "additionalItems": false,
           "items": {
-            "$ref": "#/definitions/refType"
+            "$ref": "#/definitions/refLinkType"
           },
-          "title": "Depends On"
+          "title": "Depends On",
+          "description": "The bom-ref identifiers of the components or services that are dependencies of this dependency object."
+        },
+        "provides": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/refLinkType"
+          },
+          "title": "Provides",
+          "description": "The bom-ref identifiers of the components or services that define a given specification or standard, which are provided or implemented by this dependency object.\nFor example, a cryptographic library which implements a cryptographic algorithm. A component which implements another component does not imply that the implementation is in use."
         }
       }
     },
     "service": {
       "type": "object",
-      "title": "Service Object",
+      "title": "Service",
       "required": [
         "name"
       ],
@@ -1644,27 +2372,39 @@
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
-          "title": "BOM Reference"
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the service elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "provider": {
           "title": "Provider",
+          "description": "The organization that provides the service.",
           "$ref": "#/definitions/organizationalEntity"
         },
         "group": {
           "type": "string",
-          "title": "Service Group"
+          "title": "Service Group",
+          "description": "The grouping name, namespace, or identifier. This will often be a shortened, single name of the company or project that produced the service or domain name. Whitespace and special characters should be avoided.",
+          "examples": [
+            "com.acme"
+          ]
         },
         "name": {
           "type": "string",
-          "title": "Service Name"
+          "title": "Service Name",
+          "description": "The name of the service. This will often be a shortened, single name of the service.",
+          "examples": [
+            "ticker-service"
+          ]
         },
         "version": {
-          "type": "string",
-          "title": "Service Version"
+          "$ref": "#/definitions/version",
+          "title": "Service Version",
+          "description": "The service version."
         },
         "description": {
           "type": "string",
-          "title": "Service Description"
+          "title": "Service Description",
+          "description": "Specifies a description for the service"
         },
         "endpoints": {
           "type": "array",
@@ -1672,70 +2412,86 @@
             "type": "string",
             "format": "iri-reference"
           },
-          "title": "Endpoints"
+          "title": "Endpoints",
+          "description": "The endpoint URIs of the service. Multiple endpoints are allowed.",
+          "examples": [
+            "https://example.com/api/v1/ticker"
+          ]
         },
         "authenticated": {
           "type": "boolean",
-          "title": "Authentication Required"
+          "title": "Authentication Required",
+          "description": "A boolean value indicating if the service requires authentication. A value of true indicates the service requires authentication prior to use. A value of false indicates the service does not require authentication."
         },
         "x-trust-boundary": {
           "type": "boolean",
-          "title": "Crosses Trust Boundary"
+          "title": "Crosses Trust Boundary",
+          "description": "A boolean value indicating if use of the service crosses a trust zone or boundary. A value of true indicates that by using the service, a trust boundary is crossed. A value of false indicates that by using the service, a trust boundary is not crossed."
+        },
+        "trustZone": {
+          "type": "string",
+          "title": "Trust Zone",
+          "description": "The name of the trust zone the service resides in."
         },
         "data": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/serviceData"
           },
-          "title": "Data"
+          "title": "Data",
+          "description": "Specifies information about the data including the directional flow of data and the data classification."
         },
         "licenses": {
+          "title": "Service License(s)",
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/licenseChoice"
-          },
-          "title": "Component License(s)"
+          }
         },
         "externalReferences": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/externalReference"
           },
-          "title": "External References"
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
         },
         "services": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/service"
           },
           "uniqueItems": true,
-          "title": "Services"
+          "title": "Services",
+          "description": "A list of services included or deployed behind the parent service. This is not a dependency tree. It provides a way to specify a hierarchical representation of service assemblies."
         },
         "releaseNotes": {
           "$ref": "#/definitions/releaseNotes",
-          "title": "Release notes"
+          "title": "Release notes",
+          "description": "Specifies optional release notes."
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "additionalItems": false,
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
           "items": {
             "$ref": "#/definitions/property"
           }
         },
+        "tags": {
+          "$ref": "#/definitions/tags",
+          "title": "Tags"
+        },
         "signature": {
           "$ref": "#/definitions/signature",
-          "title": "Signature"
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
         }
       }
     },
     "serviceData": {
       "type": "object",
-      "title": "Service Data",
+      "title": "Hash Objects",
       "required": [
         "flow",
         "classification"
@@ -1744,11 +2500,67 @@
       "properties": {
         "flow": {
           "$ref": "#/definitions/dataFlowDirection",
-          "title": "Directional Flow"
+          "title": "Directional Flow",
+          "description": "Specifies the flow direction of the data. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways and unknown states that the direction is not known."
         },
         "classification": {
+          "$ref": "#/definitions/dataClassification"
+        },
+        "name": {
           "type": "string",
-          "title": "Classification"
+          "title": "Name",
+          "description": "Name for the defined data",
+          "examples": [
+            "Credit card reporting"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Short description of the data content and usage",
+          "examples": [
+            "Credit card information being exchanged in between the web app and the database"
+          ]
+        },
+        "governance": {
+          "title": "Data Governance",
+          "$ref": "#/definitions/dataGovernance"
+        },
+        "source": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "title": "URL",
+                "type": "string",
+                "format": "iri-reference"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "#/definitions/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "Source",
+          "description": "The URI, URL, or BOM-Link of the components or services the data came in from"
+        },
+        "destination": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "title": "URL",
+                "type": "string",
+                "format": "iri-reference"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "#/definitions/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "Destination",
+          "description": "The URI, URL, or BOM-Link of the components or services the data is sent to"
         }
       }
     },
@@ -1760,11 +2572,19 @@
         "bi-directional",
         "unknown"
       ],
-      "title": "Data flow direction"
+      "meta:enum": {
+        "inbound": "Data that enters a service.",
+        "outbound": "Data that exits a service.",
+        "bi-directional": "Data flows in and out of the service.",
+        "unknown": "The directional flow of data is not known."
+      },
+      "title": "Data flow direction",
+      "description": "Specifies the flow direction of the data. Direction is relative to the service."
     },
     "copyright": {
       "type": "object",
       "title": "Copyright",
+      "description": "A copyright notice informing users of the underlying claims to copyright ownership in a published work.",
       "required": [
         "text"
       ],
@@ -1772,30 +2592,156 @@
       "properties": {
         "text": {
           "type": "string",
-          "title": "Copyright Text"
+          "title": "Copyright Text",
+          "description": "The textual content of the copyright."
         }
       }
     },
     "componentEvidence": {
       "type": "object",
       "title": "Evidence",
+      "description": "Provides the ability to document evidence collected through various forms of extraction or analysis.",
       "additionalProperties": false,
       "properties": {
-        "licenses": {
+        "identity": {
+          "title": "Identity Evidence",
+          "description": "Evidence that substantiates the identity of a component. The identity may be an object or an array of identity objects. Support for specifying identity as a single object was introduced in CycloneDX v1.5. Arrays were introduced in v1.6. It is recommended that all implementations use arrays, even if only one identity object is specified.",
+          "oneOf": [
+            {
+              "type": "array",
+              "title": "Array of Identity Objects",
+              "items": {
+                "$ref": "#/definitions/componentIdentityEvidence"
+              }
+            },
+            {
+              "title": "A Single Identity Object",
+              "description": "[Deprecated]",
+              "$ref": "#/definitions/componentIdentityEvidence",
+              "deprecated": true
+            }
+          ]
+        },
+        "occurrences": {
           "type": "array",
-          "additionalItems": false,
+          "title": "Occurrences",
+          "description": "Evidence of individual instances of a component spread across multiple locations.",
+          "items": {
+            "type": "object",
+            "required": [
+              "location"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An optional identifier which can be used to reference the occurrence elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+              },
+              "location": {
+                "type": "string",
+                "title": "Location",
+                "description": "The location or path to where the component was found."
+              },
+              "line": {
+                "type": "integer",
+                "minimum": 0,
+                "title": "Line Number",
+                "description": "The line number where the component was found."
+              },
+              "offset": {
+                "type": "integer",
+                "minimum": 0,
+                "title": "Offset",
+                "description": "The offset where the component was found."
+              },
+              "symbol": {
+                "type": "string",
+                "title": "Symbol",
+                "description": "The symbol name that was found associated with the component."
+              },
+              "additionalContext": {
+                "type": "string",
+                "title": "Additional Context",
+                "description": "Any additional context of the detected component (e.g. a code snippet)."
+              }
+            }
+          }
+        },
+        "callstack": {
+          "type": "object",
+          "title": "Call Stack",
+          "description": "Evidence of the components use through the callstack.",
+          "additionalProperties": false,
+          "properties": {
+            "frames": {
+              "type": "array",
+              "title": "Frames",
+              "description": "Within a call stack, a frame is a discrete unit that encapsulates an execution context, including local variables, parameters, and the return address. As function calls are made, frames are pushed onto the stack, forming an array-like structure that orchestrates the flow of program execution and manages the sequence of function invocations.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "module"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "package": {
+                    "title": "Package",
+                    "description": "A package organizes modules into namespaces, providing a unique namespace for each type it contains.",
+                    "type": "string"
+                  },
+                  "module": {
+                    "title": "Module",
+                    "description": "A module or class that encloses functions/methods and other code.",
+                    "type": "string"
+                  },
+                  "function": {
+                    "title": "Function",
+                    "description": "A block of code designed to perform a particular task.",
+                    "type": "string"
+                  },
+                  "parameters": {
+                    "title": "Parameters",
+                    "description": "Optional arguments that are passed to the module or function.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "line": {
+                    "title": "Line",
+                    "description": "The line number the code that is called resides on.",
+                    "type": "integer"
+                  },
+                  "column": {
+                    "title": "Column",
+                    "description": "The column the code that is called resides.",
+                    "type": "integer"
+                  },
+                  "fullFilename": {
+                    "title": "Full Filename",
+                    "description": "The full path and filename of the module.",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "licenses": {
+          "title": "License Evidence",
+          "type": "array",
           "items": {
             "$ref": "#/definitions/licenseChoice"
-          },
-          "title": "Component License(s)"
+          }
         },
         "copyright": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/copyright"
           },
-          "title": "Copyright"
+          "title": "Copyright Evidence",
+          "description": "Copyright evidence captures intellectual property assertions, providing evidence of possible ownership and legal protection."
         }
       }
     },
@@ -1810,19 +2756,31 @@
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
-          "title": "BOM Reference"
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the composition elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "aggregate": {
           "$ref": "#/definitions/aggregateType",
-          "title": "Aggregate"
+          "title": "Aggregate",
+          "description": "Specifies an aggregate type that describe how complete a relationship is."
         },
         "assemblies": {
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "anyOf": [
+              {
+                "title": "Ref",
+                "$ref": "#/definitions/refLinkType"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "#/definitions/bomLinkElementType"
+              }
+            ]
           },
-          "title": "BOM references"
+          "title": "BOM references",
+          "description": "The bom-ref identifiers of the components or services being described. Assemblies refer to nested relationships whereby a constituent part may include other constituent parts. References do not cascade to child parts. References are explicit for the specified constituent part only."
         },
         "dependencies": {
           "type": "array",
@@ -1830,7 +2788,8 @@
           "items": {
             "type": "string"
           },
-          "title": "BOM references"
+          "title": "BOM references",
+          "description": "The bom-ref identifiers of the components or services being described. Dependencies refer to a relationship whereby an independent constituent part requires another independent constituent part. References do not cascade to transitive dependencies. References are explicit for the specified dependency only."
         },
         "vulnerabilities": {
           "type": "array",
@@ -1838,11 +2797,13 @@
           "items": {
             "type": "string"
           },
-          "title": "Vulnerabilities"
+          "title": "BOM references",
+          "description": "The bom-ref identifiers of the vulnerabilities being described."
         },
         "signature": {
           "$ref": "#/definitions/signature",
-          "title": "Signature"
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
         }
       }
     },
@@ -1853,23 +2814,44 @@
         "complete",
         "incomplete",
         "incomplete_first_party_only",
+        "incomplete_first_party_proprietary_only",
+        "incomplete_first_party_opensource_only",
         "incomplete_third_party_only",
+        "incomplete_third_party_proprietary_only",
+        "incomplete_third_party_opensource_only",
         "unknown",
         "not_specified"
       ],
-      "additionalProperties": false
+      "meta:enum": {
+        "complete": "The relationship is complete. No further relationships including constituent components, services, or dependencies are known to exist.",
+        "incomplete": "The relationship is incomplete. Additional relationships exist and may include constituent components, services, or dependencies.",
+        "incomplete_first_party_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented.",
+        "incomplete_first_party_proprietary_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.",
+        "incomplete_first_party_opensource_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are opensource.",
+        "incomplete_third_party_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented.",
+        "incomplete_third_party_proprietary_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.",
+        "incomplete_third_party_opensource_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are opensource.",
+        "unknown": "The relationship may be complete or incomplete. This usually signifies a 'best-effort' to obtain constituent components, services, or dependencies but the completeness is inconclusive.",
+        "not_specified": "The relationship completeness is not specified."
+      }
     },
     "property": {
       "type": "object",
       "title": "Lightweight name-value pair",
+      "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+      "required": [
+        "name"
+      ],
       "properties": {
         "name": {
           "type": "string",
-          "title": "Name"
+          "title": "Name",
+          "description": "The name of the property. Duplicate names are allowed, each potentially having a different value."
         },
         "value": {
           "type": "string",
-          "title": "Value"
+          "title": "Value",
+          "description": "The value of the property."
         }
       },
       "additionalProperties": false
@@ -1878,7 +2860,7 @@
       "type": "string",
       "pattern": "^([a-z]{2})(-[A-Z]{2})?$",
       "title": "Locale",
-      "additionalProperties": false
+      "description": "Defines a syntax for representing two character language code (ISO-639) followed by an optional two character country code. The language code must be lower case. If the country code is specified, the country code must be upper case. The language code and country code must be separated by a minus sign. Examples: en, en-US, fr, fr-CA"
     },
     "releaseType": {
       "type": "string",
@@ -1889,11 +2871,12 @@
         "pre-release",
         "internal"
       ],
-      "additionalProperties": false
+      "description": "The software versioning type. It is recommended that the release type use one of 'major', 'minor', 'patch', 'pre-release', or 'internal'. Representing all possible software release types is not practical, so standardizing on the recommended values, whenever possible, is strongly encouraged.\n\n* __major__ = A major release may contain significant changes or may introduce breaking changes.\n* __minor__ = A minor release, also known as an update, may contain a smaller number of changes than major releases.\n* __patch__ = Patch releases are typically unplanned and may resolve defects or important security issues.\n* __pre-release__ = A pre-release may include alpha, beta, or release candidates and typically have limited support. They provide the ability to preview a release prior to its general availability.\n* __internal__ = Internal releases are not for public consumption and are intended to be used exclusively by the project or manufacturer that produced it."
     },
     "note": {
       "type": "object",
       "title": "Note",
+      "description": "A note containing the locale and content.",
       "required": [
         "text"
       ],
@@ -1901,10 +2884,12 @@
       "properties": {
         "locale": {
           "$ref": "#/definitions/localeType",
-          "title": "Locale"
+          "title": "Locale",
+          "description": "The ISO-639 (or higher) language code and optional ISO-3166 (or higher) country code. Examples include: \"en\", \"en-US\", \"fr\" and \"fr-CA\""
         },
         "text": {
           "title": "Release note content",
+          "description": "Specifies the full content of the release note.",
           "$ref": "#/definitions/attachment"
         }
       }
@@ -1919,65 +2904,69 @@
       "properties": {
         "type": {
           "$ref": "#/definitions/releaseType",
-          "title": "Type"
+          "title": "Type",
+          "description": "The software versioning type the release note describes."
         },
         "title": {
           "type": "string",
-          "title": "Title"
+          "title": "Title",
+          "description": "The title of the release."
         },
         "featuredImage": {
           "type": "string",
           "format": "iri-reference",
-          "title": "Featured image"
+          "title": "Featured image",
+          "description": "The URL to an image that may be prominently displayed with the release note."
         },
         "socialImage": {
           "type": "string",
           "format": "iri-reference",
-          "title": "Social image"
+          "title": "Social image",
+          "description": "The URL to an image that may be used in messaging on social media platforms."
         },
         "description": {
           "type": "string",
-          "title": "Description"
+          "title": "Description",
+          "description": "A short description of the release."
         },
         "timestamp": {
           "type": "string",
           "format": "date-time",
-          "title": "Timestamp"
+          "title": "Timestamp",
+          "description": "The date and time (timestamp) when the release note was created."
         },
         "aliases": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "title": "Aliases"
+          "title": "Aliases",
+          "description": "One or more alternate names the release may be referred to. This may include unofficial terms used by development and marketing teams (e.g. code names)."
         },
         "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "$ref": "#/definitions/tags",
           "title": "Tags"
         },
         "resolves": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/issue"
           },
-          "title": "Resolves"
+          "title": "Resolves",
+          "description": "A collection of issues that have been resolved."
         },
         "notes": {
           "type": "array",
-          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/note"
           },
-          "title": "Notes"
+          "title": "Notes",
+          "description": "Zero or more release notes containing the locale and content. Multiple note objects may be specified to support release notes in a wide variety of languages."
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "additionalItems": false,
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -1987,6 +2976,7 @@
     "advisory": {
       "type": "object",
       "title": "Advisory",
+      "description": "Title and location where advisory information can be obtained. An advisory is a notification of a threat to a component, service, or system.",
       "required": [
         "url"
       ],
@@ -1994,12 +2984,14 @@
       "properties": {
         "title": {
           "type": "string",
-          "title": "Title"
+          "title": "Title",
+          "description": "An optional name of the advisory."
         },
         "url": {
           "type": "string",
           "title": "URL",
-          "format": "iri-reference"
+          "format": "iri-reference",
+          "description": "Location where the advisory can be obtained."
         }
       }
     },
@@ -2007,11 +2999,12 @@
       "type": "integer",
       "minimum": 1,
       "title": "CWE",
-      "additionalProperties": false
+      "description": "Integer representation of a Common Weaknesses Enumerations (CWE). For example 399 (of https://cwe.mitre.org/data/definitions/399.html)"
     },
     "severity": {
       "type": "string",
       "title": "Severity",
+      "description": "Textual representation of the severity of the vulnerability adopted by the analysis method. If the analysis method uses values other than what is provided, the user is expected to translate appropriately.",
       "enum": [
         "critical",
         "high",
@@ -2021,23 +3014,43 @@
         "none",
         "unknown"
       ],
-      "additionalProperties": false
+      "meta:enum": {
+        "critical": "Critical severity",
+        "high": "High severity",
+        "medium": "Medium severity",
+        "low": "Low severity",
+        "info": "Informational warning.",
+        "none": "None",
+        "unknown": "The severity is not known"
+      }
     },
     "scoreMethod": {
       "type": "string",
       "title": "Method",
+      "description": "Specifies the severity or risk scoring methodology or standard used.",
       "enum": [
         "CVSSv2",
         "CVSSv3",
         "CVSSv31",
+        "CVSSv4",
         "OWASP",
+        "SSVC",
         "other"
       ],
-      "additionalProperties": false
+      "meta:enum": {
+        "CVSSv2": "Common Vulnerability Scoring System v2.0",
+        "CVSSv3": "Common Vulnerability Scoring System v3.0",
+        "CVSSv31": "Common Vulnerability Scoring System v3.1",
+        "CVSSv4": "Common Vulnerability Scoring System v4.0",
+        "OWASP": "OWASP Risk Rating Methodology",
+        "SSVC": "Stakeholder Specific Vulnerability Categorization",
+        "other": "Another severity or risk scoring methodology"
+      }
     },
     "impactAnalysisState": {
       "type": "string",
       "title": "Impact Analysis State",
+      "description": "Declares the current state of an occurrence of a vulnerability, after automated or manual analysis.",
       "enum": [
         "resolved",
         "resolved_with_pedigree",
@@ -2046,11 +3059,19 @@
         "false_positive",
         "not_affected"
       ],
-      "additionalProperties": false
+      "meta:enum": {
+        "resolved": "The vulnerability has been remediated.",
+        "resolved_with_pedigree": "The vulnerability has been remediated and evidence of the changes are provided in the affected components pedigree containing verifiable commit history and/or diff(s).",
+        "exploitable": "The vulnerability may be directly or indirectly exploitable.",
+        "in_triage": "The vulnerability is being investigated.",
+        "false_positive": "The vulnerability is not specific to the component or service and was falsely identified or associated.",
+        "not_affected": "The component or service is not affected by the vulnerability. Justification should be specified for all not_affected cases."
+      }
     },
     "impactAnalysisJustification": {
       "type": "string",
       "title": "Impact Analysis Justification",
+      "description": "The rationale of why the impact analysis state was asserted.",
       "enum": [
         "code_not_present",
         "code_not_reachable",
@@ -2062,72 +3083,111 @@
         "protected_at_perimeter",
         "protected_by_mitigating_control"
       ],
-      "additionalProperties": false
+      "meta:enum": {
+        "code_not_present": "The code has been removed or tree-shaked.",
+        "code_not_reachable": "The vulnerable code is not invoked at runtime.",
+        "requires_configuration": "Exploitability requires a configurable option to be set/unset.",
+        "requires_dependency": "Exploitability requires a dependency that is not present.",
+        "requires_environment": "Exploitability requires a certain environment which is not present.",
+        "protected_by_compiler": "Exploitability requires a compiler flag to be set/unset.",
+        "protected_at_runtime": "Exploits are prevented at runtime.",
+        "protected_at_perimeter": "Attacks are blocked at physical, logical, or network perimeter.",
+        "protected_by_mitigating_control": "Preventative measures have been implemented that reduce the likelihood and/or impact of the vulnerability."
+      }
     },
     "rating": {
       "type": "object",
       "title": "Rating",
+      "description": "Defines the severity or risk ratings of a vulnerability.",
       "additionalProperties": false,
       "properties": {
         "source": {
-          "$ref": "#/definitions/vulnerabilitySource"
+          "$ref": "#/definitions/vulnerabilitySource",
+          "description": "The source that calculated the severity or risk rating of the vulnerability."
         },
         "score": {
           "type": "number",
-          "title": "Score"
+          "title": "Score",
+          "description": "The numerical score of the rating."
         },
         "severity": {
-          "$ref": "#/definitions/severity"
+          "$ref": "#/definitions/severity",
+          "description": "Textual representation of the severity that corresponds to the numerical score of the rating."
         },
         "method": {
           "$ref": "#/definitions/scoreMethod"
         },
         "vector": {
           "type": "string",
-          "title": "Vector"
+          "title": "Vector",
+          "description": "Textual representation of the metric values used to score the vulnerability"
         },
         "justification": {
           "type": "string",
-          "title": "Justification"
+          "title": "Justification",
+          "description": "An optional reason for rating the vulnerability as it was"
         }
       }
     },
     "vulnerabilitySource": {
       "type": "object",
       "title": "Source",
+      "description": "The source of vulnerability information. This is often the organization that published the vulnerability.",
       "additionalProperties": false,
       "properties": {
         "url": {
           "type": "string",
-          "title": "URL"
+          "title": "URL",
+          "description": "The url of the vulnerability documentation as provided by the source.",
+          "examples": [
+            "https://nvd.nist.gov/vuln/detail/CVE-2021-39182"
+          ]
         },
         "name": {
           "type": "string",
-          "title": "Name"
+          "title": "Name",
+          "description": "The name of the source.",
+          "examples": [
+            "NVD",
+            "National Vulnerability Database",
+            "OSS Index",
+            "VulnDB",
+            "GitHub Advisories"
+          ]
         }
       }
     },
     "vulnerability": {
       "type": "object",
       "title": "Vulnerability",
+      "description": "Defines a weakness in a component or service that could be exploited or triggered by a threat source.",
       "additionalProperties": false,
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
-          "title": "BOM Reference"
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the vulnerability elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "id": {
           "type": "string",
-          "title": "ID"
+          "title": "ID",
+          "description": "The identifier that uniquely identifies the vulnerability.",
+          "examples": [
+            "CVE-2021-39182",
+            "GHSA-35m5-8cvj-8783",
+            "SNYK-PYTHON-ENROCRYPT-1912876"
+          ]
         },
         "source": {
-          "$ref": "#/definitions/vulnerabilitySource"
+          "$ref": "#/definitions/vulnerabilitySource",
+          "description": "The source that published the vulnerability."
         },
         "references": {
           "type": "array",
           "title": "References",
-          "additionalItems": false,
+          "description": "Zero or more pointers to vulnerabilities that are the equivalent of the vulnerability specified. Often times, the same vulnerability may exist in multiple sources of vulnerability intelligence, but have different identifiers. References provide a way to correlate vulnerabilities across multiple sources of vulnerability intelligence.",
           "items": {
+            "type": "object",
             "required": [
               "id",
               "source"
@@ -2136,10 +3196,17 @@
             "properties": {
               "id": {
                 "type": "string",
-                "title": "ID"
+                "title": "ID",
+                "description": "An identifier that uniquely identifies the vulnerability.",
+                "examples": [
+                  "CVE-2021-39182",
+                  "GHSA-35m5-8cvj-8783",
+                  "SNYK-PYTHON-ENROCRYPT-1912876"
+                ]
               },
               "source": {
-                "$ref": "#/definitions/vulnerabilitySource"
+                "$ref": "#/definitions/vulnerabilitySource",
+                "description": "The source that published the vulnerability."
               }
             }
           }
@@ -2147,7 +3214,7 @@
         "ratings": {
           "type": "array",
           "title": "Ratings",
-          "additionalItems": false,
+          "description": "List of vulnerability ratings",
           "items": {
             "$ref": "#/definitions/rating"
           }
@@ -2155,27 +3222,63 @@
         "cwes": {
           "type": "array",
           "title": "CWEs",
-          "additionalItems": false,
+          "description": "List of Common Weaknesses Enumerations (CWEs) codes that describes this vulnerability.",
+          "examples": [
+            399
+          ],
           "items": {
             "$ref": "#/definitions/cwe"
           }
         },
         "description": {
           "type": "string",
-          "title": "Description"
+          "title": "Description",
+          "description": "A description of the vulnerability as provided by the source."
         },
         "detail": {
           "type": "string",
-          "title": "Details"
+          "title": "Details",
+          "description": "If available, an in-depth description of the vulnerability as provided by the source organization. Details often include information useful in understanding root cause."
         },
         "recommendation": {
           "type": "string",
-          "title": "Recommendation"
+          "title": "Recommendation",
+          "description": "Recommendations of how the vulnerability can be remediated or mitigated."
+        },
+        "workaround": {
+          "type": "string",
+          "title": "Workarounds",
+          "description": "A bypass, usually temporary, of the vulnerability that reduces its likelihood and/or impact. Workarounds often involve changes to configuration or deployments."
+        },
+        "proofOfConcept": {
+          "type": "object",
+          "title": "Proof of Concept",
+          "description": "Evidence used to reproduce the vulnerability.",
+          "properties": {
+            "reproductionSteps": {
+              "type": "string",
+              "title": "Steps to Reproduce",
+              "description": "Precise steps to reproduce the vulnerability."
+            },
+            "environment": {
+              "type": "string",
+              "title": "Environment",
+              "description": "A description of the environment in which reproduction was possible."
+            },
+            "supportingMaterial": {
+              "type": "array",
+              "title": "Supporting Material",
+              "description": "Supporting material that helps in reproducing or understanding how reproduction is possible. This may include screenshots, payloads, and PoC exploit code.",
+              "items": {
+                "$ref": "#/definitions/attachment"
+              }
+            }
+          }
         },
         "advisories": {
           "type": "array",
           "title": "Advisories",
-          "additionalItems": false,
+          "description": "Published advisories of the vulnerability if provided.",
           "items": {
             "$ref": "#/definitions/advisory"
           }
@@ -2183,27 +3286,37 @@
         "created": {
           "type": "string",
           "format": "date-time",
-          "title": "Created"
+          "title": "Created",
+          "description": "The date and time (timestamp) when the vulnerability record was created in the vulnerability database."
         },
         "published": {
           "type": "string",
           "format": "date-time",
-          "title": "Published"
+          "title": "Published",
+          "description": "The date and time (timestamp) when the vulnerability record was first published."
         },
         "updated": {
           "type": "string",
           "format": "date-time",
-          "title": "Updated"
+          "title": "Updated",
+          "description": "The date and time (timestamp) when the vulnerability record was last updated."
+        },
+        "rejected": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Rejected",
+          "description": "The date and time (timestamp) when the vulnerability record was rejected (if applicable)."
         },
         "credits": {
           "type": "object",
           "title": "Credits",
+          "description": "Individuals or organizations credited with the discovery of the vulnerability.",
           "additionalProperties": false,
           "properties": {
             "organizations": {
               "type": "array",
               "title": "Organizations",
-              "additionalItems": false,
+              "description": "The organizations credited with vulnerability discovery.",
               "items": {
                 "$ref": "#/definitions/organizationalEntity"
               }
@@ -2211,7 +3324,7 @@
             "individuals": {
               "type": "array",
               "title": "Individuals",
-              "additionalItems": false,
+              "description": "The individuals, not associated with organizations, that are credited with vulnerability discovery.",
               "items": {
                 "$ref": "#/definitions/organizationalContact"
               }
@@ -2219,16 +3332,49 @@
           }
         },
         "tools": {
-          "type": "array",
-          "title": "Creation Tools",
-          "additionalItems": false,
-          "items": {
-            "$ref": "#/definitions/tool"
-          }
+          "title": "Tools",
+          "description": "The tool(s) used to identify, confirm, or score the vulnerability.",
+          "oneOf": [
+            {
+              "type": "object",
+              "title": "Tools",
+              "description": "The tool(s) used to identify, confirm, or score the vulnerability.",
+              "additionalProperties": false,
+              "properties": {
+                "components": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/component"
+                  },
+                  "uniqueItems": true,
+                  "title": "Components",
+                  "description": "A list of software and hardware components used as tools."
+                },
+                "services": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/service"
+                  },
+                  "uniqueItems": true,
+                  "title": "Services",
+                  "description": "A list of services used as tools. This may include microservices, function-as-a-service, and other types of network or intra-process services."
+                }
+              }
+            },
+            {
+              "type": "array",
+              "title": "Tools (legacy)",
+              "description": "[Deprecated] The tool(s) used to identify, confirm, or score the vulnerability.",
+              "items": {
+                "$ref": "#/definitions/tool"
+              }
+            }
+          ]
         },
         "analysis": {
           "type": "object",
           "title": "Impact Analysis",
+          "description": "An assessment of the impact and exploitability of the vulnerability.",
           "additionalProperties": false,
           "properties": {
             "state": {
@@ -2240,7 +3386,7 @@
             "response": {
               "type": "array",
               "title": "Response",
-              "additionalItems": false,
+              "description": "A response to the vulnerability by the manufacturer, supplier, or project responsible for the affected component or service. More than one response is allowed. Responses are strongly encouraged for vulnerabilities where the analysis state is exploitable.",
               "items": {
                 "type": "string",
                 "enum": [
@@ -2249,34 +3395,65 @@
                   "update",
                   "rollback",
                   "workaround_available"
-                ]
+                ],
+                "meta:enum": {
+                  "can_not_fix": "Can not fix",
+                  "will_not_fix": "Will not fix",
+                  "update": "Update to a different revision or release",
+                  "rollback": "Revert to a previous revision or release",
+                  "workaround_available": "There is a workaround available"
+                }
               }
             },
             "detail": {
               "type": "string",
-              "title": "Detail"
+              "title": "Detail",
+              "description": "Detailed description of the impact including methods used during assessment. If a vulnerability is not exploitable, this field should include specific details on why the component or service is not impacted by this vulnerability."
+            },
+            "firstIssued": {
+              "type": "string",
+              "format": "date-time",
+              "title": "First Issued",
+              "description": "The date and time (timestamp) when the analysis was first issued."
+            },
+            "lastUpdated": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Last Updated",
+              "description": "The date and time (timestamp) when the analysis was last updated."
             }
           }
         },
         "affects": {
           "type": "array",
           "uniqueItems": true,
-          "additionalItems": false,
           "items": {
+            "type": "object",
             "required": [
               "ref"
             ],
             "additionalProperties": false,
             "properties": {
               "ref": {
-                "$ref": "#/definitions/refType",
-                "title": "Reference"
+                "anyOf": [
+                  {
+                    "title": "Ref",
+                    "$ref": "#/definitions/refLinkType"
+                  },
+                  {
+                    "title": "BOM-Link Element",
+                    "$ref": "#/definitions/bomLinkElementType"
+                  }
+                ],
+                "title": "Reference",
+                "description": "References a component or service by the objects bom-ref"
               },
               "versions": {
                 "type": "array",
                 "title": "Versions",
-                "additionalItems": false,
+                "description": "Zero or more individual versions or range of versions.",
                 "items": {
+                  "type": "object",
                   "oneOf": [
                     {
                       "required": [
@@ -2292,12 +3469,18 @@
                   "additionalProperties": false,
                   "properties": {
                     "version": {
+                      "title": "Version",
+                      "description": "A single version of a component or service.",
                       "$ref": "#/definitions/version"
                     },
                     "range": {
-                      "$ref": "#/definitions/version"
+                      "title": "Version Range",
+                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst",
+                      "$ref": "#/definitions/versionRange"
                     },
                     "status": {
+                      "title": "Status",
+                      "description": "The vulnerability status for the version or range of versions.",
                       "$ref": "#/definitions/affectedStatus",
                       "default": "affected"
                     }
@@ -2306,12 +3489,13 @@
               }
             }
           },
-          "title": "Affects"
+          "title": "Affects",
+          "description": "The components or services that are affected by the vulnerability."
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "additionalItems": false,
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -2319,30 +3503,2865 @@
       }
     },
     "affectedStatus": {
+      "description": "The vulnerability status of a given version or range of versions of a product. The statuses 'affected' and 'unaffected' indicate that the version is affected or unaffected by the vulnerability. The status 'unknown' indicates that it is unknown or unspecified whether the given version is affected. There can be many reasons for an 'unknown' status, including that an investigation has not been undertaken or that a vendor has not disclosed the status.",
       "type": "string",
       "enum": [
         "affected",
         "unaffected",
         "unknown"
       ],
-      "additionalProperties": false
+      "meta:enum": {
+        "affected": "The version is affected by the vulnerability.",
+        "unaffected": "The version is not affected by the vulnerability.",
+        "unknown": "It is unknown (or unspecified) whether the given version is affected."
+      }
     },
     "version": {
+      "description": "A single disjunctive version identifier, for a component or service.",
+      "type": "string",
+      "maxLength": 1024,
+      "examples": [
+        "9.0.14",
+        "v1.33.7",
+        "7.0.0-M1",
+        "2.0pre1",
+        "1.0.0-beta1",
+        "0.8.15"
+      ],
+      "minLength": 1
+    },
+    "versionRange": {
+      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst",
       "type": "string",
       "minLength": 1,
-      "maxLength": 1024,
-      "additionalProperties": false
+      "maxLength": 4096,
+      "examples": [
+        "vers:cargo/9.0.14",
+        "vers:npm/1.2.3|>=2.0.0|<5.0.0",
+        "vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|1.0|2.0pre1",
+        "vers:tomee/>=1.0.0-beta1|<=1.7.5|>=7.0.0-M1|<=7.0.7|>=7.1.0|<=7.1.2|>=8.0.0-M1|<=8.0.1",
+        "vers:gem/>=2.2.0|!= 2.2.1|<2.3.0"
+      ]
     },
     "range": {
+      "deprecated": true,
+      "description": "Deprecated definition. use definition `versionRange` instead.",
+      "$ref": "#/definitions/versionRange"
+    },
+    "annotations": {
+      "type": "object",
+      "title": "Annotations",
+      "description": "A comment, note, explanation, or similar textual content which provides additional context to the object(s) being annotated.",
+      "required": [
+        "subjects",
+        "annotator",
+        "timestamp",
+        "text"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the annotation elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "subjects": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "anyOf": [
+              {
+                "title": "Ref",
+                "$ref": "#/definitions/refLinkType"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "#/definitions/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "Subjects",
+          "description": "The object in the BOM identified by its bom-ref. This is often a component or service, but may be any object type supporting bom-refs."
+        },
+        "annotator": {
+          "type": "object",
+          "title": "Annotator",
+          "description": "The organization, person, component, or service which created the textual content of the annotation.",
+          "oneOf": [
+            {
+              "required": [
+                "organization"
+              ]
+            },
+            {
+              "required": [
+                "individual"
+              ]
+            },
+            {
+              "required": [
+                "component"
+              ]
+            },
+            {
+              "required": [
+                "service"
+              ]
+            }
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "organization": {
+              "description": "The organization that created the annotation",
+              "$ref": "#/definitions/organizationalEntity"
+            },
+            "individual": {
+              "description": "The person that created the annotation",
+              "$ref": "#/definitions/organizationalContact"
+            },
+            "component": {
+              "description": "The tool or component that created the annotation",
+              "$ref": "#/definitions/component"
+            },
+            "service": {
+              "description": "The service that created the annotation",
+              "$ref": "#/definitions/service"
+            }
+          }
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The date and time (timestamp) when the annotation was created."
+        },
+        "text": {
+          "type": "string",
+          "title": "Text",
+          "description": "The textual content of the annotation."
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    },
+    "modelCard": {
+      "$comment": "Model card support in CycloneDX is derived from TensorFlow Model Card Toolkit released under the Apache 2.0 license and available from https://github.com/tensorflow/model-card-toolkit/blob/main/model_card_toolkit/schema/v0.0.2/model_card.schema.json. In addition, CycloneDX model card support includes portions of VerifyML, also released under the Apache 2.0 license and available from https://github.com/cylynx/verifyml/blob/main/verifyml/model_card_toolkit/schema/v0.0.4/model_card.schema.json.",
+      "type": "object",
+      "title": "Model Card",
+      "description": "A model card describes the intended uses of a machine learning model and potential limitations, including biases and ethical considerations. Model cards typically contain the training parameters, which datasets were used to train the model, performance metrics, and other relevant data useful for ML transparency. This object SHOULD be specified for any component of type `machine-learning-model` and must not be specified for other component types.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the model card elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "modelParameters": {
+          "type": "object",
+          "title": "Model Parameters",
+          "description": "Hyper-parameters for construction of the model.",
+          "additionalProperties": false,
+          "properties": {
+            "approach": {
+              "type": "object",
+              "title": "Approach",
+              "description": "The overall approach to learning used by the model for problem solving.",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "title": "Learning Type",
+                  "description": "Learning types describing the learning problem or hybrid learning problem.",
+                  "enum": [
+                    "supervised",
+                    "unsupervised",
+                    "reinforcement-learning",
+                    "semi-supervised",
+                    "self-supervised"
+                  ],
+                  "meta:enum": {
+                    "supervised": "Supervised machine learning involves training an algorithm on labeled data to predict or classify new data based on the patterns learned from the labeled examples.",
+                    "unsupervised": "Unsupervised machine learning involves training algorithms on unlabeled data to discover patterns, structures, or relationships without explicit guidance, allowing the model to identify inherent structures or clusters within the data.",
+                    "reinforcement-learning": "Reinforcement learning is a type of machine learning where an agent learns to make decisions by interacting with an environment to maximize cumulative rewards, through trial and error.",
+                    "semi-supervised": "Semi-supervised machine learning utilizes a combination of labeled and unlabeled data during training to improve model performance, leveraging the benefits of both supervised and unsupervised learning techniques.",
+                    "self-supervised": "Self-supervised machine learning involves training models to predict parts of the input data from other parts of the same data, without requiring external labels, enabling learning from large amounts of unlabeled data."
+                  }
+                }
+              }
+            },
+            "task": {
+              "type": "string",
+              "title": "Task",
+              "description": "Directly influences the input and/or output. Examples include classification, regression, clustering, etc."
+            },
+            "architectureFamily": {
+              "type": "string",
+              "title": "Architecture Family",
+              "description": "The model architecture family such as transformer network, convolutional neural network, residual neural network, LSTM neural network, etc."
+            },
+            "modelArchitecture": {
+              "type": "string",
+              "title": "Model Architecture",
+              "description": "The specific architecture of the model such as GPT-1, ResNet-50, YOLOv3, etc."
+            },
+            "datasets": {
+              "type": "array",
+              "title": "Datasets",
+              "description": "The datasets used to train and evaluate the model.",
+              "items": {
+                "oneOf": [
+                  {
+                    "title": "Inline Data Information",
+                    "$ref": "#/definitions/componentData"
+                  },
+                  {
+                    "type": "object",
+                    "title": "Data Reference",
+                    "additionalProperties": false,
+                    "properties": {
+                      "ref": {
+                        "anyOf": [
+                          {
+                            "title": "Ref",
+                            "$ref": "#/definitions/refLinkType"
+                          },
+                          {
+                            "title": "BOM-Link Element",
+                            "$ref": "#/definitions/bomLinkElementType"
+                          }
+                        ],
+                        "title": "Reference",
+                        "type": "string",
+                        "description": "References a data component by the components bom-ref attribute"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "inputs": {
+              "type": "array",
+              "title": "Inputs",
+              "description": "The input format(s) of the model",
+              "items": {
+                "$ref": "#/definitions/inputOutputMLParameters"
+              }
+            },
+            "outputs": {
+              "type": "array",
+              "title": "Outputs",
+              "description": "The output format(s) from the model",
+              "items": {
+                "$ref": "#/definitions/inputOutputMLParameters"
+              }
+            }
+          }
+        },
+        "quantitativeAnalysis": {
+          "type": "object",
+          "title": "Quantitative Analysis",
+          "description": "A quantitative analysis of the model",
+          "additionalProperties": false,
+          "properties": {
+            "performanceMetrics": {
+              "type": "array",
+              "title": "Performance Metrics",
+              "description": "The model performance metrics being reported. Examples may include accuracy, F1 score, precision, top-3 error rates, MSC, etc.",
+              "items": {
+                "$ref": "#/definitions/performanceMetric"
+              }
+            },
+            "graphics": {
+              "$ref": "#/definitions/graphicsCollection"
+            }
+          }
+        },
+        "considerations": {
+          "type": "object",
+          "title": "Considerations",
+          "description": "What considerations should be taken into account regarding the model's construction, training, and application?",
+          "additionalProperties": false,
+          "properties": {
+            "users": {
+              "type": "array",
+              "title": "Users",
+              "description": "Who are the intended users of the model?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "useCases": {
+              "type": "array",
+              "title": "Use Cases",
+              "description": "What are the intended use cases of the model?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "technicalLimitations": {
+              "type": "array",
+              "title": "Technical Limitations",
+              "description": "What are the known technical limitations of the model? E.g. What kind(s) of data should the model be expected not to perform well on? What are the factors that might degrade model performance?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "performanceTradeoffs": {
+              "type": "array",
+              "title": "Performance Tradeoffs",
+              "description": "What are the known tradeoffs in accuracy/performance of the model?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ethicalConsiderations": {
+              "type": "array",
+              "title": "Ethical Considerations",
+              "description": "What are the ethical risks involved in the application of this model?",
+              "items": {
+                "$ref": "#/definitions/risk"
+              }
+            },
+            "environmentalConsiderations": {
+              "$ref": "#/definitions/environmentalConsiderations",
+              "title": "Environmental Considerations",
+              "description": "What are the various environmental impacts the corresponding machine learning model has exhibited across its lifecycle?"
+            },
+            "fairnessAssessments": {
+              "type": "array",
+              "title": "Fairness Assessments",
+              "description": "How does the model affect groups at risk of being systematically disadvantaged? What are the harms and benefits to the various affected groups?",
+              "items": {
+                "$ref": "#/definitions/fairnessAssessment"
+              }
+            }
+          }
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "inputOutputMLParameters": {
+      "type": "object",
+      "title": "Input and Output Parameters",
+      "additionalProperties": false,
+      "properties": {
+        "format": {
+          "title": "Input/Output Format",
+          "description": "The data format for input/output to the model.",
+          "type": "string",
+          "examples": [
+            "string",
+            "image",
+            "time-series"
+          ]
+        }
+      }
+    },
+    "componentData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the dataset elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "type": {
+          "type": "string",
+          "title": "Type of Data",
+          "description": "The general theme or subject matter of the data being specified.",
+          "enum": [
+            "source-code",
+            "configuration",
+            "dataset",
+            "definition",
+            "other"
+          ],
+          "meta:enum": {
+            "source-code": "Any type of code, code snippet, or data-as-code.",
+            "configuration": "Parameters or settings that may be used by other components.",
+            "dataset": "A collection of data.",
+            "definition": "Data that can be used to create new instances of what the definition defines.",
+            "other": "Any other type of data that does not fit into existing definitions."
+          }
+        },
+        "name": {
+          "title": "Dataset Name",
+          "description": "The name of the dataset.",
+          "type": "string"
+        },
+        "contents": {
+          "type": "object",
+          "title": "Data Contents",
+          "description": "The contents or references to the contents of the data being described.",
+          "additionalProperties": false,
+          "properties": {
+            "attachment": {
+              "title": "Data Attachment",
+              "description": "An optional way to include textual or encoded data.",
+              "$ref": "#/definitions/attachment"
+            },
+            "url": {
+              "type": "string",
+              "title": "Data URL",
+              "description": "The URL to where the data can be retrieved.",
+              "format": "iri-reference"
+            },
+            "properties": {
+              "type": "array",
+              "title": "Configuration Properties",
+              "description": "Provides the ability to document name-value parameters used for configuration.",
+              "items": {
+                "$ref": "#/definitions/property"
+              }
+            }
+          }
+        },
+        "classification": {
+          "$ref": "#/definitions/dataClassification"
+        },
+        "sensitiveData": {
+          "type": "array",
+          "title": "Sensitive Data",
+          "description": "A description of any sensitive data in a dataset.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "graphics": {
+          "$ref": "#/definitions/graphicsCollection"
+        },
+        "description": {
+          "title": "Dataset Description",
+          "description": "A description of the dataset. Can describe size of dataset, whether it's used for source code, training, testing, or validation, etc.",
+          "type": "string"
+        },
+        "governance": {
+          "title": "Data Governance",
+          "$ref": "#/definitions/dataGovernance"
+        }
+      }
+    },
+    "dataGovernance": {
+      "type": "object",
+      "title": "Data Governance",
+      "description": "Data governance captures information regarding data ownership, stewardship, and custodianship, providing insights into the individuals or entities responsible for managing, overseeing, and safeguarding the data throughout its lifecycle.",
+      "additionalProperties": false,
+      "properties": {
+        "custodians": {
+          "type": "array",
+          "title": "Data Custodians",
+          "description": "Data custodians are responsible for the safe custody, transport, and storage of data.",
+          "items": {
+            "$ref": "#/definitions/dataGovernanceResponsibleParty"
+          }
+        },
+        "stewards": {
+          "type": "array",
+          "title": "Data Stewards",
+          "description": "Data stewards are responsible for data content, context, and associated business rules.",
+          "items": {
+            "$ref": "#/definitions/dataGovernanceResponsibleParty"
+          }
+        },
+        "owners": {
+          "type": "array",
+          "title": "Data Owners",
+          "description": "Data owners are concerned with risk and appropriate access to data.",
+          "items": {
+            "$ref": "#/definitions/dataGovernanceResponsibleParty"
+          }
+        }
+      }
+    },
+    "dataGovernanceResponsibleParty": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "organization": {
+          "title": "Organization",
+          "description": "The organization that is responsible for specific data governance role(s).",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "contact": {
+          "title": "Individual",
+          "description": "The individual that is responsible for specific data governance role(s).",
+          "$ref": "#/definitions/organizationalContact"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "organization"
+          ]
+        },
+        {
+          "required": [
+            "contact"
+          ]
+        }
+      ]
+    },
+    "graphicsCollection": {
+      "type": "object",
+      "title": "Graphics Collection",
+      "description": "A collection of graphics that represent various measurements.",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "title": "Description",
+          "description": "A description of this collection of graphics.",
+          "type": "string"
+        },
+        "collection": {
+          "title": "Collection",
+          "description": "A collection of graphics.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/graphic"
+          }
+        }
+      }
+    },
+    "graphic": {
+      "type": "object",
+      "title": "Graphic",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The name of the graphic.",
+          "type": "string"
+        },
+        "image": {
+          "title": "Graphic Image",
+          "description": "The graphic (vector or raster). Base64 encoding must be specified for binary images.",
+          "$ref": "#/definitions/attachment"
+        }
+      }
+    },
+    "performanceMetric": {
+      "type": "object",
+      "title": "Performance Metric",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Type",
+          "description": "The type of performance metric.",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "description": "The value of the performance metric.",
+          "type": "string"
+        },
+        "slice": {
+          "title": "Slice",
+          "description": "The name of the slice this metric was computed on. By default, assume this metric is not sliced.",
+          "type": "string"
+        },
+        "confidenceInterval": {
+          "title": "Confidence Interval",
+          "description": "The confidence interval of the metric.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "lowerBound": {
+              "title": "Lower Bound",
+              "description": "The lower bound of the confidence interval.",
+              "type": "string"
+            },
+            "upperBound": {
+              "title": "Upper Bound",
+              "description": "The upper bound of the confidence interval.",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "risk": {
+      "type": "object",
+      "title": "Risk",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The name of the risk.",
+          "type": "string"
+        },
+        "mitigationStrategy": {
+          "title": "Mitigation Strategy",
+          "description": "Strategy used to address this risk.",
+          "type": "string"
+        }
+      }
+    },
+    "fairnessAssessment": {
+      "type": "object",
+      "title": "Fairness Assessment",
+      "description": "Information about the benefits and harms of the model to an identified at risk group.",
+      "additionalProperties": false,
+      "properties": {
+        "groupAtRisk": {
+          "type": "string",
+          "title": "Group at Risk",
+          "description": "The groups or individuals at risk of being systematically disadvantaged by the model."
+        },
+        "benefits": {
+          "type": "string",
+          "title": "Benefits",
+          "description": "Expected benefits to the identified groups."
+        },
+        "harms": {
+          "type": "string",
+          "title": "Harms",
+          "description": "Expected harms to the identified groups."
+        },
+        "mitigationStrategy": {
+          "type": "string",
+          "title": "Mitigation Strategy",
+          "description": "With respect to the benefits and harms outlined, please describe any mitigation strategy implemented."
+        }
+      }
+    },
+    "dataClassification": {
       "type": "string",
-      "minLength": 1,
-      "maxLength": 1024,
-      "additionalProperties": false
+      "title": "Data Classification",
+      "description": "Data classification tags data according to its type, sensitivity, and value if altered, stolen, or destroyed."
+    },
+    "environmentalConsiderations": {
+      "type": "object",
+      "title": "Environmental Considerations",
+      "description": "Describes various environmental impact metrics.",
+      "additionalProperties": false,
+      "properties": {
+        "energyConsumptions": {
+          "title": "Energy Consumptions",
+          "description": "Describes energy consumption information incurred for one or more component lifecycle activities.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/energyConsumption"
+          }
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "energyConsumption": {
+      "title": "Energy consumption",
+      "description": "Describes energy consumption information incurred for the specified lifecycle activity.",
+      "type": "object",
+      "required": [
+        "activity",
+        "energyProviders",
+        "activityEnergyCost"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "activity": {
+          "type": "string",
+          "title": "Activity",
+          "description": "The type of activity that is part of a machine learning model development or operational lifecycle.",
+          "enum": [
+            "design",
+            "data-collection",
+            "data-preparation",
+            "training",
+            "fine-tuning",
+            "validation",
+            "deployment",
+            "inference",
+            "other"
+          ],
+          "meta:enum": {
+            "design": "A model design including problem framing, goal definition and algorithm selection.",
+            "data-collection": "Model data acquisition including search, selection and transfer.",
+            "data-preparation": "Model data preparation including data cleaning, labeling and conversion.",
+            "training": "Model building, training and generalized tuning.",
+            "fine-tuning": "Refining a trained model to produce desired outputs for a given problem space.",
+            "validation": "Model validation including model output evaluation and testing.",
+            "deployment": "Explicit model deployment to a target hosting infrastructure.",
+            "inference": "Generating an output response from a hosted model from a set of inputs.",
+            "other": "A lifecycle activity type whose description does not match currently defined values."
+          }
+        },
+        "energyProviders": {
+          "title": "Energy Providers",
+          "description": "The provider(s) of the energy consumed by the associated model development lifecycle activity.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/energyProvider"
+          }
+        },
+        "activityEnergyCost": {
+          "title": "Activity Energy Cost",
+          "description": "The total energy cost associated with the model lifecycle activity.",
+          "$ref": "#/definitions/energyMeasure"
+        },
+        "co2CostEquivalent": {
+          "title": "CO2 Equivalent Cost",
+          "description": "The CO2 cost (debit) equivalent to the total energy cost.",
+          "$ref": "#/definitions/co2Measure"
+        },
+        "co2CostOffset": {
+          "title": "CO2 Cost Offset",
+          "description": "The CO2 offset (credit) for the CO2 equivalent cost.",
+          "$ref": "#/definitions/co2Measure"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "energyMeasure": {
+      "type": "object",
+      "title": "Energy Measure",
+      "description": "A measure of energy.",
+      "required": [
+        "value",
+        "unit"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "type": "number",
+          "title": "Value",
+          "description": "Quantity of energy."
+        },
+        "unit": {
+          "type": "string",
+          "enum": [
+            "kWh"
+          ],
+          "title": "Unit",
+          "description": "Unit of energy.",
+          "meta:enum": {
+            "kWh": "Kilowatt-hour (kWh) is the energy delivered by one kilowatt (kW) of power for one hour (h)."
+          }
+        }
+      }
+    },
+    "co2Measure": {
+      "type": "object",
+      "title": "CO2 Measure",
+      "description": "A measure of carbon dioxide (CO2).",
+      "required": [
+        "value",
+        "unit"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "type": "number",
+          "title": "Value",
+          "description": "Quantity of carbon dioxide (CO2)."
+        },
+        "unit": {
+          "type": "string",
+          "enum": [
+            "tCO2eq"
+          ],
+          "title": "Unit",
+          "description": "Unit of carbon dioxide (CO2).",
+          "meta:enum": {
+            "tCO2eq": "Tonnes (t) of carbon dioxide (CO2) equivalent (eq)."
+          }
+        }
+      }
+    },
+    "energyProvider": {
+      "type": "object",
+      "title": "Energy Provider",
+      "description": "Describes the physical provider of energy used for model development or operations.",
+      "required": [
+        "organization",
+        "energySource",
+        "energyProvided"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the energy provider elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/definitions/refType"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the energy provider."
+        },
+        "organization": {
+          "type": "object",
+          "title": "Organization",
+          "description": "The organization that provides energy.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "energySource": {
+          "type": "string",
+          "enum": [
+            "coal",
+            "oil",
+            "natural-gas",
+            "nuclear",
+            "wind",
+            "solar",
+            "geothermal",
+            "hydropower",
+            "biofuel",
+            "unknown",
+            "other"
+          ],
+          "meta:enum": {
+            "coal": "Energy produced by types of coal.",
+            "oil": "Petroleum products (primarily crude oil and its derivative fuel oils).",
+            "natural-gas": "Hydrocarbon gas liquids (HGL) that occur as gases at atmospheric pressure and as liquids under higher pressures including Natural gas (C5H12 and heavier), Ethane (C2H6), Propane (C3H8), etc.",
+            "nuclear": "Energy produced from the cores of atoms (i.e., through nuclear fission or fusion).",
+            "wind": "Energy produced from moving air.",
+            "solar": "Energy produced from the sun (i.e., solar radiation).",
+            "geothermal": "Energy produced from heat within the earth.",
+            "hydropower": "Energy produced from flowing water.",
+            "biofuel": "Liquid fuels produced from biomass feedstocks (i.e., organic materials such as plants or animals).",
+            "unknown": "The energy source is unknown.",
+            "other": "An energy source that is not listed."
+          },
+          "title": "Energy Source",
+          "description": "The energy source for the energy provider."
+        },
+        "energyProvided": {
+          "$ref": "#/definitions/energyMeasure",
+          "title": "Energy Provided",
+          "description": "The energy provided by the energy source for an associated activity."
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/externalReference"
+          },
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+        }
+      }
+    },
+    "postalAddress": {
+      "type": "object",
+      "title": "Postal address",
+      "description": "An address used to identify a contactable location.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the address elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/definitions/refType"
+        },
+        "country": {
+          "type": "string",
+          "title": "Country",
+          "description": "The country name or the two-letter ISO 3166-1 country code."
+        },
+        "region": {
+          "type": "string",
+          "title": "Region",
+          "description": "The region or state in the country.",
+          "examples": [
+            "Texas"
+          ]
+        },
+        "locality": {
+          "type": "string",
+          "title": "Locality",
+          "description": "The locality or city within the country.",
+          "examples": [
+            "Austin"
+          ]
+        },
+        "postOfficeBoxNumber": {
+          "type": "string",
+          "title": "Post Office Box Number",
+          "description": "The post office box number.",
+          "examples": [
+            "901"
+          ]
+        },
+        "postalCode": {
+          "type": "string",
+          "title": "Postal Code",
+          "description": "The postal code.",
+          "examples": [
+            "78758"
+          ]
+        },
+        "streetAddress": {
+          "type": "string",
+          "title": "Street Address",
+          "description": "The street address.",
+          "examples": [
+            "100 Main Street"
+          ]
+        }
+      }
+    },
+    "formula": {
+      "title": "Formula",
+      "description": "Describes workflows and resources that captures rules and other aspects of how the associated BOM component or service was formed.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the formula elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/definitions/refType"
+        },
+        "components": {
+          "title": "Components",
+          "description": "Transient components that are used in tasks that constitute one or more of this formula's workflows",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/component"
+          },
+          "uniqueItems": true
+        },
+        "services": {
+          "title": "Services",
+          "description": "Transient services that are used in tasks that constitute one or more of this formula's workflows",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/service"
+          },
+          "uniqueItems": true
+        },
+        "workflows": {
+          "title": "Workflows",
+          "description": "List of workflows that can be declared to accomplish specific orchestrated goals and independently triggered.",
+          "$comment": "Different workflows can be designed to work together to perform end-to-end CI/CD builds and deployments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/workflow"
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "workflow": {
+      "title": "Workflow",
+      "description": "A specialized orchestration task.",
+      "$comment": "Workflow are as task themselves and can trigger other workflow tasks.  These relationships can be modeled in the taskDependencies graph.",
+      "type": "object",
+      "required": [
+        "bom-ref",
+        "uid",
+        "taskTypes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the workflow elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/definitions/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/resourceReferenceChoice"
+          }
+        },
+        "tasks": {
+          "title": "Tasks",
+          "description": "The tasks that comprise the workflow.",
+          "$comment": "Note that tasks can appear more than once as different instances (by name or UID).",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/task"
+          }
+        },
+        "taskDependencies": {
+          "title": "Task dependency graph",
+          "description": "The graph of dependencies between tasks within the workflow.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/dependency"
+          }
+        },
+        "taskTypes": {
+          "title": "Task types",
+          "description": "Indicates the types of activities performed by the set of workflow tasks.",
+          "$comment": "Currently, these types reflect common CI/CD actions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/taskType"
+          }
+        },
+        "trigger": {
+          "title": "Trigger",
+          "description": "The trigger that initiated the task.",
+          "$ref": "#/definitions/trigger"
+        },
+        "steps": {
+          "title": "Steps",
+          "description": "The sequence of steps for the task.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "uniqueItems": true
+        },
+        "inputs": {
+          "title": "Inputs",
+          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+          "examples": [
+            "a `configuration` file which was declared as a local `component` or `externalReference`"
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inputType"
+          },
+          "uniqueItems": true
+        },
+        "outputs": {
+          "title": "Outputs",
+          "description": "Represents resources and data output from a task at runtime by executor or task commands",
+          "examples": [
+            "a log file or metrics data produced by the task"
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/outputType"
+          },
+          "uniqueItems": true
+        },
+        "timeStart": {
+          "title": "Time start",
+          "description": "The date and time (timestamp) when the task started.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "timeEnd": {
+          "title": "Time end",
+          "description": "The date and time (timestamp) when the task ended.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "workspaces": {
+          "title": "Workspaces",
+          "description": "A set of named filesystem or data resource shareable by workflow tasks.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/workspace"
+          }
+        },
+        "runtimeTopology": {
+          "title": "Runtime topology",
+          "description": "A graph of the component runtime topology for workflow's instance.",
+          "$comment": "A description of the runtime component and service topology.  This can describe a partial or complete topology used to host and execute the task (e.g., hardware, operating systems, configurations, etc.),",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/dependency"
+          }
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "task": {
+      "title": "Task",
+      "description": "Describes the inputs, sequence of steps and resources used to accomplish a task and its output.",
+      "$comment": "Tasks are building blocks for constructing assemble CI/CD workflows or pipelines.",
+      "type": "object",
+      "required": [
+        "bom-ref",
+        "uid",
+        "taskTypes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the task elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/definitions/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/resourceReferenceChoice"
+          }
+        },
+        "taskTypes": {
+          "title": "Task types",
+          "description": "Indicates the types of activities performed by the set of workflow tasks.",
+          "$comment": "Currently, these types reflect common CI/CD actions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/taskType"
+          }
+        },
+        "trigger": {
+          "title": "Trigger",
+          "description": "The trigger that initiated the task.",
+          "$ref": "#/definitions/trigger"
+        },
+        "steps": {
+          "title": "Steps",
+          "description": "The sequence of steps for the task.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "uniqueItems": true
+        },
+        "inputs": {
+          "title": "Inputs",
+          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+          "examples": [
+            "a `configuration` file which was declared as a local `component` or `externalReference`"
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inputType"
+          },
+          "uniqueItems": true
+        },
+        "outputs": {
+          "title": "Outputs",
+          "description": "Represents resources and data output from a task at runtime by executor or task commands",
+          "examples": [
+            "a log file or metrics data produced by the task"
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/outputType"
+          },
+          "uniqueItems": true
+        },
+        "timeStart": {
+          "title": "Time start",
+          "description": "The date and time (timestamp) when the task started.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "timeEnd": {
+          "title": "Time end",
+          "description": "The date and time (timestamp) when the task ended.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "workspaces": {
+          "title": "Workspaces",
+          "description": "A set of named filesystem or data resource shareable by workflow tasks.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/workspace"
+          },
+          "uniqueItems": true
+        },
+        "runtimeTopology": {
+          "title": "Runtime topology",
+          "description": "A graph of the component runtime topology for task's instance.",
+          "$comment": "A description of the runtime component and service topology.  This can describe a partial or complete topology used to host and execute the task (e.g., hardware, operating systems, configurations, etc.),",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/dependency"
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "step": {
+      "type": "object",
+      "description": "Executes specific commands or tools in order to accomplish its owning task as part of a sequence.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "A name for the step.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the step.",
+          "type": "string"
+        },
+        "commands": {
+          "title": "Commands",
+          "description": "Ordered list of commands or directives for the step",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/command"
+          }
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "executed": {
+          "title": "Executed",
+          "description": "A text representation of the executed command.",
+          "type": "string"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "workspace": {
+      "title": "Workspace",
+      "description": "A named filesystem or data resource shareable by workflow tasks.",
+      "type": "object",
+      "required": [
+        "bom-ref",
+        "uid"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the workspace elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/definitions/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "aliases": {
+          "title": "Aliases",
+          "description": "The names for the workspace as referenced by other workflow tasks. Effectively, a name mapping so other tasks can use their own local name in their steps.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/resourceReferenceChoice"
+          }
+        },
+        "accessMode": {
+          "title": "Access mode",
+          "description": "Describes the read-write access control for the workspace relative to the owning resource instance.",
+          "type": "string",
+          "enum": [
+            "read-only",
+            "read-write",
+            "read-write-once",
+            "write-once",
+            "write-only"
+          ]
+        },
+        "mountPath": {
+          "title": "Mount path",
+          "description": "A path to a location on disk where the workspace will be available to the associated task's steps.",
+          "type": "string"
+        },
+        "managedDataType": {
+          "title": "Managed data type",
+          "description": "The name of a domain-specific data type the workspace represents.",
+          "$comment": "This property is for CI/CD frameworks that are able to provide access to structured, managed data at a more granular level than a filesystem.",
+          "examples": [
+            "ConfigMap",
+            "Secret"
+          ],
+          "type": "string"
+        },
+        "volumeRequest": {
+          "title": "Volume request",
+          "description": "Identifies the reference to the request for a specific volume type and parameters.",
+          "examples": [
+            "a kubernetes Persistent Volume Claim (PVC) name"
+          ],
+          "type": "string"
+        },
+        "volume": {
+          "title": "Volume",
+          "description": "Information about the actual volume instance allocated to the workspace.",
+          "$comment": "The actual volume allocated may be different than the request.",
+          "examples": [
+            "see https://kubernetes.io/docs/concepts/storage/persistent-volumes/"
+          ],
+          "$ref": "#/definitions/volume"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "volume": {
+      "title": "Volume",
+      "description": "An identifiable, logical unit of data storage tied to a physical device.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the volume instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the volume instance",
+          "type": "string"
+        },
+        "mode": {
+          "title": "Mode",
+          "description": "The mode for the volume instance.",
+          "type": "string",
+          "enum": [
+            "filesystem",
+            "block"
+          ],
+          "default": "filesystem"
+        },
+        "path": {
+          "title": "Path",
+          "description": "The underlying path created from the actual volume.",
+          "type": "string"
+        },
+        "sizeAllocated": {
+          "title": "Size allocated",
+          "description": "The allocated size of the volume accessible to the associated workspace. This should include the scalar size as well as IEC standard unit in either decimal or binary form.",
+          "examples": [
+            "10GB",
+            "2Ti",
+            "1Pi"
+          ],
+          "type": "string"
+        },
+        "persistent": {
+          "title": "Persistent",
+          "description": "Indicates if the volume persists beyond the life of the resource it is associated with.",
+          "type": "boolean"
+        },
+        "remote": {
+          "title": "Remote",
+          "description": "Indicates if the volume is remotely (i.e., network) attached.",
+          "type": "boolean"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "trigger": {
+      "title": "Trigger",
+      "description": "Represents a resource that can conditionally activate (or fire) tasks based upon associated events and their data.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "bom-ref",
+        "uid"
+      ],
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the trigger elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/definitions/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/resourceReferenceChoice"
+          }
+        },
+        "type": {
+          "title": "Type",
+          "description": "The source type of event which caused the trigger to fire.",
+          "type": "string",
+          "enum": [
+            "manual",
+            "api",
+            "webhook",
+            "scheduled"
+          ]
+        },
+        "event": {
+          "title": "Event",
+          "description": "The event data that caused the associated trigger to activate.",
+          "$ref": "#/definitions/event"
+        },
+        "conditions": {
+          "type": "array",
+          "title": "Conditions",
+          "description": "A list of conditions used to determine if a trigger should be activated.",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/condition"
+          }
+        },
+        "timeActivated": {
+          "title": "Time activated",
+          "description": "The date and time (timestamp) when the trigger was activated.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "inputs": {
+          "title": "Inputs",
+          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+          "examples": [
+            "a `configuration` file which was declared as a local `component` or `externalReference`"
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/inputType"
+          },
+          "uniqueItems": true
+        },
+        "outputs": {
+          "title": "Outputs",
+          "description": "Represents resources and data output from a task at runtime by executor or task commands",
+          "examples": [
+            "a log file or metrics data produced by the task"
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/outputType"
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "event": {
+      "title": "Event",
+      "description": "Represents something that happened that may trigger a response.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier of the event.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the event.",
+          "type": "string"
+        },
+        "timeReceived": {
+          "title": "Time Received",
+          "description": "The date and time (timestamp) when the event was received.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "data": {
+          "title": "Data",
+          "description": "Encoding of the raw event data.",
+          "$ref": "#/definitions/attachment"
+        },
+        "source": {
+          "title": "Source",
+          "description": "References the component or service that was the source of the event",
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "target": {
+          "title": "Target",
+          "description": "References the component or service that was the target of the event",
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "inputType": {
+      "title": "Input type",
+      "description": "Type that represents various input data types and formats.",
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "resource"
+          ]
+        },
+        {
+          "required": [
+            "parameters"
+          ]
+        },
+        {
+          "required": [
+            "environmentVars"
+          ]
+        },
+        {
+          "required": [
+            "data"
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "title": "Source",
+          "description": "A reference to the component or service that provided the input to the task (e.g., reference to a service with data flow value of `inbound`)",
+          "examples": [
+            "source code repository",
+            "database"
+          ],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "target": {
+          "title": "Target",
+          "description": "A reference to the component or service that received or stored the input if not the task itself (e.g., a local, named storage workspace)",
+          "examples": [
+            "workspace",
+            "directory"
+          ],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "resource": {
+          "title": "Resource",
+          "description": "A reference to an independent resource provided as an input to a task by the workflow runtime.",
+          "examples": [
+            "a reference to a configuration file in a repository (i.e., a bom-ref)",
+            "a reference to a scanning service used in a task (i.e., a bom-ref)"
+          ],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "parameters": {
+          "title": "Parameters",
+          "description": "Inputs that have the form of parameters with names and values.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/parameter"
+          }
+        },
+        "environmentVars": {
+          "title": "Environment variables",
+          "description": "Inputs that have the form of parameters with names and values.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/property"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "data": {
+          "title": "Data",
+          "description": "Inputs that have the form of data.",
+          "$ref": "#/definitions/attachment"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "outputType": {
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "resource"
+          ]
+        },
+        {
+          "required": [
+            "environmentVars"
+          ]
+        },
+        {
+          "required": [
+            "data"
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Type",
+          "description": "Describes the type of data output.",
+          "type": "string",
+          "enum": [
+            "artifact",
+            "attestation",
+            "log",
+            "evidence",
+            "metrics",
+            "other"
+          ]
+        },
+        "source": {
+          "title": "Source",
+          "description": "Component or service that generated or provided the output from the task (e.g., a build tool)",
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "target": {
+          "title": "Target",
+          "description": "Component or service that received the output from the task (e.g., reference to an artifactory service with data flow value of `outbound`)",
+          "examples": [
+            "a log file described as an `externalReference` within its target domain."
+          ],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "resource": {
+          "title": "Resource",
+          "description": "A reference to an independent resource generated as output by the task.",
+          "examples": [
+            "configuration file",
+            "source code",
+            "scanning service"
+          ],
+          "$ref": "#/definitions/resourceReferenceChoice"
+        },
+        "data": {
+          "title": "Data",
+          "description": "Outputs that have the form of data.",
+          "$ref": "#/definitions/attachment"
+        },
+        "environmentVars": {
+          "title": "Environment variables",
+          "description": "Outputs that have the form of environment variables.",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/property"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "resourceReferenceChoice": {
+      "title": "Resource reference choice",
+      "description": "A reference to a locally defined resource (e.g., a bom-ref) or an externally accessible resource.",
+      "$comment": "Enables reference to a resource that participates in a workflow; using either internal (bom-ref) or external (externalReference) types.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ref": {
+          "title": "BOM Reference",
+          "description": "References an object by its bom-ref attribute",
+          "anyOf": [
+            {
+              "title": "Ref",
+              "$ref": "#/definitions/refLinkType"
+            },
+            {
+              "title": "BOM-Link Element",
+              "$ref": "#/definitions/bomLinkElementType"
+            }
+          ]
+        },
+        "externalReference": {
+          "title": "External reference",
+          "description": "Reference to an externally accessible resource.",
+          "$ref": "#/definitions/externalReference"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "ref"
+          ]
+        },
+        {
+          "required": [
+            "externalReference"
+          ]
+        }
+      ]
+    },
+    "condition": {
+      "title": "Condition",
+      "description": "A condition that was used to determine a trigger should be activated.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "title": "Description",
+          "description": "Describes the set of conditions which cause the trigger to activate.",
+          "type": "string"
+        },
+        "expression": {
+          "title": "Expression",
+          "description": "The logical expression that was evaluated that determined the trigger should be fired.",
+          "type": "string"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        }
+      }
+    },
+    "taskType": {
+      "type": "string",
+      "enum": [
+        "copy",
+        "clone",
+        "lint",
+        "scan",
+        "merge",
+        "build",
+        "test",
+        "deliver",
+        "deploy",
+        "release",
+        "clean",
+        "other"
+      ],
+      "meta:enum": {
+        "copy": "A task that copies software or data used to accomplish other tasks in the workflow.",
+        "clone": "A task that clones a software repository into the workflow in order to retrieve its source code or data for use in a build step.",
+        "lint": "A task that checks source code for programmatic and stylistic errors.",
+        "scan": "A task that performs a scan against source code, or built or deployed components and services. Scans are typically run to gather or test for security vulnerabilities or policy compliance.",
+        "merge": "A task that merges changes or fixes into source code prior to a build step in the workflow.",
+        "build": "A task that builds the source code, dependencies and/or data into an artifact that can be deployed to and executed on target systems.",
+        "test": "A task that verifies the functionality of a component or service.",
+        "deliver": "A task that delivers a built artifact to one or more target repositories or storage systems.",
+        "deploy": "A task that deploys a built artifact for execution on one or more target systems.",
+        "release": "A task that releases a built, versioned artifact to a target repository or distribution system.",
+        "clean": "A task that cleans unnecessary tools, build artifacts and/or data from workflow storage.",
+        "other": "A workflow task that does not match current task type definitions."
+      }
+    },
+    "parameter": {
+      "title": "Parameter",
+      "description": "A representation of a functional parameter.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The name of the parameter.",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "description": "The value of the parameter.",
+          "type": "string"
+        },
+        "dataType": {
+          "title": "Data type",
+          "description": "The data type of the parameter.",
+          "type": "string"
+        }
+      }
+    },
+    "componentIdentityEvidence": {
+      "type": "object",
+      "title": "Identity Evidence",
+      "description": "Evidence that substantiates the identity of a component.",
+      "required": [
+        "field"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string",
+          "enum": [
+            "group",
+            "name",
+            "version",
+            "purl",
+            "cpe",
+            "omniborId",
+            "swhid",
+            "swid",
+            "hash"
+          ],
+          "title": "Field",
+          "description": "The identity field of the component which the evidence describes."
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "title": "Confidence",
+          "description": "The overall confidence of the evidence from 0 - 1, where 1 is 100% confidence."
+        },
+        "concludedValue": {
+          "type": "string",
+          "title": "Concluded Value",
+          "description": "The value of the field (cpe, purl, etc) that has been concluded based on the aggregate of all methods (if available)."
+        },
+        "methods": {
+          "type": "array",
+          "title": "Methods",
+          "description": "The methods used to extract and/or analyze the evidence.",
+          "items": {
+            "type": "object",
+            "required": [
+              "technique",
+              "confidence"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "technique": {
+                "title": "Technique",
+                "description": "The technique used in this method of analysis.",
+                "type": "string",
+                "enum": [
+                  "source-code-analysis",
+                  "binary-analysis",
+                  "manifest-analysis",
+                  "ast-fingerprint",
+                  "hash-comparison",
+                  "instrumentation",
+                  "dynamic-analysis",
+                  "filename",
+                  "attestation",
+                  "other"
+                ]
+              },
+              "confidence": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "title": "Confidence",
+                "description": "The confidence of the evidence from 0 - 1, where 1 is 100% confidence. Confidence is specific to the technique used. Each technique of analysis can have independent confidence."
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "The value or contents of the evidence."
+              }
+            }
+          }
+        },
+        "tools": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "anyOf": [
+              {
+                "title": "Ref",
+                "$ref": "#/definitions/refLinkType"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "#/definitions/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "BOM References",
+          "description": "The object in the BOM identified by its bom-ref. This is often a component or service but may be any object type supporting bom-refs. Tools used for analysis should already be defined in the BOM, either in the metadata/tools, components, or formulation."
+        }
+      }
+    },
+    "standard": {
+      "type": "object",
+      "title": "Standard",
+      "description": "A standard may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the standard. This will often be a shortened, single name of the standard."
+        },
+        "version": {
+          "type": "string",
+          "title": "Version",
+          "description": "The version of the standard."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "The description of the standard."
+        },
+        "owner": {
+          "type": "string",
+          "title": "Owner",
+          "description": "The owner of the standard, often the entity responsible for its release."
+        },
+        "requirements": {
+          "type": "array",
+          "title": "Requirements",
+          "description": "The list of requirements comprising the standard.",
+          "items": {
+            "type": "object",
+            "title": "Requirement",
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+              },
+              "identifier": {
+                "type": "string",
+                "title": "Identifier",
+                "description": "The unique identifier used in the standard to identify a specific requirement. This should match what is in the standard and should not be the requirements bom-ref."
+              },
+              "title": {
+                "type": "string",
+                "title": "Title",
+                "description": "The title of the requirement."
+              },
+              "text": {
+                "type": "string",
+                "title": "Text",
+                "description": "The textual content of the requirement."
+              },
+              "descriptions": {
+                "type": "array",
+                "title": "Descriptions",
+                "description": "The supplemental text that provides additional guidance or context to the requirement, but is not directly part of the requirement.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "openCre": {
+                "type": "array",
+                "title": "OWASP OpenCRE Identifier(s)",
+                "description": "The Common Requirements Enumeration (CRE) identifier(s). CRE is a structured and standardized framework for uniting security standards and guidelines. CRE links each section of a resource to a shared topic identifier (a Common Requirement). Through this shared topic link, all resources map to each other. Use of CRE promotes clear and unambiguous communication among stakeholders.",
+                "items": {
+                  "type": "string",
+                  "pattern": "^CRE:[0-9]+-[0-9]+$",
+                  "examples": [
+                    "CRE:764-507"
+                  ]
+                }
+              },
+              "parent": {
+                "$ref": "#/definitions/refLinkType",
+                "title": "Parent BOM Reference",
+                "description": "The optional `bom-ref` to a parent requirement. This establishes a hierarchy of requirements. Top-level requirements must not define a parent. Only child requirements should define parents."
+              },
+              "properties": {
+                "type": "array",
+                "title": "Properties",
+                "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+                "items": {
+                  "$ref": "#/definitions/property"
+                }
+              },
+              "externalReferences": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/externalReference"
+                },
+                "title": "External References",
+                "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+              }
+            }
+          }
+        },
+        "levels": {
+          "type": "array",
+          "title": "Levels",
+          "description": "The list of levels associated with the standard. Some standards have different levels of compliance.",
+          "items": {
+            "type": "object",
+            "title": "Level",
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "#/definitions/refType",
+                "title": "BOM Reference",
+                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+              },
+              "identifier": {
+                "type": "string",
+                "title": "Identifier",
+                "description": "The identifier used in the standard to identify a specific level."
+              },
+              "title": {
+                "type": "string",
+                "title": "Title",
+                "description": "The title of the level."
+              },
+              "description": {
+                "type": "string",
+                "title": "Description",
+                "description": "The description of the level."
+              },
+              "requirements": {
+                "type": "array",
+                "title": "Requirements",
+                "description": "The list of requirement `bom-ref`s that comprise the level.",
+                "items": {
+                  "$ref": "#/definitions/refLinkType"
+                }
+              }
+            }
+          }
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/externalReference"
+          },
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
     },
     "signature": {
       "$ref": "jsf-0.82.schema.json#/definitions/signature",
       "title": "Signature",
-      "additionalProperties": false
+      "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+    },
+    "cryptoProperties": {
+      "type": "object",
+      "title": "Cryptographic Properties",
+      "description": "Cryptographic assets have properties that uniquely define them and that make them actionable for further reasoning. As an example, it makes a difference if one knows the algorithm family (e.g. AES) or the specific variant or instantiation (e.g. AES-128-GCM). This is because the security level and the algorithm primitive (authenticated encryption) are only defined by the definition of the algorithm variant. The presence of a weak cryptographic algorithm like SHA1 vs. HMAC-SHA1 also makes a difference.",
+      "additionalProperties": false,
+      "required": [
+        "assetType"
+      ],
+      "properties": {
+        "assetType": {
+          "type": "string",
+          "title": "Asset Type",
+          "description": "Cryptographic assets occur in several forms. Algorithms and protocols are most commonly implemented in specialized cryptographic libraries. They may, however, also be 'hardcoded' in software components. Certificates and related cryptographic material like keys, tokens, secrets or passwords are other cryptographic assets to be modelled.",
+          "enum": [
+            "algorithm",
+            "certificate",
+            "protocol",
+            "related-crypto-material"
+          ],
+          "meta:enum": {
+            "algorithm": "Mathematical function commonly used for data encryption, authentication, and digital signatures.",
+            "certificate": "An electronic document that is used to provide the identity or validate a public key.",
+            "protocol": "A set of rules and guidelines that govern the behavior and communication with each other.",
+            "related-crypto-material": "Other cryptographic assets related to algorithms, certificates, and protocols such as keys and tokens."
+          }
+        },
+        "algorithmProperties": {
+          "type": "object",
+          "title": "Algorithm Properties",
+          "description": "Additional properties specific to a cryptographic algorithm.",
+          "additionalProperties": false,
+          "properties": {
+            "primitive": {
+              "type": "string",
+              "title": "primitive",
+              "description": "Cryptographic building blocks used in higher-level cryptographic systems and protocols. Primitives represent different cryptographic routines: deterministic random bit generators (drbg, e.g. CTR_DRBG from NIST SP800-90A-r1), message authentication codes (mac, e.g. HMAC-SHA-256), blockciphers (e.g. AES), streamciphers (e.g. Salsa20), signatures (e.g. ECDSA), hash functions (e.g. SHA-256), public-key encryption schemes (pke, e.g. RSA), extended output functions (xof, e.g. SHAKE256), key derivation functions (e.g. pbkdf2), key agreement algorithms (e.g. ECDH), key encapsulation mechanisms (e.g. ML-KEM), authenticated encryption (ae, e.g. AES-GCM) and the combination of multiple algorithms (combiner, e.g. SP800-56Cr2).",
+              "enum": [
+                "drbg",
+                "mac",
+                "block-cipher",
+                "stream-cipher",
+                "signature",
+                "hash",
+                "pke",
+                "xof",
+                "kdf",
+                "key-agree",
+                "kem",
+                "ae",
+                "combiner",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "drbg": "Deterministic Random Bit Generator (DRBG) is a type of pseudorandom number generator designed to produce a sequence of bits from an initial seed value. DRBGs are commonly used in cryptographic applications where reproducibility of random values is important.",
+                "mac": "In cryptography, a Message Authentication Code (MAC) is information used for authenticating and integrity-checking a message.",
+                "block-cipher": "A block cipher is a symmetric key algorithm that operates on fixed-size blocks of data. It encrypts or decrypts the data in block units, providing confidentiality. Block ciphers are widely used in various cryptographic modes and protocols for secure data transmission.",
+                "stream-cipher": "A stream cipher is a symmetric key cipher where plaintext digits are combined with a pseudorandom cipher digit stream (keystream).",
+                "signature": "In cryptography, a signature is a digital representation of a message or data that proves its origin, identity, and integrity. Digital signatures are generated using cryptographic algorithms and are widely used for authentication and verification in secure communication.",
+                "hash": "A hash function is a mathematical algorithm that takes an input (or 'message') and produces a fixed-size string of characters, which is typically a hash value. Hash functions are commonly used in various cryptographic applications, including data integrity verification and password hashing.",
+                "pke": "Public Key Encryption (PKE) is a type of encryption that uses a pair of public and private keys for secure communication. The public key is used for encryption, while the private key is used for decryption. PKE is a fundamental component of public-key cryptography.",
+                "xof": "An XOF is an extendable output function that can take arbitrary input and creates a stream of output, up to a limit determined by the size of the internal state of the hash function that underlies the XOF.",
+                "kdf": "A Key Derivation Function (KDF) derives key material from another source of entropy while preserving the entropy of the input.",
+                "key-agree": "In cryptography, a key-agreement is a protocol whereby two or more parties agree on a cryptographic key in such a way that both influence the outcome.",
+                "kem": "A Key Encapsulation Mechanism (KEM) algorithm is a mechanism for transporting random keying material to a recipient using the recipient's public key.",
+                "ae": "Authenticated Encryption (AE) is a cryptographic process that provides both confidentiality and data integrity. It ensures that the encrypted data has not been tampered with and comes from a legitimate source. AE is commonly used in secure communication protocols.",
+                "combiner": "A combiner aggregates many candidates for a cryptographic primitive and generates a new candidate for the same primitive.",
+                "other": "Another primitive type.",
+                "unknown": "The primitive is not known."
+              }
+            },
+            "parameterSetIdentifier": {
+              "type": "string",
+              "title": "Parameter Set Identifier",
+              "description": "An identifier for the parameter set of the cryptographic algorithm. Examples: in AES128, '128' identifies the key length in bits, in SHA256, '256' identifies the digest length, '128' in SHAKE128 identifies its maximum security level in bits, and 'SHA2-128s' identifies a parameter set used in SLH-DSA (FIPS205)."
+            },
+            "curve": {
+              "type": "string",
+              "title": "Elliptic Curve",
+              "description": "The specific underlying Elliptic Curve (EC) definition employed which is an indicator of the level of security strength, performance and complexity. Absent an authoritative source of curve names, CycloneDX recommends using curve names as defined at [https://neuromancer.sk/std/](https://neuromancer.sk/std/), the source of which can be found at [https://github.com/J08nY/std-curves](https://github.com/J08nY/std-curves)."
+            },
+            "executionEnvironment": {
+              "type": "string",
+              "title": "Execution Environment",
+              "description": "The target and execution environment in which the algorithm is implemented in.",
+              "enum": [
+                "software-plain-ram",
+                "software-encrypted-ram",
+                "software-tee",
+                "hardware",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "software-plain-ram": "A software implementation running in plain unencrypted RAM.",
+                "software-encrypted-ram": "A software implementation running in encrypted RAM.",
+                "software-tee": "A software implementation running in a trusted execution environment.",
+                "hardware": "A hardware implementation.",
+                "other": "Another implementation environment.",
+                "unknown": "The execution environment is not known."
+              }
+            },
+            "implementationPlatform": {
+              "type": "string",
+              "title": "Implementation platform",
+              "description": "The target platform for which the algorithm is implemented. The implementation can be 'generic', running on any platform or for a specific platform.",
+              "enum": [
+                "generic",
+                "x86_32",
+                "x86_64",
+                "armv7-a",
+                "armv7-m",
+                "armv8-a",
+                "armv8-m",
+                "armv9-a",
+                "armv9-m",
+                "s390x",
+                "ppc64",
+                "ppc64le",
+                "other",
+                "unknown"
+              ]
+            },
+            "certificationLevel": {
+              "type": "array",
+              "title": "Certification Level",
+              "description": "The certification that the implementation of the cryptographic algorithm has received, if any. Certifications include revisions and levels of FIPS 140 or Common Criteria of different Extended Assurance Levels (CC-EAL).",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "fips140-1-l1",
+                  "fips140-1-l2",
+                  "fips140-1-l3",
+                  "fips140-1-l4",
+                  "fips140-2-l1",
+                  "fips140-2-l2",
+                  "fips140-2-l3",
+                  "fips140-2-l4",
+                  "fips140-3-l1",
+                  "fips140-3-l2",
+                  "fips140-3-l3",
+                  "fips140-3-l4",
+                  "cc-eal1",
+                  "cc-eal1+",
+                  "cc-eal2",
+                  "cc-eal2+",
+                  "cc-eal3",
+                  "cc-eal3+",
+                  "cc-eal4",
+                  "cc-eal4+",
+                  "cc-eal5",
+                  "cc-eal5+",
+                  "cc-eal6",
+                  "cc-eal6+",
+                  "cc-eal7",
+                  "cc-eal7+",
+                  "other",
+                  "unknown"
+                ],
+                "meta:enum": {
+                  "none": "No certification obtained",
+                  "fips140-1-l1": "FIPS 140-1 Level 1",
+                  "fips140-1-l2": "FIPS 140-1 Level 2",
+                  "fips140-1-l3": "FIPS 140-1 Level 3",
+                  "fips140-1-l4": "FIPS 140-1 Level 4",
+                  "fips140-2-l1": "FIPS 140-2 Level 1",
+                  "fips140-2-l2": "FIPS 140-2 Level 2",
+                  "fips140-2-l3": "FIPS 140-2 Level 3",
+                  "fips140-2-l4": "FIPS 140-2 Level 4",
+                  "fips140-3-l1": "FIPS 140-3 Level 1",
+                  "fips140-3-l2": "FIPS 140-3 Level 2",
+                  "fips140-3-l3": "FIPS 140-3 Level 3",
+                  "fips140-3-l4": "FIPS 140-3 Level 4",
+                  "cc-eal1": "Common Criteria - Evaluation Assurance Level 1",
+                  "cc-eal1+": "Common Criteria - Evaluation Assurance Level 1 (Augmented)",
+                  "cc-eal2": "Common Criteria - Evaluation Assurance Level 2",
+                  "cc-eal2+": "Common Criteria - Evaluation Assurance Level 2 (Augmented)",
+                  "cc-eal3": "Common Criteria - Evaluation Assurance Level 3",
+                  "cc-eal3+": "Common Criteria - Evaluation Assurance Level 3 (Augmented)",
+                  "cc-eal4": "Common Criteria - Evaluation Assurance Level 4",
+                  "cc-eal4+": "Common Criteria - Evaluation Assurance Level 4 (Augmented)",
+                  "cc-eal5": "Common Criteria - Evaluation Assurance Level 5",
+                  "cc-eal5+": "Common Criteria - Evaluation Assurance Level 5 (Augmented)",
+                  "cc-eal6": "Common Criteria - Evaluation Assurance Level 6",
+                  "cc-eal6+": "Common Criteria - Evaluation Assurance Level 6 (Augmented)",
+                  "cc-eal7": "Common Criteria - Evaluation Assurance Level 7",
+                  "cc-eal7+": "Common Criteria - Evaluation Assurance Level 7 (Augmented)",
+                  "other": "Another certification",
+                  "unknown": "The certification level is not known"
+                }
+              }
+            },
+            "mode": {
+              "type": "string",
+              "title": "Mode",
+              "description": "The mode of operation in which the cryptographic algorithm (block cipher) is used.",
+              "enum": [
+                "cbc",
+                "ecb",
+                "ccm",
+                "gcm",
+                "cfb",
+                "ofb",
+                "ctr",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "cbc": "Cipher block chaining",
+                "ecb": "Electronic codebook",
+                "ccm": "Counter with cipher block chaining message authentication code",
+                "gcm": "Galois/counter",
+                "cfb": "Cipher feedback",
+                "ofb": "Output feedback",
+                "ctr": "Counter",
+                "other": "Another mode of operation",
+                "unknown": "The mode of operation is not known"
+              }
+            },
+            "padding": {
+              "type": "string",
+              "title": "Padding",
+              "description": "The padding scheme that is used for the cryptographic algorithm.",
+              "enum": [
+                "pkcs5",
+                "pkcs7",
+                "pkcs1v15",
+                "oaep",
+                "raw",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "pkcs5": "Public Key Cryptography Standard: Password-Based Cryptography",
+                "pkcs7": "Public Key Cryptography Standard: Cryptographic Message Syntax",
+                "pkcs1v15": "Public Key Cryptography Standard: RSA Cryptography v1.5",
+                "oaep": "Optimal asymmetric encryption padding",
+                "raw": "Raw",
+                "other": "Another padding scheme",
+                "unknown": "The padding scheme is not known"
+              }
+            },
+            "cryptoFunctions": {
+              "type": "array",
+              "title": "Cryptographic functions",
+              "description": "The cryptographic functions implemented by the cryptographic algorithm.",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "generate",
+                  "keygen",
+                  "encrypt",
+                  "decrypt",
+                  "digest",
+                  "tag",
+                  "keyderive",
+                  "sign",
+                  "verify",
+                  "encapsulate",
+                  "decapsulate",
+                  "other",
+                  "unknown"
+                ]
+              }
+            },
+            "classicalSecurityLevel": {
+              "type": "integer",
+              "title": "classical security level",
+              "description": "The classical security level that a cryptographic algorithm provides (in bits).",
+              "minimum": 0
+            },
+            "nistQuantumSecurityLevel": {
+              "type": "integer",
+              "title": "NIST security strength category",
+              "description": "The NIST security strength category as defined in https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/evaluation-criteria/security-(evaluation-criteria). A value of 0 indicates that none of the categories are met.",
+              "minimum": 0,
+              "maximum": 6
+            }
+          }
+        },
+        "certificateProperties": {
+          "type": "object",
+          "title": "Certificate Properties",
+          "description": "Properties for cryptographic assets of asset type 'certificate'",
+          "additionalProperties": false,
+          "properties": {
+            "subjectName": {
+              "type": "string",
+              "title": "Subject Name",
+              "description": "The subject name for the certificate"
+            },
+            "issuerName": {
+              "type": "string",
+              "title": "Issuer Name",
+              "description": "The issuer name for the certificate"
+            },
+            "notValidBefore": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Not Valid Before",
+              "description": "The date and time according to ISO-8601 standard from which the certificate is valid"
+            },
+            "notValidAfter": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Not Valid After",
+              "description": "The date and time according to ISO-8601 standard from which the certificate is not valid anymore"
+            },
+            "signatureAlgorithmRef": {
+              "$ref": "#/definitions/refType",
+              "title": "Algorithm Reference",
+              "description": "The bom-ref to signature algorithm used by the certificate"
+            },
+            "subjectPublicKeyRef": {
+              "$ref": "#/definitions/refType",
+              "title": "Key reference",
+              "description": "The bom-ref to the public key of the subject"
+            },
+            "certificateFormat": {
+              "type": "string",
+              "title": "Certificate Format",
+              "description": "The format of the certificate",
+              "examples": [
+                "X.509",
+                "PEM",
+                "DER",
+                "CVC"
+              ]
+            },
+            "certificateExtension": {
+              "type": "string",
+              "title": "Certificate File Extension",
+              "description": "The file extension of the certificate",
+              "examples": [
+                "crt",
+                "pem",
+                "cer",
+                "der",
+                "p12"
+              ]
+            }
+          }
+        },
+        "relatedCryptoMaterialProperties": {
+          "type": "object",
+          "title": "Related Cryptographic Material Properties",
+          "description": "Properties for cryptographic assets of asset type: `related-crypto-material`",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "title": "relatedCryptoMaterialType",
+              "description": "The type for the related cryptographic material",
+              "enum": [
+                "private-key",
+                "public-key",
+                "secret-key",
+                "key",
+                "ciphertext",
+                "signature",
+                "digest",
+                "initialization-vector",
+                "nonce",
+                "seed",
+                "salt",
+                "shared-secret",
+                "tag",
+                "additional-data",
+                "password",
+                "credential",
+                "token",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "private-key": "The confidential key of a key pair used in asymmetric cryptography.",
+                "public-key": "The non-confidential key of a key pair used in asymmetric cryptography.",
+                "secret-key": "A key used to encrypt and decrypt messages in symmetric cryptography.",
+                "key": "A piece of information, usually an octet string, which, when processed through a cryptographic algorithm, processes cryptographic data.",
+                "ciphertext": "The result of encryption performed on plaintext using an algorithm (or cipher).",
+                "signature": "A cryptographic value that is calculated from the data and a key known only by the signer.",
+                "digest": "The output of the hash function.",
+                "initialization-vector": "A fixed-size random or pseudo-random value used as an input parameter for cryptographic algorithms.",
+                "nonce": "A random or pseudo-random number that can only be used once in a cryptographic communication.",
+                "seed": "The input to a pseudo-random number generator. Different seeds generate different pseudo-random sequences.",
+                "salt": "A value used in a cryptographic process, usually to ensure that the results of computations for one instance cannot be reused by an attacker.",
+                "shared-secret": "A piece of data known only to the parties involved, in a secure communication.",
+                "tag": "A message authentication code (MAC), sometimes known as an authentication tag, is a short piece of information used for authenticating and integrity-checking a message.",
+                "additional-data": "An unspecified collection of data with relevance to cryptographic activity.",
+                "password": "A secret word, phrase, or sequence of characters used during authentication or authorization.",
+                "credential": "Establishes the identity of a party to communication, usually in the form of cryptographic keys or passwords.",
+                "token": "An object encapsulating a security identity.",
+                "other": "Another type of cryptographic asset.",
+                "unknown": "The type of cryptographic asset is not known."
+              }
+            },
+            "id": {
+              "type": "string",
+              "title": "ID",
+              "description": "The optional unique identifier for the related cryptographic material."
+            },
+            "state": {
+              "type": "string",
+              "title": "State",
+              "description": "The key state as defined by NIST SP 800-57.",
+              "enum": [
+                "pre-activation",
+                "active",
+                "suspended",
+                "deactivated",
+                "compromised",
+                "destroyed"
+              ]
+            },
+            "algorithmRef": {
+              "$ref": "#/definitions/refType",
+              "title": "Algorithm Reference",
+              "description": "The bom-ref to the algorithm used to generate the related cryptographic material."
+            },
+            "creationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Creation Date",
+              "description": "The date and time (timestamp) when the related cryptographic material was created."
+            },
+            "activationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Activation Date",
+              "description": "The date and time (timestamp) when the related cryptographic material was activated."
+            },
+            "updateDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Update Date",
+              "description": "The date and time (timestamp) when the related cryptographic material was updated."
+            },
+            "expirationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Expiration Date",
+              "description": "The date and time (timestamp) when the related cryptographic material expires."
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "The associated value of the cryptographic material."
+            },
+            "size": {
+              "type": "integer",
+              "title": "Size",
+              "description": "The size of the cryptographic asset (in bits)."
+            },
+            "format": {
+              "type": "string",
+              "title": "Format",
+              "description": "The format of the related cryptographic material (e.g. P8, PEM, DER)."
+            },
+            "securedBy": {
+              "$ref": "#/definitions/securedBy",
+              "title": "Secured By",
+              "description": "The mechanism by which the cryptographic asset is secured by."
+            }
+          }
+        },
+        "protocolProperties": {
+          "type": "object",
+          "title": "Protocol Properties",
+          "description": "Properties specific to cryptographic assets of type: `protocol`.",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "description": "The concrete protocol type.",
+              "enum": [
+                "tls",
+                "ssh",
+                "ipsec",
+                "ike",
+                "sstp",
+                "wpa",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "tls": "Transport Layer Security",
+                "ssh": "Secure Shell",
+                "ipsec": "Internet Protocol Security",
+                "ike": "Internet Key Exchange",
+                "sstp": "Secure Socket Tunneling Protocol",
+                "wpa": "Wi-Fi Protected Access",
+                "other": "Another protocol type",
+                "unknown": "The protocol type is not known"
+              }
+            },
+            "version": {
+              "type": "string",
+              "title": "Protocol Version",
+              "description": "The version of the protocol.",
+              "examples": [
+                "1.0",
+                "1.2",
+                "1.99"
+              ]
+            },
+            "cipherSuites": {
+              "type": "array",
+              "title": "Cipher Suites",
+              "description": "A list of cipher suites related to the protocol.",
+              "items": {
+                "$ref": "#/definitions/cipherSuite",
+                "title": "Cipher Suite"
+              }
+            },
+            "ikev2TransformTypes": {
+              "type": "object",
+              "title": "IKEv2 Transform Types",
+              "description": "The IKEv2 transform types supported (types 1-4), defined in [RFC 7296 section 3.3.2](https://www.ietf.org/rfc/rfc7296.html#section-3.3.2), and additional properties.",
+              "additionalProperties": false,
+              "properties": {
+                "encr": {
+                  "$ref": "#/definitions/cryptoRefArray",
+                  "title": "Encryption Algorithm (ENCR)",
+                  "description": "Transform Type 1: encryption algorithms"
+                },
+                "prf": {
+                  "$ref": "#/definitions/cryptoRefArray",
+                  "title": "Pseudorandom Function (PRF)",
+                  "description": "Transform Type 2: pseudorandom functions"
+                },
+                "integ": {
+                  "$ref": "#/definitions/cryptoRefArray",
+                  "title": "Integrity Algorithm (INTEG)",
+                  "description": "Transform Type 3: integrity algorithms"
+                },
+                "ke": {
+                  "$ref": "#/definitions/cryptoRefArray",
+                  "title": "Key Exchange Method (KE)",
+                  "description": "Transform Type 4: Key Exchange Method (KE) per [RFC 9370](https://www.ietf.org/rfc/rfc9370.html), formerly called Diffie-Hellman Group (D-H)."
+                },
+                "esn": {
+                  "type": "boolean",
+                  "title": "Extended Sequence Numbers (ESN)",
+                  "description": "Specifies if an Extended Sequence Number (ESN) is used."
+                },
+                "auth": {
+                  "$ref": "#/definitions/cryptoRefArray",
+                  "title": "IKEv2 Authentication method",
+                  "description": "IKEv2 Authentication method"
+                }
+              }
+            },
+            "cryptoRefArray": {
+              "$ref": "#/definitions/cryptoRefArray",
+              "title": "Cryptographic References",
+              "description": "A list of protocol-related cryptographic assets"
+            }
+          }
+        },
+        "oid": {
+          "type": "string",
+          "title": "OID",
+          "description": "The object identifier (OID) of the cryptographic asset."
+        }
+      }
+    },
+    "cipherSuite": {
+      "type": "object",
+      "title": "Cipher Suite",
+      "description": "Object representing a cipher suite",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Common Name",
+          "description": "A common name for the cipher suite.",
+          "examples": [
+            "TLS_DHE_RSA_WITH_AES_128_CCM"
+          ]
+        },
+        "algorithms": {
+          "type": "array",
+          "title": "Related Algorithms",
+          "description": "A list of algorithms related to the cipher suite.",
+          "items": {
+            "$ref": "#/definitions/refType",
+            "title": "Algorithm reference",
+            "description": "The bom-ref to algorithm cryptographic asset."
+          }
+        },
+        "identifiers": {
+          "type": "array",
+          "title": "Cipher Suite Identifiers",
+          "description": "A list of common identifiers for the cipher suite.",
+          "items": {
+            "type": "string",
+            "title": "identifier",
+            "description": "Cipher suite identifier",
+            "examples": [
+              "0xC0",
+              "0x9E"
+            ]
+          }
+        }
+      }
+    },
+    "cryptoRefArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/refType"
+      }
+    },
+    "securedBy": {
+      "type": "object",
+      "title": "Secured By",
+      "description": "Specifies the mechanism by which the cryptographic asset is secured by",
+      "additionalProperties": false,
+      "properties": {
+        "mechanism": {
+          "type": "string",
+          "title": "Mechanism",
+          "description": "Specifies the mechanism by which the cryptographic asset is secured by.",
+          "examples": [
+            "HSM",
+            "TPM",
+            "SGX",
+            "Software",
+            "None"
+          ]
+        },
+        "algorithmRef": {
+          "$ref": "#/definitions/refType",
+          "title": "Algorithm Reference",
+          "description": "The bom-ref to the algorithm."
+        }
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "Tags",
+      "description": "Textual strings that aid in discovery, search, and retrieval of the associated object. Tags often serve as a way to group or categorize similar or related objects by various attributes.",
+      "examples": [
+        "json-parser",
+        "object-persistence",
+        "text-to-image",
+        "translation",
+        "object-detection"
+      ]
     }
+  },
+  "if": {
+    "required": [
+      "components"
+    ]
+  },
+  "then": {
+    "required": [
+      "bomFormat",
+      "specVersion",
+      "version",
+      "metadata",
+      "compositions",
+      "dependencies"
+    ]
+  },
+  "else": {
+    "required": [
+      "bomFormat",
+      "specVersion",
+      "version",
+      "metadata",
+      "compositions"
+    ]
   }
 }

--- a/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
@@ -1993,32 +1993,63 @@
       }
     },
     "licenseChoice": {
-      "type": "object",
-      "title": "License(s)",
-      "additionalProperties": false,
-      "properties": {
-        "license": {
-          "$ref": "#/definitions/license"
-        },
-        "expression": {
-          "type": "string",
-          "minLength": 1,
-          "title": "SPDX License Expression",
-          "examples": [
-            "Apache-2.0 AND (MIT OR GPL-2.0-only)",
-            "GPL-3.0-only WITH Classpath-exception-2.0"
-          ]
-        }
-      },
+      "title": "License Choice",
+      "description": "EITHER (list of SPDX licenses and/or named licenses) OR (tuple of one SPDX License Expression)",
+      "type": "array",
       "oneOf": [
         {
-          "required": [
-            "license"
-          ]
+          "title": "Multiple licenses",
+          "description": "A list of SPDX licenses and/or named licenses.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "License",
+            "required": [
+              "license"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "license": {
+                "$ref": "#/definitions/license"
+              }
+            }
+          }
         },
         {
-          "required": [
-            "expression"
+          "title": "SPDX License Expression",
+          "description": "A tuple of exactly one SPDX License Expression.",
+          "type": "array",
+          "additionalItems": false,
+          "minItems": 1,
+          "maxItems": 1,
+          "items": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string",
+                  "title": "SPDX License Expression",
+                  "description": "A valid SPDX license expression.\nRefer to https://spdx.org/specifications for syntax requirements",
+                  "minLength": 1,
+                  "examples": [
+                    "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+                    "GPL-3.0-only WITH Classpath-exception-2.0"
+                  ]
+                },
+                "acknowledgement": {
+                  "$ref": "#/definitions/licenseAcknowledgementEnumeration"
+                },
+                "bom-ref": {
+                  "$ref": "#/definitions/refType",
+                  "title": "BOM Reference",
+                  "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+                }
+              }
+            }
           ]
         }
       ]
@@ -2469,8 +2500,6 @@
           "description": "Specifies information about the data including the directional flow of data and the data classification."
         },
         "licenses": {
-          "type": "array",
-          "additionalItems": false,
           "$ref": "#/definitions/licenseChoice",
           "title": "Service License(s)"
         },

--- a/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "./bom-1.6-custom.schema.json",
   "type": "object",
-  "title": "CycloneDX Bill of Materials Standard",
+  "title": "CycloneDX Software Bill of Materials Standard",
   "$comment": "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
   "if": {
     "required": [
@@ -31,12 +31,15 @@
   "additionalProperties": false,
   "properties": {
     "$schema": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "./bom-1.6-custom.schema.json"
+      ]
     },
     "bomFormat": {
       "type": "string",
       "title": "BOM Format",
-      "description": "Specifies the format of the BOM. This helps to identify the file as CycloneDX since BOMs do not have a filename convention, nor does JSON schema support namespaces. This value must be \"CycloneDX\".",
+      "description": "Specifies the format of the BOM. This helps to identify the file as CycloneDX since BOMs do not have a filename convention nor does JSON schema support namespaces. This value MUST be \"CycloneDX\".",
       "enum": [
         "CycloneDX"
       ]
@@ -44,7 +47,7 @@
     "specVersion": {
       "type": "string",
       "title": "CycloneDX Specification Version",
-      "description": "The version of the CycloneDX specification the BOM conforms to.",
+      "description": "The version of the CycloneDX specification a BOM conforms to (starting at version 1.2).",
       "examples": [
         "1.6"
       ]
@@ -52,7 +55,7 @@
     "serialNumber": {
       "type": "string",
       "title": "BOM Serial Number",
-      "description": "Every BOM generated SHOULD have a unique serial number, even if the contents of the BOM have not changed over time. If specified, the serial number must conform to RFC-4122. Use of serial numbers is recommended.",
+      "description": "Every BOM generated SHOULD have a unique serial number, even if the contents of the BOM have not changed over time. If specified, the serial number MUST conform to RFC-4122. Use of serial numbers are RECOMMENDED.",
       "examples": [
         "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
       ],
@@ -62,7 +65,6 @@
       "type": "integer",
       "title": "BOM Version",
       "description": "Whenever an existing BOM is modified, either manually or through automated processes, the version of the BOM SHOULD be incremented by 1. When a system is presented with multiple BOMs with identical serial numbers, the system SHOULD use the most recent version of the BOM. The default version is '1'.",
-      "minimum": 1,
       "default": 1,
       "examples": [
         1
@@ -75,6 +77,7 @@
     },
     "components": {
       "type": "array",
+      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/component"
       },
@@ -84,6 +87,7 @@
     },
     "services": {
       "type": "array",
+      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/service"
       },
@@ -93,32 +97,36 @@
     },
     "externalReferences": {
       "type": "array",
+      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/externalReference"
       },
       "title": "External References",
-      "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+      "description": "External references provide a way to document systems, sites, and information that may be relevant but which are not included with the BOM."
     },
     "dependencies": {
       "type": "array",
+      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/dependency"
       },
       "uniqueItems": true,
       "title": "Dependencies",
-      "description": "Provides the ability to document dependency relationships including provided & implemented components."
+      "description": "Provides the ability to document dependency relationships."
     },
     "compositions": {
       "type": "array",
+      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/compositions"
       },
       "uniqueItems": true,
       "title": "Compositions",
-      "description": "Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness. The completeness of vulnerabilities expressed in a BOM may also be described."
+      "description": "Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness."
     },
     "vulnerabilities": {
       "type": "array",
+      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/vulnerability"
       },
@@ -128,468 +136,36 @@
     },
     "annotations": {
       "type": "array",
+      "additionalItems": false,
       "items": {
-        "$ref": "#/definitions/annotations"
+        "type": "object"
       },
-      "uniqueItems": true,
       "title": "Annotations",
-      "description": "Comments made by people, organizations, or tools about any object with a bom-ref, such as components, services, vulnerabilities, or the BOM itself. Unlike inventory information, annotations may contain opinions or commentary from various stakeholders. Annotations may be inline (with inventory) or externalized via BOM-Link and may optionally be signed."
+      "description": "Comments made by people, organizations, or tools about any object with a bom-ref."
     },
     "formulation": {
       "type": "array",
+      "additionalItems": false,
       "items": {
-        "$ref": "#/definitions/formula"
+        "type": "object"
       },
-      "uniqueItems": true,
       "title": "Formulation",
-      "description": "Describes how a component or service was manufactured or deployed. This is achieved through the use of formulas, workflows, tasks, and steps, which declare the precise steps to reproduce along with the observed formulas describing the steps which transpired in the manufacturing process."
+      "description": "Describes how a component or service was manufactured or deployed."
     },
     "declarations": {
       "type": "object",
       "title": "Declarations",
-      "description": "The list of declarations which describe the conformance to standards. Each declaration may include attestations, claims, and evidence.",
-      "additionalProperties": false,
-      "properties": {
-        "assessors": {
-          "type": "array",
-          "title": "Assessors",
-          "description": "The list of assessors evaluating claims and determining conformance to requirements and confidence in that assessment.",
-          "items": {
-            "type": "object",
-            "title": "Assessor",
-            "description": "The assessor who evaluates claims and determines conformance to requirements and confidence in that assessment.",
-            "additionalProperties": false,
-            "properties": {
-              "bom-ref": {
-                "$ref": "#/definitions/refType",
-                "title": "BOM Reference",
-                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
-              },
-              "thirdParty": {
-                "type": "boolean",
-                "title": "Third Party",
-                "description": "The boolean indicating if the assessor is outside the organization generating claims. A value of false indicates a self assessor."
-              },
-              "organization": {
-                "$ref": "#/definitions/organizationalEntity",
-                "title": "Organization",
-                "description": "The entity issuing the assessment."
-              }
-            }
-          }
-        },
-        "attestations": {
-          "type": "array",
-          "title": "Attestations",
-          "description": "The list of attestations asserted by an assessor that maps requirements to claims.",
-          "items": {
-            "type": "object",
-            "title": "Attestation",
-            "additionalProperties": false,
-            "properties": {
-              "summary": {
-                "type": "string",
-                "title": "Summary",
-                "description": "The short description explaining the main points of the attestation."
-              },
-              "assessor": {
-                "$ref": "#/definitions/refLinkType",
-                "title": "Assessor",
-                "description": "The `bom-ref` to the assessor asserting the attestation."
-              },
-              "map": {
-                "type": "array",
-                "title": "Map",
-                "description": "The grouping of requirements to claims and the attestors declared conformance and confidence thereof.",
-                "items": {
-                  "type": "object",
-                  "title": "Map",
-                  "additionalProperties": false,
-                  "properties": {
-                    "requirement": {
-                      "$ref": "#/definitions/refLinkType",
-                      "title": "Requirement",
-                      "description": "The `bom-ref` to the requirement being attested to."
-                    },
-                    "claims": {
-                      "type": "array",
-                      "title": "Claims",
-                      "description": "The list of `bom-ref` to the claims being attested to.",
-                      "items": {
-                        "$ref": "#/definitions/refLinkType"
-                      }
-                    },
-                    "counterClaims": {
-                      "type": "array",
-                      "title": "Counter Claims",
-                      "description": "The list of  `bom-ref` to the counter claims being attested to.",
-                      "items": {
-                        "$ref": "#/definitions/refLinkType"
-                      }
-                    },
-                    "conformance": {
-                      "type": "object",
-                      "title": "Conformance",
-                      "description": "The conformance of the claim meeting a requirement.",
-                      "additionalProperties": false,
-                      "properties": {
-                        "score": {
-                          "type": "number",
-                          "minimum": 0,
-                          "maximum": 1,
-                          "title": "Score",
-                          "description": "The conformance of the claim between and inclusive of 0 and 1, where 1 is 100% conformance."
-                        },
-                        "rationale": {
-                          "type": "string",
-                          "title": "Rationale",
-                          "description": "The rationale for the conformance score."
-                        },
-                        "mitigationStrategies": {
-                          "type": "array",
-                          "title": "Mitigation Strategies",
-                          "description": "The list of  `bom-ref` to the evidence provided describing the mitigation strategies.",
-                          "items": {
-                            "$ref": "#/definitions/refLinkType"
-                          }
-                        }
-                      }
-                    },
-                    "confidence": {
-                      "type": "object",
-                      "title": "Confidence",
-                      "description": "The confidence of the claim meeting the requirement.",
-                      "additionalProperties": false,
-                      "properties": {
-                        "score": {
-                          "type": "number",
-                          "minimum": 0,
-                          "maximum": 1,
-                          "title": "Score",
-                          "description": "The confidence of the claim between and inclusive of 0 and 1, where 1 is 100% confidence."
-                        },
-                        "rationale": {
-                          "type": "string",
-                          "title": "Rationale",
-                          "description": "The rationale for the confidence score."
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "signature": {
-                "$ref": "#/definitions/signature",
-                "title": "Signature",
-                "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
-              }
-            }
-          }
-        },
-        "claims": {
-          "type": "array",
-          "title": "Claims",
-          "description": "The list of claims.",
-          "items": {
-            "type": "object",
-            "title": "Claim",
-            "additionalProperties": false,
-            "properties": {
-              "bom-ref": {
-                "$ref": "#/definitions/refType",
-                "title": "BOM Reference",
-                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
-              },
-              "target": {
-                "$ref": "#/definitions/refLinkType",
-                "title": "Target",
-                "description": "The `bom-ref` to a target representing a specific system, application, API, module, team, person, process, business unit, company, etc...  that this claim is being applied to."
-              },
-              "predicate": {
-                "type": "string",
-                "title": "Predicate",
-                "description": "The specific statement or assertion about the target."
-              },
-              "mitigationStrategies": {
-                "type": "array",
-                "title": "Mitigation Strategies",
-                "description": "The list of  `bom-ref` to the evidence provided describing the mitigation strategies. Each mitigation strategy should include an explanation of how any weaknesses in the evidence will be mitigated.",
-                "items": {
-                  "$ref": "#/definitions/refLinkType"
-                }
-              },
-              "reasoning": {
-                "type": "string",
-                "title": "Reasoning",
-                "description": "The written explanation of why the evidence provided substantiates the claim."
-              },
-              "evidence": {
-                "type": "array",
-                "title": "Evidence",
-                "description": "The list of `bom-ref` to evidence that supports this claim.",
-                "items": {
-                  "$ref": "#/definitions/refLinkType"
-                }
-              },
-              "counterEvidence": {
-                "type": "array",
-                "title": "Counter Evidence",
-                "description": "The list of `bom-ref` to counterEvidence that supports this claim.",
-                "items": {
-                  "$ref": "#/definitions/refLinkType"
-                }
-              },
-              "externalReferences": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/externalReference"
-                },
-                "title": "External References",
-                "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
-              },
-              "signature": {
-                "$ref": "#/definitions/signature",
-                "title": "Signature",
-                "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
-              }
-            }
-          }
-        },
-        "evidence": {
-          "type": "array",
-          "title": "Evidence",
-          "description": "The list of evidence",
-          "items": {
-            "type": "object",
-            "title": "Evidence",
-            "additionalProperties": false,
-            "properties": {
-              "bom-ref": {
-                "$ref": "#/definitions/refType",
-                "title": "BOM Reference",
-                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
-              },
-              "propertyName": {
-                "type": "string",
-                "title": "Property Name",
-                "description": "The reference to the property name as defined in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy/)."
-              },
-              "description": {
-                "type": "string",
-                "title": "Description",
-                "description": "The written description of what this evidence is and how it was created."
-              },
-              "data": {
-                "type": "array",
-                "title": "Data",
-                "description": "The output or analysis that supports claims.",
-                "items": {
-                  "type": "object",
-                  "title": "Data",
-                  "additionalProperties": false,
-                  "properties": {
-                    "name": {
-                      "title": "Data Name",
-                      "description": "The name of the data.",
-                      "type": "string"
-                    },
-                    "contents": {
-                      "type": "object",
-                      "title": "Data Contents",
-                      "description": "The contents or references to the contents of the data being described.",
-                      "additionalProperties": false,
-                      "properties": {
-                        "attachment": {
-                          "title": "Data Attachment",
-                          "description": "An optional way to include textual or encoded data.",
-                          "$ref": "#/definitions/attachment"
-                        },
-                        "url": {
-                          "type": "string",
-                          "title": "Data URL",
-                          "description": "The URL to where the data can be retrieved.",
-                          "format": "iri-reference"
-                        }
-                      }
-                    },
-                    "classification": {
-                      "$ref": "#/definitions/dataClassification"
-                    },
-                    "sensitiveData": {
-                      "type": "array",
-                      "title": "Sensitive Data",
-                      "description": "A description of any sensitive data included.",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "governance": {
-                      "title": "Data Governance",
-                      "$ref": "#/definitions/dataGovernance"
-                    }
-                  }
-                }
-              },
-              "created": {
-                "type": "string",
-                "format": "date-time",
-                "title": "Created",
-                "description": "The date and time (timestamp) when the evidence was created."
-              },
-              "expires": {
-                "type": "string",
-                "format": "date-time",
-                "title": "Expires",
-                "description": "The optional date and time (timestamp) when the evidence is no longer valid."
-              },
-              "author": {
-                "$ref": "#/definitions/organizationalContact",
-                "title": "Author",
-                "description": "The author of the evidence."
-              },
-              "reviewer": {
-                "$ref": "#/definitions/organizationalContact",
-                "title": "Reviewer",
-                "description": "The reviewer of the evidence."
-              },
-              "signature": {
-                "$ref": "#/definitions/signature",
-                "title": "Signature",
-                "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
-              }
-            }
-          }
-        },
-        "targets": {
-          "type": "object",
-          "title": "Targets",
-          "description": "The list of targets which claims are made against.",
-          "additionalProperties": false,
-          "properties": {
-            "organizations": {
-              "type": "array",
-              "title": "Organizations",
-              "description": "The list of organizations which claims are made against.",
-              "items": {
-                "$ref": "#/definitions/organizationalEntity"
-              }
-            },
-            "components": {
-              "type": "array",
-              "title": "Components",
-              "description": "The list of components which claims are made against.",
-              "items": {
-                "$ref": "#/definitions/component"
-              }
-            },
-            "services": {
-              "type": "array",
-              "title": "Services",
-              "description": "The list of services which claims are made against.",
-              "items": {
-                "$ref": "#/definitions/service"
-              }
-            }
-          }
-        },
-        "affirmation": {
-          "type": "object",
-          "title": "Affirmation",
-          "description": "A concise statement affirmed by an individual regarding all declarations, often used for third-party auditor acceptance or recipient acknowledgment. It includes a list of authorized signatories who assert the validity of the document on behalf of the organization.",
-          "additionalProperties": false,
-          "properties": {
-            "statement": {
-              "type": "string",
-              "title": "Statement",
-              "description": "The brief statement affirmed by an individual regarding all declarations.\n*- Notes This could be an affirmation of acceptance by a third-party auditor or receiving individual of a file.",
-              "examples": [
-                "I certify, to the best of my knowledge, that all information is correct."
-              ]
-            },
-            "signatories": {
-              "type": "array",
-              "title": "Signatories",
-              "description": "The list of signatories authorized on behalf of an organization to assert validity of this document.",
-              "items": {
-                "type": "object",
-                "title": "Signatory",
-                "additionalProperties": false,
-                "oneOf": [
-                  {
-                    "required": [
-                      "signature"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "externalReference",
-                      "organization"
-                    ]
-                  }
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "title": "Name",
-                    "description": "The signatory's name."
-                  },
-                  "role": {
-                    "type": "string",
-                    "title": "Role",
-                    "description": "The signatory's role within an organization."
-                  },
-                  "signature": {
-                    "$ref": "#/definitions/signature",
-                    "title": "Signature",
-                    "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
-                  },
-                  "organization": {
-                    "$ref": "#/definitions/organizationalEntity",
-                    "title": "Organization",
-                    "description": "The signatory's organization."
-                  },
-                  "externalReference": {
-                    "$ref": "#/definitions/externalReference",
-                    "title": "External Reference",
-                    "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
-                  }
-                }
-              }
-            },
-            "signature": {
-              "$ref": "#/definitions/signature",
-              "title": "Signature",
-              "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
-            }
-          }
-        },
-        "signature": {
-          "$ref": "#/definitions/signature",
-          "title": "Signature",
-          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
-        }
-      }
+      "description": "The list of declarations which describe the conformance to standards."
     },
     "definitions": {
       "type": "object",
       "title": "Definitions",
-      "description": "A collection of reusable objects that are defined and may be used elsewhere in the BOM.",
-      "additionalProperties": false,
-      "properties": {
-        "standards": {
-          "type": "array",
-          "title": "Standards",
-          "description": "The list of standards which may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.",
-          "items": {
-            "$ref": "#/definitions/standard"
-          }
-        }
-      }
+      "description": "A collection of reusable objects that are defined and may be used elsewhere in the BOM."
     },
     "properties": {
       "type": "array",
       "title": "Properties",
-      "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+      "additionalItems": false,
       "items": {
         "$ref": "#/definitions/property"
       }
@@ -602,34 +178,33 @@
   },
   "definitions": {
     "refType": {
-      "description": "Identifier for referable and therefore interlinkable elements.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+      "$comment": "Identifier-DataType for interlinked elements.",
       "type": "string",
-      "additionalProperties": false,
-      "minLength": 1,
-      "$comment": "TODO (breaking change): add a format constraint that prevents the value from staring with 'urn:cdx:'"
+      "additionalProperties": false
     },
     "refLinkType": {
-      "description": "Descriptor for an element identified by the attribute 'bom-ref' in the same BOM document.\nIn contrast to `bomLinkElementType`.",
-      "$ref": "#/definitions/refType"
+      "description": "Descriptor for an element identified by the attribute 'bom-ref' in the same BOM document.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/refType"
+        }
+      ]
     },
     "bomLinkDocumentType": {
       "title": "BOM-Link Document",
-      "description": "Descriptor for another BOM document. See https://cyclonedx.org/capabilities/bomlink/",
+      "description": "Descriptor for another BOM document.",
       "type": "string",
       "format": "iri-reference",
-      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*$",
-      "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
+      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*$"
     },
     "bomLinkElementType": {
       "title": "BOM-Link Element",
-      "description": "Descriptor for an element in a BOM document. See https://cyclonedx.org/capabilities/bomlink/",
+      "description": "Descriptor for an element in a BOM document.",
       "type": "string",
       "format": "iri-reference",
-      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*#.+$",
-      "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
+      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*#.+$"
     },
     "bomLink": {
-      "title": "BOM-Link",
       "anyOf": [
         {
           "title": "BOM-Link Document",
@@ -643,7 +218,7 @@
     },
     "metadata": {
       "type": "object",
-      "title": "BOM Metadata",
+      "title": "BOM Metadata Object",
       "additionalProperties": false,
       "properties": {
         "timestamp": {
@@ -655,115 +230,48 @@
         "lifecycles": {
           "type": "array",
           "title": "Lifecycles",
-          "description": "Lifecycles communicate the stage(s) in which data in the BOM was captured. Different types of data may be available at various phases of a lifecycle, such as the Software Development Lifecycle (SDLC), IT Asset Management (ITAM), and Software Asset Management (SAM). Thus, a BOM may include data specific to or only obtainable in a given lifecycle.",
           "items": {
-            "type": "object",
-            "title": "Lifecycle",
-            "description": "The product lifecycle(s) that this BOM represents.",
-            "oneOf": [
-              {
-                "title": "Pre-Defined Phase",
-                "required": [
-                  "phase"
-                ],
-                "additionalProperties": false,
-                "properties": {
-                  "phase": {
-                    "type": "string",
-                    "title": "Phase",
-                    "description": "A pre-defined phase in the product lifecycle.",
-                    "enum": [
-                      "design",
-                      "pre-build",
-                      "build",
-                      "post-build",
-                      "operations",
-                      "discovery",
-                      "decommission"
-                    ],
-                    "meta:enum": {
-                      "design": "BOM produced early in the development lifecycle containing an inventory of components and services that are proposed or planned to be used. The inventory may need to be procured, retrieved, or resourced prior to use.",
-                      "pre-build": "BOM consisting of information obtained prior to a build process and may contain source files and development artifacts and manifests. The inventory may need to be resolved and retrieved prior to use.",
-                      "build": "BOM consisting of information obtained during a build process where component inventory is available for use. The precise versions of resolved components are usually available at this time as well as the provenance of where the components were retrieved from.",
-                      "post-build": "BOM consisting of information obtained after a build process has completed and the resulting components(s) are available for further analysis. Built components may exist as the result of a CI/CD process, may have been installed or deployed to a system or device, and may need to be retrieved or extracted from the system or device.",
-                      "operations": "BOM produced that represents inventory that is running and operational. This may include staging or production environments and will generally encompass multiple SBOMs describing the applications and operating system, along with HBOMs describing the hardware that makes up the system. Operations Bill of Materials (OBOM) can provide full-stack inventory of runtime environments, configurations, and additional dependencies.",
-                      "discovery": "BOM consisting of information observed through network discovery providing point-in-time enumeration of embedded, on-premise, and cloud-native services such as server applications, connected devices, microservices, and serverless functions.",
-                      "decommission": "BOM containing inventory that will be, or has been retired from operations."
-                    }
-                  }
-                }
-              },
-              {
-                "title": "Custom Phase",
-                "required": [
-                  "name"
-                ],
-                "additionalProperties": false,
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "title": "Name",
-                    "description": "The name of the lifecycle phase"
-                  },
-                  "description": {
-                    "type": "string",
-                    "title": "Description",
-                    "description": "The description of the lifecycle phase"
-                  }
-                }
-              }
-            ]
+            "type": "object"
           }
         },
         "tools": {
-          "title": "Tools",
-          "description": "The tool(s) used in the creation, enrichment, and validation of the BOM.",
           "oneOf": [
             {
               "type": "object",
-              "title": "Tools",
-              "description": "The tool(s) used in the creation, enrichment, and validation of the BOM.",
+              "title": "Creation Tools",
               "additionalProperties": false,
               "properties": {
                 "components": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/tools_component"
-                  },
-                  "uniqueItems": true,
-                  "title": "Components",
-                  "description": "A list of software and hardware components used as tools."
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ]
+                  }
                 },
                 "services": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/service"
-                  },
-                  "uniqueItems": true,
-                  "title": "Services",
-                  "description": "A list of services used as tools. This may include microservices, function-as-a-service, and other types of network or intra-process services."
+                    "type": "object"
+                  }
                 }
               }
             },
             {
               "type": "array",
-              "title": "Tools (legacy)",
-              "description": "[Deprecated] The tool(s) used in the creation, enrichment, and validation of the BOM.",
+              "title": "Creation Tools (legacy)",
               "items": {
                 "$ref": "#/definitions/tool"
               }
             }
           ]
         },
-        "manufacturer": {
-          "title": "BOM Manufacturer",
-          "description": "The organization that created the BOM.\nManufacturer is common in BOMs created through automated processes. BOMs created through manual means may have `@.authors` instead.",
-          "$ref": "#/definitions/organizationalEntity"
-        },
         "authors": {
           "type": "array",
-          "title": "BOM Authors",
-          "description": "The person(s) who created the BOM.\nAuthors are common in BOMs created through manual processes. BOMs created through automated means may have `@.manufacturer` instead.",
+          "title": "Authors",
+          "description": "The person(s) who created the BOM. Authors are common in BOMs created through manual processes. BOMs created through automated means may not have authors.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/organizationalContact"
           }
@@ -774,9 +282,8 @@
           "$ref": "#/definitions/component"
         },
         "manufacture": {
-          "deprecated": true,
-          "title": "Component Manufacture (legacy)",
-          "description": "[Deprecated] This will be removed in a future version. Use the `@.component.manufacturer` instead.\nThe organization that manufactured the component that the BOM describes.",
+          "title": "Manufacture",
+          "description": "The organization that manufactured the component that the BOM describes.",
           "$ref": "#/definitions/organizationalEntity"
         },
         "supplier": {
@@ -785,20 +292,18 @@
           "$ref": "#/definitions/organizationalEntity"
         },
         "licenses": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/licenseChoice"
-            },
-            {
-              "minItems": 1
-            }
-          ],
-          "title": "Component License(s)"
+          "type": "array",
+          "title": "BOM License(s)",
+          "minItems": 1,
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/licenseChoice"
+          }
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -813,7 +318,7 @@
     "tool": {
       "type": "object",
       "title": "Tool",
-      "description": "[Deprecated] This will be removed in a future version. Use component or service instead. Information about the automated or manual tool used",
+      "description": "Information about the automated or manual tool used",
       "additionalProperties": false,
       "properties": {
         "vendor": {
@@ -827,12 +332,13 @@
           "description": "The name of the tool"
         },
         "version": {
-          "$ref": "#/definitions/version",
+          "type": "string",
           "title": "Tool Version",
           "description": "The version of the tool"
         },
         "hashes": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/hash"
           },
@@ -841,37 +347,34 @@
         },
         "externalReferences": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/externalReference"
           },
           "title": "External References",
-          "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but which are not included with the BOM."
         }
       }
     },
     "organizationalEntity": {
       "type": "object",
-      "title": "Organizational Entity",
+      "title": "Organizational Entity Object",
+      "description": "",
       "additionalProperties": false,
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
         },
         "name": {
           "type": "string",
-          "title": "Organization Name",
+          "title": "Name",
           "minLength": 1,
           "description": "The name of the organization",
           "examples": [
             "Example Inc."
           ]
-        },
-        "address": {
-          "$ref": "#/definitions/postalAddress",
-          "title": "Organization Address",
-          "description": "The physical address (location) of the organization"
         },
         "url": {
           "type": "array",
@@ -879,7 +382,7 @@
             "type": "string",
             "format": "iri-reference"
           },
-          "title": "Organization URL(s)",
+          "title": "URL",
           "description": "The URL of the organization. Multiple URLs are allowed.",
           "examples": [
             "https://example.com"
@@ -887,8 +390,9 @@
         },
         "contact": {
           "type": "array",
-          "title": "Organizational Contact",
+          "title": "Contact",
           "description": "A contact at the organization. Multiple contacts are allowed.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/organizationalContact"
           }
@@ -914,13 +418,14 @@
     },
     "organizationalContact": {
       "type": "object",
-      "title": "Organizational Contact",
+      "title": "Organizational Contact Object",
+      "description": "",
       "additionalProperties": false,
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
         },
         "name": {
           "type": "string",
@@ -954,7 +459,7 @@
     },
     "component": {
       "type": "object",
-      "title": "Component",
+      "title": "Component Object",
       "required": [
         "type",
         "name",
@@ -979,23 +484,7 @@
             "data",
             "cryptographic-asset"
           ],
-          "meta:enum": {
-            "application": "A software application. Refer to [https://en.wikipedia.org/wiki/Application_software](https://en.wikipedia.org/wiki/Application_software) for information about applications.",
-            "framework": "A software framework. Refer to [https://en.wikipedia.org/wiki/Software_framework](https://en.wikipedia.org/wiki/Software_framework) for information on how frameworks vary slightly from libraries.",
-            "library": "A software library. Refer to [https://en.wikipedia.org/wiki/Library_(computing)](https://en.wikipedia.org/wiki/Library_(computing)) for information about libraries. All third-party and open source reusable components will likely be a library. If the library also has key features of a framework, then it should be classified as a framework. If not, or is unknown, then specifying library is recommended.",
-            "container": "A packaging and/or runtime format, not specific to any particular technology, which isolates software inside the container from software outside of a container through virtualization technology. Refer to [https://en.wikipedia.org/wiki/OS-level_virtualization](https://en.wikipedia.org/wiki/OS-level_virtualization).",
-            "platform": "A runtime environment which interprets or executes software. This may include runtimes such as those that execute bytecode or low-code/no-code application platforms.",
-            "operating-system": "A software operating system without regard to deployment model (i.e. installed on physical hardware, virtual machine, image, etc) Refer to [https://en.wikipedia.org/wiki/Operating_system](https://en.wikipedia.org/wiki/Operating_system).",
-            "device": "A hardware device such as a processor or chip-set. A hardware device containing firmware SHOULD include a component for the physical hardware itself and another component of type 'firmware' or 'operating-system' (whichever is relevant), describing information about the software running on the device. See also the list of [known device properties](https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/device.md).",
-            "device-driver": "A special type of software that operates or controls a particular type of device. Refer to [https://en.wikipedia.org/wiki/Device_driver](https://en.wikipedia.org/wiki/Device_driver).",
-            "firmware": "A special type of software that provides low-level control over a device's hardware. Refer to [https://en.wikipedia.org/wiki/Firmware](https://en.wikipedia.org/wiki/Firmware).",
-            "file": "A computer file. Refer to [https://en.wikipedia.org/wiki/Computer_file](https://en.wikipedia.org/wiki/Computer_file) for information about files.",
-            "machine-learning-model": "A model based on training data that can make predictions or decisions without being explicitly programmed to do so.",
-            "data": "A collection of discrete values that convey information.",
-            "cryptographic-asset": "A cryptographic asset including algorithms, protocols, certificates, keys, tokens, and secrets."
-          },
           "title": "Component Type",
-          "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component.",
           "examples": [
             "library"
           ]
@@ -1003,7 +492,7 @@
         "mime-type": {
           "type": "string",
           "title": "Mime-Type",
-          "description": "The optional mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented, such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
+          "description": "The optional mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
           "examples": [
             "image/jpeg"
           ],
@@ -1012,32 +501,17 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "minLength": 1,
-          "description": "An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
         },
         "supplier": {
           "title": "Component Supplier",
           "description": " The organization that supplied the component. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
           "$ref": "#/definitions/organizationalEntity"
         },
-        "manufacturer": {
-          "title": "Component Manufacturer",
-          "description": "The organization that created the component.\nManufacturer is common in components created through automated processes. Components created through manual means may have `@.authors` instead.",
-          "$ref": "#/definitions/organizationalEntity"
-        },
-        "authors": {
-          "type": "array",
-          "title": "Component Authors",
-          "description": "The person(s) who created the component.\nAuthors are common in components created through manual processes. Components created through automated means may have `@.manufacturer` instead.",
-          "items": {
-            "$ref": "#/definitions/organizationalContact"
-          }
-        },
         "author": {
-          "deprecated": true,
           "type": "string",
-          "title": "Component Author (legacy)",
-          "description": "[Deprecated] This will be removed in a future version. Use `@.authors` or `@.manufacturer` instead.\nThe person(s) or organization(s) that authored the component",
+          "title": "Component Author",
+          "description": "The person(s) or organization(s) that authored the component",
           "examples": [
             "Acme Inc"
           ]
@@ -1060,18 +534,21 @@
         },
         "name": {
           "type": "string",
-          "title": "Component Name",
           "minLength": 1,
+          "title": "Component Name",
           "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
           "examples": [
             "tomcat-catalina"
           ]
         },
         "version": {
-          "$ref": "#/definitions/version",
+          "type": "string",
           "title": "Component Version",
           "minLength": 1,
-          "description": "The component version. The version should ideally comply with semantic versioning but is not enforced."
+          "description": "The component version. The version should ideally comply with semantic versioning but is not enforced.",
+          "examples": [
+            "9.0.14"
+          ]
         },
         "description": {
           "type": "string",
@@ -1085,11 +562,6 @@
             "optional",
             "excluded"
           ],
-          "meta:enum": {
-            "required": "The component is required for runtime",
-            "optional": "The component is optional at runtime. Optional components are components that are not capable of being called due to them not being installed or otherwise accessible by any means. Components that are installed but due to configuration or other restrictions are prohibited from being called must be scoped as 'required'.",
-            "excluded": "Components that are excluded provide the ability to document component usage for test and other non-runtime purposes. Excluded components are not reachable within a call graph at runtime."
-          },
           "title": "Component Scope",
           "description": "Specifies the scope of the component. If scope is not specified, 'required' scope SHOULD be assumed by the consumer of the BOM.",
           "default": "required"
@@ -1097,20 +569,18 @@
         "hashes": {
           "type": "array",
           "title": "Component Hashes",
-          "description": "The hashes of the component.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/hash"
           }
         },
         "licenses": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/licenseChoice"
-            },
-            {
-              "minItems": 1
-            }
-          ],
+          "type": "array",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/licenseChoice"
+          },
+          "minItems": 1,
           "title": "Component License(s)"
         },
         "copyright": {
@@ -1123,63 +593,38 @@
         },
         "cpe": {
           "type": "string",
-          "title": "Common Platform Enumeration (CPE)",
-          "description": "Asserts the identity of the component using CPE. The CPE must conform to the CPE 2.2 or 2.3 specification. See [https://nvd.nist.gov/products/cpe](https://nvd.nist.gov/products/cpe). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "title": "Component Common Platform Enumeration (CPE)",
+          "description": "Specifies a well-formed CPE name that conforms to the CPE 2.2 or 2.3 specification. See [https://nvd.nist.gov/products/cpe](https://nvd.nist.gov/products/cpe)",
           "examples": [
             "cpe:2.3:a:acme:component_framework:-:*:*:*:*:*:*:*"
           ]
         },
         "purl": {
           "type": "string",
-          "title": "Package URL (purl)",
-          "description": "Asserts the identity of the component using package-url (purl). The purl, if specified, must be valid and conform to the specification defined at: [https://github.com/package-url/purl-spec](https://github.com/package-url/purl-spec). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "title": "Component Package URL (purl)",
+          "description": "Specifies the package-url (purl). The purl, if specified, MUST be valid and conform to the specification defined at: [https://github.com/package-url/purl-spec](https://github.com/package-url/purl-spec)",
           "examples": [
             "pkg:maven/com.acme/tomcat-catalina@9.0.14?packaging=jar"
-          ]
-        },
-        "omniborId": {
-          "type": "array",
-          "title": "OmniBOR Artifact Identifier (gitoid)",
-          "description": "Asserts the identity of the component using the OmniBOR Artifact ID. The OmniBOR, if specified, must be valid and conform to the specification defined at: [https://www.iana.org/assignments/uri-schemes/prov/gitoid](https://www.iana.org/assignments/uri-schemes/prov/gitoid). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
-          "items": {
-            "type": "string"
-          },
-          "examples": [
-            "gitoid:blob:sha1:a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-            "gitoid:blob:sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
-          ]
-        },
-        "swhid": {
-          "type": "array",
-          "title": "SoftWare Heritage Identifier",
-          "description": "Asserts the identity of the component using the Software Heritage persistent identifier (SWHID). The SWHID, if specified, must be valid and conform to the specification defined at: [https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html](https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
-          "items": {
-            "type": "string"
-          },
-          "examples": [
-            "swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2"
           ]
         },
         "swid": {
           "$ref": "#/definitions/swid",
           "title": "SWID Tag",
-          "description": "Asserts the identity of the component using [ISO-IEC 19770-2 Software Identification (SWID) Tags](https://www.iso.org/standard/65666.html). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity."
+          "description": "Specifies metadata and content for [ISO-IEC 19770-2 Software Identification (SWID) Tags](https://www.iso.org/standard/65666.html)."
         },
         "modified": {
           "type": "boolean",
-          "title": "Component Modified From Original",
-          "description": "[Deprecated] This will be removed in a future version. Use the pedigree element instead to supply information on exactly how the component was modified. A boolean value indicating if the component has been modified from the original. A value of true indicates the component is a derivative of the original. A value of false indicates the component has not been modified from the original."
+          "title": "Component Modified From Original"
         },
         "pedigree": {
           "type": "object",
           "title": "Component Pedigree",
-          "description": "Component pedigree is a way to document complex supply chain scenarios where components are created, distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to document variants where the exact relation may not be known.",
           "additionalProperties": false,
           "properties": {
             "ancestors": {
               "type": "array",
               "title": "Ancestors",
-              "description": "Describes zero or more components in which a component is derived from. This is commonly used to describe forks from existing projects where the forked version contains a ancestor node containing the original component it was forked from. For example, Component A is the original component. Component B is the component being used and documented in the BOM. However, Component B contains a pedigree node with a single ancestor documenting Component A - the original component from which Component B is derived from.",
+              "additionalItems": false,
               "items": {
                 "$ref": "#/definitions/component"
               }
@@ -1187,7 +632,7 @@
             "descendants": {
               "type": "array",
               "title": "Descendants",
-              "description": "Descendants are the exact opposite of ancestors. This provides a way to document all forks (and their forks) of an original or root component.",
+              "additionalItems": false,
               "items": {
                 "$ref": "#/definitions/component"
               }
@@ -1195,7 +640,7 @@
             "variants": {
               "type": "array",
               "title": "Variants",
-              "description": "Variants describe relations where the relationship between the components is not known. For example, if Component A contains nearly identical code to Component B. They are both related, but it is unclear if one is derived from the other, or if they share a common ancestor.",
+              "additionalItems": false,
               "items": {
                 "$ref": "#/definitions/component"
               }
@@ -1203,7 +648,7 @@
             "commits": {
               "type": "array",
               "title": "Commits",
-              "description": "A list of zero or more commits which provide a trail describing how the component deviates from an ancestor, descendant, or variant.",
+              "additionalItems": false,
               "items": {
                 "$ref": "#/definitions/commit"
               }
@@ -1211,77 +656,64 @@
             "patches": {
               "type": "array",
               "title": "Patches",
-              "description": ">A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complementary to commits or may be used in place of commits.",
+              "additionalItems": false,
               "items": {
                 "$ref": "#/definitions/patch"
               }
             },
             "notes": {
               "type": "string",
-              "title": "Notes",
-              "description": "Notes, observations, and other non-structured commentary describing the components pedigree."
+              "title": "Notes"
             }
           }
         },
         "externalReferences": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/externalReference"
           },
-          "title": "External References",
-          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+          "title": "External References"
         },
         "components": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/component"
           },
           "uniqueItems": true,
-          "title": "Components",
-          "description": "A list of software and hardware components included in the parent component. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system &#8594; subsystem &#8594; parts assembly in physical supply chains."
+          "title": "Components"
         },
         "evidence": {
           "$ref": "#/definitions/componentEvidence",
-          "title": "Evidence",
-          "description": "Provides the ability to document evidence collected through various forms of extraction or analysis."
+          "title": "Evidence"
         },
         "releaseNotes": {
           "$ref": "#/definitions/releaseNotes",
-          "title": "Release notes",
-          "description": "Specifies optional release notes."
+          "title": "Release notes"
         },
         "modelCard": {
-          "$ref": "#/definitions/modelCard",
-          "title": "AI/ML Model Card"
+          "type": "object",
+          "title": "Machine Learning Model Card"
         },
         "data": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/componentData"
+            "type": "object"
           },
-          "title": "Data",
-          "description": "This object SHOULD be specified for any component of type `data` and must not be specified for other component types."
-        },
-        "cryptoProperties": {
-          "$ref": "#/definitions/cryptoProperties",
-          "title": "Cryptographic Properties"
+          "title": "Data"
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/property"
           }
         },
-        "tags": {
-          "$ref": "#/definitions/tags",
-          "title": "Tags"
-        },
         "signature": {
           "$ref": "#/definitions/signature",
-          "title": "Signature",
-          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+          "title": "Signature"
         }
       },
       "anyOf": [
@@ -1324,7 +756,7 @@
         ]
       },
       "else": {
-        "$comment": "These requirements only apply to components which DO not reference an external SBOM.",
+        "$comment": "These requirements only apply to components which DO NOT reference an external SBOM.",
         "allOf": [
           {
             "required": [
@@ -1647,13 +1079,8 @@
         "contentType": {
           "type": "string",
           "title": "Content-Type",
-          "description": "Specifies the format and nature of the data being attached, helping systems correctly interpret and process the content. Common content type examples include `application/json` for JSON data and `text/plain` for plan text documents.\n [RFC 2045 section 5.1](https://www.ietf.org/rfc/rfc2045.html#section-5.1) outlines the structure and use of content types. For a comprehensive list of registered content types, refer to the [IANA media types registry](https://www.iana.org/assignments/media-types/media-types.xhtml).",
-          "default": "text/plain",
-          "examples": [
-            "text/plain",
-            "application/json",
-            "image/png"
-          ]
+          "description": "Specifies the content type of the text. Defaults to text/plain if not specified.",
+          "default": "text/plain"
         },
         "encoding": {
           "type": "string",
@@ -1661,10 +1088,7 @@
           "description": "Specifies the optional encoding the text is represented in.",
           "enum": [
             "base64"
-          ],
-          "meta:enum": {
-            "base64": "Base64 is a binary-to-text encoding scheme that represents binary data in an ASCII string."
-          }
+          ]
         },
         "content": {
           "type": "string",
@@ -1676,7 +1100,7 @@
     },
     "hash": {
       "type": "object",
-      "title": "Hash",
+      "title": "Hash Objects",
       "required": [
         "alg",
         "content"
@@ -1693,8 +1117,6 @@
     },
     "hash-alg": {
       "type": "string",
-      "title": "Hash Algorithm",
-      "description": "The algorithm that generated the hash value.",
       "enum": [
         "MD5",
         "SHA-1",
@@ -1709,12 +1131,12 @@
         "BLAKE2b-512",
         "BLAKE3"
       ],
+      "title": "Hash Algorithm",
       "additionalProperties": false
     },
     "hash-content": {
       "type": "string",
-      "title": "Hash Value",
-      "description": "The value of the hash.",
+      "title": "Hash Content (value)",
       "examples": [
         "3942447fac867ae5cdb3229b658f4d48"
       ],
@@ -1723,8 +1145,7 @@
     },
     "license": {
       "type": "object",
-      "title": "License",
-      "description": "Specifies the details and attributes related to a software license. It can either include a valid SPDX license identifier or a named license, along with additional properties such as license acknowledgment, comprehensive commercial licensing information, and the full text of the license.",
+      "title": "License Object",
       "oneOf": [
         {
           "required": [
@@ -1742,27 +1163,24 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref MUST be unique within the BOM."
         },
         "id": {
           "$ref": "spdx.schema.json",
           "title": "License ID (SPDX)",
-          "description": "A valid SPDX license identifier. If specified, this value must be one of the enumeration of valid SPDX license identifiers defined in the spdx.schema.json (or spdx.xml) subschema which is synchronized with the official SPDX license list.",
+          "description": "A valid SPDX license ID",
           "examples": [
             "Apache-2.0"
           ]
         },
         "name": {
           "type": "string",
-          "title": "License Name",
           "minLength": 1,
-          "description": "The name of the license. This may include the name of a commercial or proprietary license or an open source license that may not be defined by SPDX.",
+          "title": "License Name",
+          "description": "If SPDX does not define the license used, this field may be used to provide the license name",
           "examples": [
             "Acme Software License"
           ]
-        },
-        "acknowledgement": {
-          "$ref": "#/definitions/licenseAcknowledgementEnumeration"
         },
         "text": {
           "title": "License text",
@@ -1783,11 +1201,32 @@
           "title": "Licensing information",
           "description": "Licensing details describing the licensor/licensee, license type, renewal and expiration dates, and other important metadata",
           "additionalProperties": false,
+          "required": [
+            "licenseTypes"
+          ],
+          "if": {
+            "properties": {
+              "licenseTypes": {
+                "contains": {
+                  "not": {
+                    "const": "appliance"
+                  }
+                }
+              }
+            },
+            "required": [
+              "licenseTypes"
+            ]
+          },
+          "then": {
+            "required": [
+              "licensor"
+            ]
+          },
           "properties": {
             "altIds": {
               "type": "array",
               "title": "Alternate License Identifiers",
-              "description": "License identifiers that may be used to manage licenses and their lifecycle",
               "items": {
                 "type": "string"
               }
@@ -1830,12 +1269,10 @@
               "properties": {
                 "organization": {
                   "title": "Licensee (Organization)",
-                  "description": "The organization that was granted the license",
                   "$ref": "#/definitions/organizationalEntity"
                 },
                 "individual": {
                   "title": "Licensee (Individual)",
-                  "description": "The individual, not associated with an organization, that was granted the license",
                   "$ref": "#/definitions/organizationalContact"
                 }
               },
@@ -1860,12 +1297,10 @@
               "properties": {
                 "organization": {
                   "title": "Purchaser (Organization)",
-                  "description": "The organization that purchased the license",
                   "$ref": "#/definitions/organizationalEntity"
                 },
                 "individual": {
                   "title": "Purchaser (Individual)",
-                  "description": "The individual, not associated with an organization, that purchased the license",
                   "$ref": "#/definitions/organizationalContact"
                 }
               },
@@ -1884,13 +1319,11 @@
             },
             "purchaseOrder": {
               "type": "string",
-              "title": "Purchase Order",
-              "description": "The purchase order identifier the purchaser sent to a supplier or vendor to authorize a purchase"
+              "title": "Purchase Order"
             },
             "licenseTypes": {
               "type": "array",
               "title": "License Type",
-              "description": "The type of license(s) that was granted to the licensee.",
               "items": {
                 "type": "string",
                 "enum": [
@@ -1910,68 +1343,24 @@
                   "subscription",
                   "user",
                   "other"
-                ],
-                "meta:enum": {
-                  "academic": "A license that grants use of software solely for the purpose of education or research.",
-                  "appliance": "A license covering use of software embedded in a specific piece of hardware.",
-                  "client-access": "A Client Access License (CAL) allows client computers to access services provided by server software.",
-                  "concurrent-user": "A Concurrent User license (aka floating license) limits the number of licenses for a software application and licenses are shared among a larger number of users.",
-                  "core-points": "A license where the core of a computer's processor is assigned a specific number of points.",
-                  "custom-metric": "A license for which consumption is measured by non-standard metrics.",
-                  "device": "A license that covers a defined number of installations on computers and other types of devices.",
-                  "evaluation": "A license that grants permission to install and use software for trial purposes.",
-                  "named-user": "A license that grants access to the software to one or more pre-defined users.",
-                  "node-locked": "A license that grants access to the software on one or more pre-defined computers or devices.",
-                  "oem": "An Original Equipment Manufacturer license that is delivered with hardware, cannot be transferred to other hardware, and is valid for the life of the hardware.",
-                  "perpetual": "A license where the software is sold on a one-time basis and the licensee can use a copy of the software indefinitely.",
-                  "processor-points": "A license where each installation consumes points per processor.",
-                  "subscription": "A license where the licensee pays a fee to use the software or service.",
-                  "user": "A license that grants access to the software or service by a specified number of users.",
-                  "other": "Another license type."
-                }
+                ]
               }
             },
             "lastRenewal": {
               "type": "string",
               "format": "date-time",
-              "title": "Last Renewal",
-              "description": "The timestamp indicating when the license was last renewed. For new purchases, this is often the purchase or acquisition date. For non-perpetual licenses or subscriptions, this is the timestamp of when the license was last renewed."
+              "title": "Last Renewal"
             },
             "expiration": {
               "type": "string",
               "format": "date-time",
-              "title": "Expiration",
-              "description": "The timestamp indicating when the current license expires (if applicable)."
+              "title": "Expiration"
             }
-          },
-          "allOf": [
-            {
-              "if": {
-                "properties": {
-                  "licenseTypes": {
-                    "contains": {
-                      "const": "appliance"
-                    }
-                  }
-                },
-                "required": [
-                  "licenseTypes"
-                ]
-              },
-              "then": {},
-              "else": {
-                "required": [
-                  "licenseTypes",
-                  "licensor"
-                ]
-              }
-            }
-          ]
+          }
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -1984,62 +1373,36 @@
         ]
       }
     },
-    "licenseAcknowledgementEnumeration": {
-      "title": "License Acknowledgement",
-      "description": "Declared licenses and concluded licenses represent two different stages in the licensing process within software development. Declared licenses refer to the initial intention of the software authors regarding the licensing terms under which their code is released. On the other hand, concluded licenses are the result of a comprehensive analysis of the project's codebase to identify and confirm the actual licenses of the components used, which may differ from the initially declared licenses. While declared licenses provide an upfront indication of the licensing intentions, concluded licenses offer a more thorough understanding of the actual licensing within a project, facilitating proper compliance and risk management. Observed licenses are defined in `@.evidence.licenses`. Observed licenses form the evidence necessary to substantiate a concluded license.",
-      "type": "string",
-      "enum": [
-        "declared",
-        "concluded"
-      ],
-      "meta:enum": {
-        "declared": "Declared licenses represent the initial intentions of authors regarding the licensing terms of their code.",
-        "concluded": "Concluded licenses are verified and confirmed."
-      }
-    },
     "licenseChoice": {
-      "title": "License Choice",
-      "description": "EITHER (list of SPDX licenses and/or named licenses) OR (tuple of one SPDX License Expression)",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "oneOf": [
-          {
-            "required": [
-              "license"
-            ]
-          },
-          {
-            "required": [
-              "expression"
-            ]
-          }
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "license": {
-            "$ref": "#/definitions/license"
-          },
-          "expression": {
-            "type": "string",
-            "title": "SPDX License Expression",
-            "description": "A valid SPDX license expression.\nRefer to https://spdx.org/specifications for syntax requirements",
-            "minLength": 1,
-            "examples": [
-              "Apache-2.0 AND (MIT OR GPL-2.0-only)",
-              "GPL-3.0-only WITH Classpath-exception-2.0"
-            ]
-          },
-          "acknowledgement": {
-            "$ref": "#/definitions/licenseAcknowledgementEnumeration"
-          },
-          "bom-ref": {
-            "$ref": "#/definitions/refType",
-            "title": "BOM Reference",
-            "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
-          }
+      "type": "object",
+      "title": "License(s)",
+      "additionalProperties": false,
+      "properties": {
+        "license": {
+          "$ref": "#/definitions/license"
+        },
+        "expression": {
+          "type": "string",
+          "minLength": 1,
+          "title": "SPDX License Expression",
+          "examples": [
+            "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+            "GPL-3.0-only WITH Classpath-exception-2.0"
+          ]
         }
-      }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "license"
+          ]
+        },
+        {
+          "required": [
+            "expression"
+          ]
+        }
+      ]
     },
     "commit": {
       "type": "object",
@@ -2049,29 +1412,24 @@
       "properties": {
         "uid": {
           "type": "string",
-          "title": "UID",
-          "description": "A unique identifier of the commit. This may be version control specific. For example, Subversion uses revision numbers whereas git uses commit hashes."
+          "title": "UID"
         },
         "url": {
           "type": "string",
           "title": "URL",
-          "description": "The URL to the commit. This URL will typically point to a commit in a version control system.",
           "format": "iri-reference"
         },
         "author": {
           "title": "Author",
-          "description": "The author who created the changes in the commit",
           "$ref": "#/definitions/identifiableAction"
         },
         "committer": {
           "title": "Committer",
-          "description": "The person who committed or pushed the commit",
           "$ref": "#/definitions/identifiableAction"
         },
         "message": {
           "type": "string",
-          "title": "Message",
-          "description": "The text description of the contents of the commit"
+          "title": "Message"
         }
       }
     },
@@ -2092,45 +1450,34 @@
             "backport",
             "cherry-pick"
           ],
-          "meta:enum": {
-            "unofficial": "A patch which is not developed by the creators or maintainers of the software being patched. Refer to [https://en.wikipedia.org/wiki/Unofficial_patch](https://en.wikipedia.org/wiki/Unofficial_patch).",
-            "monkey": "A patch which dynamically modifies runtime behavior. Refer to [https://en.wikipedia.org/wiki/Monkey_patch](https://en.wikipedia.org/wiki/Monkey_patch).",
-            "backport": "A patch which takes code from a newer version of the software and applies it to older versions of the same software. Refer to [https://en.wikipedia.org/wiki/Backporting](https://en.wikipedia.org/wiki/Backporting).",
-            "cherry-pick": "A patch created by selectively applying commits from other versions or branches of the same software."
-          },
-          "title": "Patch Type",
-          "description": "Specifies the purpose for the patch including the resolution of defects, security issues, or new behavior or functionality."
+          "title": "Type"
         },
         "diff": {
           "title": "Diff",
-          "description": "The patch file (or diff) that shows changes. Refer to [https://en.wikipedia.org/wiki/Diff](https://en.wikipedia.org/wiki/Diff)",
           "$ref": "#/definitions/diff"
         },
         "resolves": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/issue"
           },
-          "title": "Resolves",
-          "description": "A collection of issues the patch resolves"
+          "title": "Resolves"
         }
       }
     },
     "diff": {
       "type": "object",
       "title": "Diff",
-      "description": "The patch file (or diff) that shows changes. Refer to https://en.wikipedia.org/wiki/Diff",
       "additionalProperties": false,
       "properties": {
         "text": {
           "title": "Diff text",
-          "description": "Specifies the optional text of the diff",
           "$ref": "#/definitions/attachment"
         },
         "url": {
           "type": "string",
           "title": "URL",
-          "description": "Specifies the URL to the diff",
           "format": "iri-reference"
         }
       }
@@ -2151,49 +1498,32 @@
             "enhancement",
             "security"
           ],
-          "meta:enum": {
-            "defect": "A fault, flaw, or bug in software.",
-            "enhancement": "A new feature or behavior in software.",
-            "security": "A special type of defect which impacts security."
-          },
-          "title": "Issue Type",
-          "description": "Specifies the type of issue"
+          "title": "Type"
         },
         "id": {
           "type": "string",
-          "title": "Issue ID",
-          "description": "The identifier of the issue assigned by the source of the issue"
+          "title": "ID"
         },
         "name": {
           "type": "string",
-          "title": "Issue Name",
-          "description": "The name of the issue"
+          "title": "Name"
         },
         "description": {
           "type": "string",
-          "title": "Issue Description",
-          "description": "A description of the issue"
+          "title": "Description"
         },
         "source": {
           "type": "object",
           "title": "Source",
-          "description": "The source of the issue where it is documented",
           "additionalProperties": false,
           "properties": {
             "name": {
               "type": "string",
-              "title": "Name",
-              "description": "The name of the source.",
-              "examples": [
-                "National Vulnerability Database",
-                "NVD",
-                "Apache"
-              ]
+              "title": "Name"
             },
             "url": {
               "type": "string",
               "title": "URL",
-              "description": "The url of the issue documentation as provided by the source",
               "format": "iri-reference"
             }
           }
@@ -2204,43 +1534,35 @@
             "type": "string",
             "format": "iri-reference"
           },
-          "title": "References",
-          "description": "A collection of URL's for reference. Multiple URLs are allowed.",
-          "examples": [
-            "https://example.com"
-          ]
+          "title": "References"
         }
       }
     },
     "identifiableAction": {
       "type": "object",
       "title": "Identifiable Action",
-      "description": "Specifies an individual commit",
       "additionalProperties": false,
       "properties": {
         "timestamp": {
           "type": "string",
           "format": "date-time",
-          "title": "Timestamp",
-          "description": "The timestamp in which the action occurred"
+          "title": "Timestamp"
         },
         "name": {
           "type": "string",
-          "title": "Name",
-          "description": "The name of the individual who performed the action"
+          "title": "Name"
         },
         "email": {
           "type": "string",
           "format": "idn-email",
-          "title": "E-mail",
-          "description": "The email address of the individual who performed the action"
+          "title": "E-mail"
         }
       }
     },
     "externalReference": {
       "type": "object",
       "title": "External Reference",
-      "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM.",
+      "description": "Specifies an individual external reference",
       "required": [
         "url",
         "type"
@@ -2248,30 +1570,18 @@
       "additionalProperties": false,
       "properties": {
         "url": {
-          "anyOf": [
-            {
-              "title": "URL",
-              "type": "string",
-              "format": "iri-reference",
-              "minLength": 1
-            },
-            {
-              "title": "BOM-Link",
-              "$ref": "#/definitions/bomLink"
-            }
-          ],
+          "type": "string",
           "title": "URL",
-          "description": "The URI (URL or URN) to the external reference. External references are URIs and therefore can accept any URL scheme including https ([RFC-7230](https://www.ietf.org/rfc/rfc7230.txt)), mailto ([RFC-2368](https://www.ietf.org/rfc/rfc2368.txt)), tel ([RFC-3966](https://www.ietf.org/rfc/rfc3966.txt)), and dns ([RFC-4501](https://www.ietf.org/rfc/rfc4501.txt)). External references may also include formally registered URNs such as [CycloneDX BOM-Link](https://cyclonedx.org/capabilities/bomlink/) to reference CycloneDX BOMs or any object within a BOM. BOM-Link transforms applicable external references into relationships that can be expressed in a BOM or across BOMs."
+          "format": "iri-reference",
+          "minLength": 1
         },
         "comment": {
           "type": "string",
-          "title": "Comment",
-          "description": "An optional comment describing the external reference"
+          "title": "Comment"
         },
         "type": {
           "type": "string",
           "title": "Type",
-          "description": "Specifies the type of external reference.",
           "enum": [
             "vcs",
             "issue-tracker",
@@ -2283,133 +1593,50 @@
             "chat",
             "documentation",
             "support",
-            "source-distribution",
             "distribution",
-            "distribution-intake",
             "license",
             "build-meta",
             "build-system",
             "release-notes",
-            "security-contact",
-            "model-card",
-            "log",
-            "configuration",
-            "evidence",
-            "formulation",
-            "attestation",
-            "threat-model",
-            "adversary-model",
-            "risk-assessment",
-            "vulnerability-assertion",
-            "exploitability-statement",
-            "pentest-report",
-            "static-analysis-report",
-            "dynamic-analysis-report",
-            "runtime-analysis-report",
-            "component-analysis-report",
-            "maturity-report",
-            "certification-report",
-            "codified-infrastructure",
-            "quality-metrics",
-            "poam",
-            "electronic-signature",
-            "digital-signature",
-            "rfc-9116",
             "other"
-          ],
-          "meta:enum": {
-            "vcs": "Version Control System",
-            "issue-tracker": "Issue or defect tracking system, or an Application Lifecycle Management (ALM) system",
-            "website": "Website",
-            "advisories": "Security advisories",
-            "bom": "Bill of Materials (SBOM, OBOM, HBOM, SaaSBOM, etc)",
-            "mailing-list": "Mailing list or discussion group",
-            "social": "Social media account",
-            "chat": "Real-time chat platform",
-            "documentation": "Documentation, guides, or how-to instructions",
-            "support": "Community or commercial support",
-            "source-distribution": "The location where the source code distributable can be obtained. This is often an archive format such as zip or tgz. The source-distribution type complements use of the version control (vcs) type.",
-            "distribution": "Direct or repository download location",
-            "distribution-intake": "The location where a component was published to. This is often the same as \"distribution\" but may also include specialized publishing processes that act as an intermediary.",
-            "license": "The reference to the license file. If a license URL has been defined in the license node, it should also be defined as an external reference for completeness.",
-            "build-meta": "Build-system specific meta file (i.e. pom.xml, package.json, .nuspec, etc)",
-            "build-system": "Reference to an automated build system",
-            "release-notes": "Reference to release notes",
-            "security-contact": "Specifies a way to contact the maintainer, supplier, or provider in the event of a security incident. Common URIs include links to a disclosure procedure, a mailto (RFC-2368) that specifies an email address, a tel (RFC-3966) that specifies a phone number, or dns (RFC-4501) that specifies the records containing DNS Security TXT.",
-            "model-card": "A model card describes the intended uses of a machine learning model, potential limitations, biases, ethical considerations, training parameters, datasets used to train the model, performance metrics, and other relevant data useful for ML transparency.",
-            "log": "A record of events that occurred in a computer system or application, such as problems, errors, or information on current operations.",
-            "configuration": "Parameters or settings that may be used by other components or services.",
-            "evidence": "Information used to substantiate a claim.",
-            "formulation": "Describes how a component or service was manufactured or deployed.",
-            "attestation": "Human or machine-readable statements containing facts, evidence, or testimony.",
-            "threat-model": "An enumeration of identified weaknesses, threats, and countermeasures, dataflow diagram (DFD), attack tree, and other supporting documentation in human-readable or machine-readable format.",
-            "adversary-model": "The defined assumptions, goals, and capabilities of an adversary.",
-            "risk-assessment": "Identifies and analyzes the potential of future events that may negatively impact individuals, assets, and/or the environment. Risk assessments may also include judgments on the tolerability of each risk.",
-            "vulnerability-assertion": "A Vulnerability Disclosure Report (VDR) which asserts the known and previously unknown vulnerabilities that affect a component, service, or product including the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on a component, service, or product.",
-            "exploitability-statement": "A Vulnerability Exploitability eXchange (VEX) which asserts the known vulnerabilities that do not affect a product, product family, or organization, and optionally the ones that do. The VEX should include the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on the product, product family, or organization.",
-            "pentest-report": "Results from an authorized simulated cyberattack on a component or service, otherwise known as a penetration test.",
-            "static-analysis-report": "SARIF or proprietary machine or human-readable report for which static analysis has identified code quality, security, and other potential issues with the source code.",
-            "dynamic-analysis-report": "Dynamic analysis report that has identified issues such as vulnerabilities and misconfigurations.",
-            "runtime-analysis-report": "Report generated by analyzing the call stack of a running application.",
-            "component-analysis-report": "Report generated by Software Composition Analysis (SCA), container analysis, or other forms of component analysis.",
-            "maturity-report": "Report containing a formal assessment of an organization, business unit, or team against a maturity model.",
-            "certification-report": "Industry, regulatory, or other certification from an accredited (if applicable) certification body.",
-            "codified-infrastructure": "Code or configuration that defines and provisions virtualized infrastructure, commonly referred to as Infrastructure as Code (IaC).",
-            "quality-metrics": "Report or system in which quality metrics can be obtained.",
-            "poam": "Plans of Action and Milestones (POA&M) complement an \"attestation\" external reference. POA&M is defined by NIST as a \"document that identifies tasks needing to be accomplished. It details resources required to accomplish the elements of the plan, any milestones in meeting the tasks and scheduled completion dates for the milestones\".",
-            "electronic-signature": "An e-signature is commonly a scanned representation of a written signature or a stylized script of the person's name.",
-            "digital-signature": "A signature that leverages cryptography, typically public/private key pairs, which provides strong authenticity verification.",
-            "rfc-9116": "Document that complies with [RFC 9116](https://www.ietf.org/rfc/rfc9116.html) (A File Format to Aid in Security Vulnerability Disclosure)",
-            "other": "Use this if no other types accurately describe the purpose of the external reference."
-          }
+          ]
         },
         "hashes": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/hash"
           },
-          "title": "Hashes",
-          "description": "The hashes of the external reference (if applicable)."
+          "title": "Hashes"
         }
       }
     },
     "dependency": {
       "type": "object",
       "title": "Dependency",
-      "description": "Defines the direct dependencies of a component, service, or the components provided/implemented by a given component. Components or services that do not have their own dependencies must be declared as empty elements within the graph. Components or services that are not represented in the dependency graph may have unknown dependencies. It is recommended that implementations assume this to be opaque and not an indicator of an object being dependency-free. It is recommended to leverage compositions to indicate unknown dependency graphs.",
       "required": [
         "ref"
       ],
       "additionalProperties": false,
       "properties": {
         "ref": {
-          "$ref": "#/definitions/refLinkType",
-          "title": "Reference",
-          "description": "References a component or service by its bom-ref attribute"
+          "$ref": "#/definitions/refType",
+          "title": "Reference"
         },
         "dependsOn": {
           "type": "array",
           "uniqueItems": true,
+          "additionalItems": false,
           "items": {
-            "$ref": "#/definitions/refLinkType"
+            "$ref": "#/definitions/refType"
           },
-          "title": "Depends On",
-          "description": "The bom-ref identifiers of the components or services that are dependencies of this dependency object."
-        },
-        "provides": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/refLinkType"
-          },
-          "title": "Provides",
-          "description": "The bom-ref identifiers of the components or services that define a given specification or standard, which are provided or implemented by this dependency object.\nFor example, a cryptographic library which implements a cryptographic algorithm. A component which implements another component does not imply that the implementation is in use."
+          "title": "Depends On"
         }
       }
     },
     "service": {
       "type": "object",
-      "title": "Service",
+      "title": "Service Object",
       "required": [
         "name"
       ],
@@ -2417,39 +1644,27 @@
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "title": "BOM Reference"
         },
         "provider": {
           "title": "Provider",
-          "description": "The organization that provides the service.",
           "$ref": "#/definitions/organizationalEntity"
         },
         "group": {
           "type": "string",
-          "title": "Service Group",
-          "description": "The grouping name, namespace, or identifier. This will often be a shortened, single name of the company or project that produced the service or domain name. Whitespace and special characters should be avoided.",
-          "examples": [
-            "com.acme"
-          ]
+          "title": "Service Group"
         },
         "name": {
           "type": "string",
-          "title": "Service Name",
-          "description": "The name of the service. This will often be a shortened, single name of the service.",
-          "examples": [
-            "ticker-service"
-          ]
+          "title": "Service Name"
         },
         "version": {
-          "$ref": "#/definitions/version",
-          "title": "Service Version",
-          "description": "The service version."
+          "type": "string",
+          "title": "Service Version"
         },
         "description": {
           "type": "string",
-          "title": "Service Description",
-          "description": "Specifies a description for the service"
+          "title": "Service Description"
         },
         "endpoints": {
           "type": "array",
@@ -2457,83 +1672,70 @@
             "type": "string",
             "format": "iri-reference"
           },
-          "title": "Endpoints",
-          "description": "The endpoint URIs of the service. Multiple endpoints are allowed.",
-          "examples": [
-            "https://example.com/api/v1/ticker"
-          ]
+          "title": "Endpoints"
         },
         "authenticated": {
           "type": "boolean",
-          "title": "Authentication Required",
-          "description": "A boolean value indicating if the service requires authentication. A value of true indicates the service requires authentication prior to use. A value of false indicates the service does not require authentication."
+          "title": "Authentication Required"
         },
         "x-trust-boundary": {
           "type": "boolean",
-          "title": "Crosses Trust Boundary",
-          "description": "A boolean value indicating if use of the service crosses a trust zone or boundary. A value of true indicates that by using the service, a trust boundary is crossed. A value of false indicates that by using the service, a trust boundary is not crossed."
-        },
-        "trustZone": {
-          "type": "string",
-          "title": "Trust Zone",
-          "description": "The name of the trust zone the service resides in."
+          "title": "Crosses Trust Boundary"
         },
         "data": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/serviceData"
           },
-          "title": "Data",
-          "description": "Specifies information about the data including the directional flow of data and the data classification."
+          "title": "Data"
         },
         "licenses": {
-          "$ref": "#/definitions/licenseChoice",
-          "title": "Service License(s)"
+          "type": "array",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/licenseChoice"
+          },
+          "title": "Component License(s)"
         },
         "externalReferences": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/externalReference"
           },
-          "title": "External References",
-          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+          "title": "External References"
         },
         "services": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/service"
           },
           "uniqueItems": true,
-          "title": "Services",
-          "description": "A list of services included or deployed behind the parent service. This is not a dependency tree. It provides a way to specify a hierarchical representation of service assemblies."
+          "title": "Services"
         },
         "releaseNotes": {
           "$ref": "#/definitions/releaseNotes",
-          "title": "Release notes",
-          "description": "Specifies optional release notes."
+          "title": "Release notes"
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/property"
           }
         },
-        "tags": {
-          "$ref": "#/definitions/tags",
-          "title": "Tags"
-        },
         "signature": {
           "$ref": "#/definitions/signature",
-          "title": "Signature",
-          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+          "title": "Signature"
         }
       }
     },
     "serviceData": {
       "type": "object",
-      "title": "Hash Objects",
+      "title": "Service Data",
       "required": [
         "flow",
         "classification"
@@ -2542,67 +1744,11 @@
       "properties": {
         "flow": {
           "$ref": "#/definitions/dataFlowDirection",
-          "title": "Directional Flow",
-          "description": "Specifies the flow direction of the data. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways and unknown states that the direction is not known."
+          "title": "Directional Flow"
         },
         "classification": {
-          "$ref": "#/definitions/dataClassification"
-        },
-        "name": {
           "type": "string",
-          "title": "Name",
-          "description": "Name for the defined data",
-          "examples": [
-            "Credit card reporting"
-          ]
-        },
-        "description": {
-          "type": "string",
-          "title": "Description",
-          "description": "Short description of the data content and usage",
-          "examples": [
-            "Credit card information being exchanged in between the web app and the database"
-          ]
-        },
-        "governance": {
-          "title": "Data Governance",
-          "$ref": "#/definitions/dataGovernance"
-        },
-        "source": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "title": "URL",
-                "type": "string",
-                "format": "iri-reference"
-              },
-              {
-                "title": "BOM-Link Element",
-                "$ref": "#/definitions/bomLinkElementType"
-              }
-            ]
-          },
-          "title": "Source",
-          "description": "The URI, URL, or BOM-Link of the components or services the data came in from"
-        },
-        "destination": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "title": "URL",
-                "type": "string",
-                "format": "iri-reference"
-              },
-              {
-                "title": "BOM-Link Element",
-                "$ref": "#/definitions/bomLinkElementType"
-              }
-            ]
-          },
-          "title": "Destination",
-          "description": "The URI, URL, or BOM-Link of the components or services the data is sent to"
+          "title": "Classification"
         }
       }
     },
@@ -2614,20 +1760,11 @@
         "bi-directional",
         "unknown"
       ],
-      "meta:enum": {
-        "inbound": "Data that enters a service.",
-        "outbound": "Data that exits a service.",
-        "bi-directional": "Data flows in and out of the service.",
-        "unknown": "The directional flow of data is not known."
-      },
-      "title": "Data flow direction",
-      "additionalProperties": false,
-      "description": "Specifies the flow direction of the data. Direction is relative to the service."
+      "title": "Data flow direction"
     },
     "copyright": {
       "type": "object",
       "title": "Copyright",
-      "description": "A copyright notice informing users of the underlying claims to copyright ownership in a published work.",
       "required": [
         "text"
       ],
@@ -2635,153 +1772,30 @@
       "properties": {
         "text": {
           "type": "string",
-          "title": "Copyright Text",
-          "description": "The textual content of the copyright."
+          "title": "Copyright Text"
         }
       }
     },
     "componentEvidence": {
       "type": "object",
       "title": "Evidence",
-      "description": "Provides the ability to document evidence collected through various forms of extraction or analysis.",
       "additionalProperties": false,
       "properties": {
-        "identity": {
-          "title": "Identity Evidence",
-          "description": "Evidence that substantiates the identity of a component. The identify may be an object or an array of identity objects. Support for specifying identity as a single object was introduced in CycloneDX v1.5. Arrays were introduced in v1.6. It is recommended that all implementations use arrays, even if only one identity object is specified.",
-          "oneOf": [
-            {
-              "type": "array",
-              "title": "Array of Identity Objects",
-              "items": {
-                "$ref": "#/definitions/componentIdentityEvidence"
-              }
-            },
-            {
-              "title": "A Single Identity Object",
-              "description": "[Deprecated]",
-              "$ref": "#/definitions/componentIdentityEvidence",
-              "deprecated": true
-            }
-          ]
-        },
-        "occurrences": {
-          "type": "array",
-          "title": "Occurrences",
-          "description": "Evidence of individual instances of a component spread across multiple locations.",
-          "items": {
-            "type": "object",
-            "required": [
-              "location"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "bom-ref": {
-                "$ref": "#/definitions/refType",
-                "title": "BOM Reference",
-                "description": "An optional identifier which can be used to reference the occurrence elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
-              },
-              "location": {
-                "type": "string",
-                "title": "Location",
-                "description": "The location or path to where the component was found."
-              },
-              "line": {
-                "type": "integer",
-                "minimum": 0,
-                "title": "Line Number",
-                "description": "The line number where the component was found."
-              },
-              "offset": {
-                "type": "integer",
-                "minimum": 0,
-                "title": "Offset",
-                "description": "The offset where the component was found."
-              },
-              "symbol": {
-                "type": "string",
-                "title": "Symbol",
-                "description": "The symbol name that was found associated with the component."
-              },
-              "additionalContext": {
-                "type": "string",
-                "title": "Additional Context",
-                "description": "Any additional context of the detected component (e.g. a code snippet)."
-              }
-            }
-          }
-        },
-        "callstack": {
-          "type": "object",
-          "title": "Call Stack",
-          "description": "Evidence of the components use through the callstack.",
-          "additionalProperties": false,
-          "properties": {
-            "frames": {
-              "type": "array",
-              "title": "Frames",
-              "description": "Within a call stack, a frame is a discrete unit that encapsulates an execution context, including local variables, parameters, and the return address. As function calls are made, frames are pushed onto the stack, forming an array-like structure that orchestrates the flow of program execution and manages the sequence of function invocations.",
-              "items": {
-                "type": "object",
-                "required": [
-                  "module"
-                ],
-                "additionalProperties": false,
-                "properties": {
-                  "package": {
-                    "title": "Package",
-                    "description": "A package organizes modules into namespaces, providing a unique namespace for each type it contains.",
-                    "type": "string"
-                  },
-                  "module": {
-                    "title": "Module",
-                    "description": "A module or class that encloses functions/methods and other code.",
-                    "type": "string"
-                  },
-                  "function": {
-                    "title": "Function",
-                    "description": "A block of code designed to perform a particular task.",
-                    "type": "string"
-                  },
-                  "parameters": {
-                    "title": "Parameters",
-                    "description": "Optional arguments that are passed to the module or function.",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "line": {
-                    "title": "Line",
-                    "description": "The line number the code that is called resides on.",
-                    "type": "integer"
-                  },
-                  "column": {
-                    "title": "Column",
-                    "description": "The column the code that is called resides.",
-                    "type": "integer"
-                  },
-                  "fullFilename": {
-                    "title": "Full Filename",
-                    "description": "The full path and filename of the module.",
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
         "licenses": {
-          "$ref": "#/definitions/licenseChoice",
-          "title": "License Evidence"
+          "type": "array",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/licenseChoice"
+          },
+          "title": "Component License(s)"
         },
         "copyright": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/copyright"
           },
-          "title": "Copyright Evidence",
-          "description": "Copyright evidence captures intellectual property assertions, providing evidence of possible ownership and legal protection."
+          "title": "Copyright"
         }
       }
     },
@@ -2796,31 +1810,19 @@
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the composition elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "title": "BOM Reference"
         },
         "aggregate": {
           "$ref": "#/definitions/aggregateType",
-          "title": "Aggregate",
-          "description": "Specifies an aggregate type that describe how complete a relationship is."
+          "title": "Aggregate"
         },
         "assemblies": {
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "anyOf": [
-              {
-                "title": "Ref",
-                "$ref": "#/definitions/refLinkType"
-              },
-              {
-                "title": "BOM-Link Element",
-                "$ref": "#/definitions/bomLinkElementType"
-              }
-            ]
+            "type": "string"
           },
-          "title": "BOM references",
-          "description": "The bom-ref identifiers of the components or services being described. Assemblies refer to nested relationships whereby a constituent part may include other constituent parts. References do not cascade to child parts. References are explicit for the specified constituent part only."
+          "title": "BOM references"
         },
         "dependencies": {
           "type": "array",
@@ -2828,8 +1830,7 @@
           "items": {
             "type": "string"
           },
-          "title": "BOM references",
-          "description": "The bom-ref identifiers of the components or services being described. Dependencies refer to a relationship whereby an independent constituent part requires another independent constituent part. References do not cascade to transitive dependencies. References are explicit for the specified dependency only."
+          "title": "BOM references"
         },
         "vulnerabilities": {
           "type": "array",
@@ -2837,13 +1838,11 @@
           "items": {
             "type": "string"
           },
-          "title": "BOM references",
-          "description": "The bom-ref identifiers of the vulnerabilities being described."
+          "title": "Vulnerabilities"
         },
         "signature": {
           "$ref": "#/definitions/signature",
-          "title": "Signature",
-          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+          "title": "Signature"
         }
       }
     },
@@ -2854,45 +1853,23 @@
         "complete",
         "incomplete",
         "incomplete_first_party_only",
-        "incomplete_first_party_proprietary_only",
-        "incomplete_first_party_opensource_only",
         "incomplete_third_party_only",
-        "incomplete_third_party_proprietary_only",
-        "incomplete_third_party_opensource_only",
         "unknown",
         "not_specified"
       ],
-      "additionalProperties": false,
-      "meta:enum": {
-        "complete": "The relationship is complete. No further relationships including constituent components, services, or dependencies are known to exist.",
-        "incomplete": "The relationship is incomplete. Additional relationships exist and may include constituent components, services, or dependencies.",
-        "incomplete_first_party_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented.",
-        "incomplete_first_party_proprietary_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.",
-        "incomplete_first_party_opensource_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are opensource.",
-        "incomplete_third_party_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented.",
-        "incomplete_third_party_proprietary_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.",
-        "incomplete_third_party_opensource_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are opensource.",
-        "unknown": "The relationship may be complete or incomplete. This usually signifies a 'best-effort' to obtain constituent components, services, or dependencies but the completeness is inconclusive.",
-        "not_specified": "The relationship completeness is not specified."
-      }
+      "additionalProperties": false
     },
     "property": {
       "type": "object",
       "title": "Lightweight name-value pair",
-      "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-      "required": [
-        "name"
-      ],
       "properties": {
         "name": {
           "type": "string",
-          "title": "Name",
-          "description": "The name of the property. Duplicate names are allowed, each potentially having a different value."
+          "title": "Name"
         },
         "value": {
           "type": "string",
-          "title": "Value",
-          "description": "The value of the property."
+          "title": "Value"
         }
       },
       "additionalProperties": false
@@ -2901,7 +1878,6 @@
       "type": "string",
       "pattern": "^([a-z]{2})(-[A-Z]{2})?$",
       "title": "Locale",
-      "description": "Defines a syntax for representing two character language code (ISO-639) followed by an optional two character country code. The language code must be lower case. If the country code is specified, the country code must be upper case. The language code and country code must be separated by a minus sign. Examples: en, en-US, fr, fr-CA",
       "additionalProperties": false
     },
     "releaseType": {
@@ -2913,12 +1889,11 @@
         "pre-release",
         "internal"
       ],
-      "description": "The software versioning type. It is recommended that the release type use one of 'major', 'minor', 'patch', 'pre-release', or 'internal'. Representing all possible software release types is not practical, so standardizing on the recommended values, whenever possible, is strongly encouraged.\n\n* __major__ = A major release may contain significant changes or may introduce breaking changes.\n* __minor__ = A minor release, also known as an update, may contain a smaller number of changes than major releases.\n* __patch__ = Patch releases are typically unplanned and may resolve defects or important security issues.\n* __pre-release__ = A pre-release may include alpha, beta, or release candidates and typically have limited support. They provide the ability to preview a release prior to its general availability.\n* __internal__ = Internal releases are not for public consumption and are intended to be used exclusively by the project or manufacturer that produced it."
+      "additionalProperties": false
     },
     "note": {
       "type": "object",
       "title": "Note",
-      "description": "A note containing the locale and content.",
       "required": [
         "text"
       ],
@@ -2926,12 +1901,10 @@
       "properties": {
         "locale": {
           "$ref": "#/definitions/localeType",
-          "title": "Locale",
-          "description": "The ISO-639 (or higher) language code and optional ISO-3166 (or higher) country code. Examples include: \"en\", \"en-US\", \"fr\" and \"fr-CA\""
+          "title": "Locale"
         },
         "text": {
           "title": "Release note content",
-          "description": "Specifies the full content of the release note.",
           "$ref": "#/definitions/attachment"
         }
       }
@@ -2946,69 +1919,65 @@
       "properties": {
         "type": {
           "$ref": "#/definitions/releaseType",
-          "title": "Type",
-          "description": "The software versioning type the release note describes."
+          "title": "Type"
         },
         "title": {
           "type": "string",
-          "title": "Title",
-          "description": "The title of the release."
+          "title": "Title"
         },
         "featuredImage": {
           "type": "string",
           "format": "iri-reference",
-          "title": "Featured image",
-          "description": "The URL to an image that may be prominently displayed with the release note."
+          "title": "Featured image"
         },
         "socialImage": {
           "type": "string",
           "format": "iri-reference",
-          "title": "Social image",
-          "description": "The URL to an image that may be used in messaging on social media platforms."
+          "title": "Social image"
         },
         "description": {
           "type": "string",
-          "title": "Description",
-          "description": "A short description of the release."
+          "title": "Description"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time",
-          "title": "Timestamp",
-          "description": "The date and time (timestamp) when the release note was created."
+          "title": "Timestamp"
         },
         "aliases": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "title": "Aliases",
-          "description": "One or more alternate names the release may be referred to. This may include unofficial terms used by development and marketing teams (e.g. code names)."
+          "title": "Aliases"
         },
         "tags": {
-          "$ref": "#/definitions/tags",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "title": "Tags"
         },
         "resolves": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/issue"
           },
-          "title": "Resolves",
-          "description": "A collection of issues that have been resolved."
+          "title": "Resolves"
         },
         "notes": {
           "type": "array",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/note"
           },
-          "title": "Notes",
-          "description": "Zero or more release notes containing the locale and content. Multiple note objects may be specified to support release notes in a wide variety of languages."
+          "title": "Notes"
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -3018,7 +1987,6 @@
     "advisory": {
       "type": "object",
       "title": "Advisory",
-      "description": "Title and location where advisory information can be obtained. An advisory is a notification of a threat to a component, service, or system.",
       "required": [
         "url"
       ],
@@ -3026,14 +1994,12 @@
       "properties": {
         "title": {
           "type": "string",
-          "title": "Title",
-          "description": "An optional name of the advisory."
+          "title": "Title"
         },
         "url": {
           "type": "string",
           "title": "URL",
-          "format": "iri-reference",
-          "description": "Location where the advisory can be obtained."
+          "format": "iri-reference"
         }
       }
     },
@@ -3041,13 +2007,11 @@
       "type": "integer",
       "minimum": 1,
       "title": "CWE",
-      "description": "Integer representation of a Common Weaknesses Enumerations (CWE). For example 399 (of https://cwe.mitre.org/data/definitions/399.html)",
       "additionalProperties": false
     },
     "severity": {
       "type": "string",
       "title": "Severity",
-      "description": "Textual representation of the severity of the vulnerability adopted by the analysis method. If the analysis method uses values other than what is provided, the user is expected to translate appropriately.",
       "enum": [
         "critical",
         "high",
@@ -3057,45 +2021,23 @@
         "none",
         "unknown"
       ],
-      "additionalProperties": false,
-      "meta:enum": {
-        "critical": "Critical severity",
-        "high": "High severity",
-        "medium": "Medium severity",
-        "low": "Low severity",
-        "info": "Informational warning.",
-        "none": "None",
-        "unknown": "The severity is not known"
-      }
+      "additionalProperties": false
     },
     "scoreMethod": {
       "type": "string",
       "title": "Method",
-      "description": "Specifies the severity or risk scoring methodology or standard used.",
       "enum": [
         "CVSSv2",
         "CVSSv3",
         "CVSSv31",
-        "CVSSv4",
         "OWASP",
-        "SSVC",
         "other"
       ],
-      "additionalProperties": false,
-      "meta:enum": {
-        "CVSSv2": "Common Vulnerability Scoring System v2.0",
-        "CVSSv3": "Common Vulnerability Scoring System v3.0",
-        "CVSSv31": "Common Vulnerability Scoring System v3.1",
-        "CVSSv4": "Common Vulnerability Scoring System v4.0",
-        "OWASP": "OWASP Risk Rating Methodology",
-        "SSVC": "Stakeholder Specific Vulnerability Categorization",
-        "other": "Another severity or risk scoring methodology"
-      }
+      "additionalProperties": false
     },
     "impactAnalysisState": {
       "type": "string",
       "title": "Impact Analysis State",
-      "description": "Declares the current state of an occurrence of a vulnerability, after automated or manual analysis.",
       "enum": [
         "resolved",
         "resolved_with_pedigree",
@@ -3104,19 +2046,11 @@
         "false_positive",
         "not_affected"
       ],
-      "meta:enum": {
-        "resolved": "The vulnerability has been remediated.",
-        "resolved_with_pedigree": "The vulnerability has been remediated and evidence of the changes are provided in the affected components pedigree containing verifiable commit history and/or diff(s).",
-        "exploitable": "The vulnerability may be directly or indirectly exploitable.",
-        "in_triage": "The vulnerability is being investigated.",
-        "false_positive": "The vulnerability is not specific to the component or service and was falsely identified or associated.",
-        "not_affected": "The component or service is not affected by the vulnerability. Justification should be specified for all not_affected cases."
-      }
+      "additionalProperties": false
     },
     "impactAnalysisJustification": {
       "type": "string",
       "title": "Impact Analysis Justification",
-      "description": "The rationale of why the impact analysis state was asserted.",
       "enum": [
         "code_not_present",
         "code_not_reachable",
@@ -3128,112 +2062,72 @@
         "protected_at_perimeter",
         "protected_by_mitigating_control"
       ],
-      "additionalProperties": false,
-      "meta:enum": {
-        "code_not_present": "The code has been removed or tree-shaked.",
-        "code_not_reachable": "The vulnerable code is not invoked at runtime.",
-        "requires_configuration": "Exploitability requires a configurable option to be set/unset.",
-        "requires_dependency": "Exploitability requires a dependency that is not present.",
-        "requires_environment": "Exploitability requires a certain environment which is not present.",
-        "protected_by_compiler": "Exploitability requires a compiler flag to be set/unset.",
-        "protected_at_runtime": "Exploits are prevented at runtime.",
-        "protected_at_perimeter": "Attacks are blocked at physical, logical, or network perimeter.",
-        "protected_by_mitigating_control": "Preventative measures have been implemented that reduce the likelihood and/or impact of the vulnerability."
-      }
+      "additionalProperties": false
     },
     "rating": {
       "type": "object",
       "title": "Rating",
-      "description": "Defines the severity or risk ratings of a vulnerability.",
       "additionalProperties": false,
       "properties": {
         "source": {
-          "$ref": "#/definitions/vulnerabilitySource",
-          "description": "The source that calculated the severity or risk rating of the vulnerability."
+          "$ref": "#/definitions/vulnerabilitySource"
         },
         "score": {
           "type": "number",
-          "title": "Score",
-          "description": "The numerical score of the rating."
+          "title": "Score"
         },
         "severity": {
-          "$ref": "#/definitions/severity",
-          "description": "Textual representation of the severity that corresponds to the numerical score of the rating."
+          "$ref": "#/definitions/severity"
         },
         "method": {
           "$ref": "#/definitions/scoreMethod"
         },
         "vector": {
           "type": "string",
-          "title": "Vector",
-          "description": "Textual representation of the metric values used to score the vulnerability"
+          "title": "Vector"
         },
         "justification": {
           "type": "string",
-          "title": "Justification",
-          "description": "An optional reason for rating the vulnerability as it was"
+          "title": "Justification"
         }
       }
     },
     "vulnerabilitySource": {
       "type": "object",
       "title": "Source",
-      "description": "The source of vulnerability information. This is often the organization that published the vulnerability.",
       "additionalProperties": false,
       "properties": {
         "url": {
           "type": "string",
-          "title": "URL",
-          "description": "The url of the vulnerability documentation as provided by the source.",
-          "examples": [
-            "https://nvd.nist.gov/vuln/detail/CVE-2021-39182"
-          ]
+          "title": "URL"
         },
         "name": {
           "type": "string",
-          "title": "Name",
-          "description": "The name of the source.",
-          "examples": [
-            "NVD",
-            "National Vulnerability Database",
-            "OSS Index",
-            "VulnDB",
-            "GitHub Advisories"
-          ]
+          "title": "Name"
         }
       }
     },
     "vulnerability": {
       "type": "object",
       "title": "Vulnerability",
-      "description": "Defines a weakness in a component or service that could be exploited or triggered by a threat source.",
       "additionalProperties": false,
       "properties": {
         "bom-ref": {
           "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the vulnerability elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "title": "BOM Reference"
         },
         "id": {
           "type": "string",
-          "title": "ID",
-          "description": "The identifier that uniquely identifies the vulnerability.",
-          "examples": [
-            "CVE-2021-39182",
-            "GHSA-35m5-8cvj-8783",
-            "SNYK-PYTHON-ENROCRYPT-1912876"
-          ]
+          "title": "ID"
         },
         "source": {
-          "$ref": "#/definitions/vulnerabilitySource",
-          "description": "The source that published the vulnerability."
+          "$ref": "#/definitions/vulnerabilitySource"
         },
         "references": {
           "type": "array",
           "title": "References",
-          "description": "Zero or more pointers to vulnerabilities that are the equivalent of the vulnerability specified. Often times, the same vulnerability may exist in multiple sources of vulnerability intelligence, but have different identifiers. References provide a way to correlate vulnerabilities across multiple sources of vulnerability intelligence.",
+          "additionalItems": false,
           "items": {
-            "type": "object",
             "required": [
               "id",
               "source"
@@ -3242,17 +2136,10 @@
             "properties": {
               "id": {
                 "type": "string",
-                "title": "ID",
-                "description": "An identifier that uniquely identifies the vulnerability.",
-                "examples": [
-                  "CVE-2021-39182",
-                  "GHSA-35m5-8cvj-8783",
-                  "SNYK-PYTHON-ENROCRYPT-1912876"
-                ]
+                "title": "ID"
               },
               "source": {
-                "$ref": "#/definitions/vulnerabilitySource",
-                "description": "The source that published the vulnerability."
+                "$ref": "#/definitions/vulnerabilitySource"
               }
             }
           }
@@ -3260,7 +2147,7 @@
         "ratings": {
           "type": "array",
           "title": "Ratings",
-          "description": "List of vulnerability ratings",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/rating"
           }
@@ -3268,63 +2155,27 @@
         "cwes": {
           "type": "array",
           "title": "CWEs",
-          "description": "List of Common Weaknesses Enumerations (CWEs) codes that describes this vulnerability.",
-          "examples": [
-            399
-          ],
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/cwe"
           }
         },
         "description": {
           "type": "string",
-          "title": "Description",
-          "description": "A description of the vulnerability as provided by the source."
+          "title": "Description"
         },
         "detail": {
           "type": "string",
-          "title": "Details",
-          "description": "If available, an in-depth description of the vulnerability as provided by the source organization. Details often include information useful in understanding root cause."
+          "title": "Details"
         },
         "recommendation": {
           "type": "string",
-          "title": "Recommendation",
-          "description": "Recommendations of how the vulnerability can be remediated or mitigated."
-        },
-        "workaround": {
-          "type": "string",
-          "title": "Workarounds",
-          "description": "A bypass, usually temporary, of the vulnerability that reduces its likelihood and/or impact. Workarounds often involve changes to configuration or deployments."
-        },
-        "proofOfConcept": {
-          "type": "object",
-          "title": "Proof of Concept",
-          "description": "Evidence used to reproduce the vulnerability.",
-          "properties": {
-            "reproductionSteps": {
-              "type": "string",
-              "title": "Steps to Reproduce",
-              "description": "Precise steps to reproduce the vulnerability."
-            },
-            "environment": {
-              "type": "string",
-              "title": "Environment",
-              "description": "A description of the environment in which reproduction was possible."
-            },
-            "supportingMaterial": {
-              "type": "array",
-              "title": "Supporting Material",
-              "description": "Supporting material that helps in reproducing or understanding how reproduction is possible. This may include screenshots, payloads, and PoC exploit code.",
-              "items": {
-                "$ref": "#/definitions/attachment"
-              }
-            }
-          }
+          "title": "Recommendation"
         },
         "advisories": {
           "type": "array",
           "title": "Advisories",
-          "description": "Published advisories of the vulnerability if provided.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/advisory"
           }
@@ -3332,37 +2183,27 @@
         "created": {
           "type": "string",
           "format": "date-time",
-          "title": "Created",
-          "description": "The date and time (timestamp) when the vulnerability record was created in the vulnerability database."
+          "title": "Created"
         },
         "published": {
           "type": "string",
           "format": "date-time",
-          "title": "Published",
-          "description": "The date and time (timestamp) when the vulnerability record was first published."
+          "title": "Published"
         },
         "updated": {
           "type": "string",
           "format": "date-time",
-          "title": "Updated",
-          "description": "The date and time (timestamp) when the vulnerability record was last updated."
-        },
-        "rejected": {
-          "type": "string",
-          "format": "date-time",
-          "title": "Rejected",
-          "description": "The date and time (timestamp) when the vulnerability record was rejected (if applicable)."
+          "title": "Updated"
         },
         "credits": {
           "type": "object",
           "title": "Credits",
-          "description": "Individuals or organizations credited with the discovery of the vulnerability.",
           "additionalProperties": false,
           "properties": {
             "organizations": {
               "type": "array",
               "title": "Organizations",
-              "description": "The organizations credited with vulnerability discovery.",
+              "additionalItems": false,
               "items": {
                 "$ref": "#/definitions/organizationalEntity"
               }
@@ -3370,7 +2211,7 @@
             "individuals": {
               "type": "array",
               "title": "Individuals",
-              "description": "The individuals, not associated with organizations, that are credited with vulnerability discovery.",
+              "additionalItems": false,
               "items": {
                 "$ref": "#/definitions/organizationalContact"
               }
@@ -3378,49 +2219,16 @@
           }
         },
         "tools": {
-          "title": "Tools",
-          "description": "The tool(s) used to identify, confirm, or score the vulnerability.",
-          "oneOf": [
-            {
-              "type": "object",
-              "title": "Tools",
-              "description": "The tool(s) used to identify, confirm, or score the vulnerability.",
-              "additionalProperties": false,
-              "properties": {
-                "components": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/tools_component"
-                  },
-                  "uniqueItems": true,
-                  "title": "Components",
-                  "description": "A list of software and hardware components used as tools."
-                },
-                "services": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/service"
-                  },
-                  "uniqueItems": true,
-                  "title": "Services",
-                  "description": "A list of services used as tools. This may include microservices, function-as-a-service, and other types of network or intra-process services."
-                }
-              }
-            },
-            {
-              "type": "array",
-              "title": "Tools (legacy)",
-              "description": "[Deprecated] The tool(s) used to identify, confirm, or score the vulnerability.",
-              "items": {
-                "$ref": "#/definitions/tool"
-              }
-            }
-          ]
+          "type": "array",
+          "title": "Creation Tools",
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/definitions/tool"
+          }
         },
         "analysis": {
           "type": "object",
           "title": "Impact Analysis",
-          "description": "An assessment of the impact and exploitability of the vulnerability.",
           "additionalProperties": false,
           "properties": {
             "state": {
@@ -3432,7 +2240,7 @@
             "response": {
               "type": "array",
               "title": "Response",
-              "description": "A response to the vulnerability by the manufacturer, supplier, or project responsible for the affected component or service. More than one response is allowed. Responses are strongly encouraged for vulnerabilities where the analysis state is exploitable.",
+              "additionalItems": false,
               "items": {
                 "type": "string",
                 "enum": [
@@ -3441,65 +2249,34 @@
                   "update",
                   "rollback",
                   "workaround_available"
-                ],
-                "meta:enum": {
-                  "can_not_fix": "Can not fix",
-                  "will_not_fix": "Will not fix",
-                  "update": "Update to a different revision or release",
-                  "rollback": "Revert to a previous revision or release",
-                  "workaround_available": "There is a workaround available"
-                }
+                ]
               }
             },
             "detail": {
               "type": "string",
-              "title": "Detail",
-              "description": "Detailed description of the impact including methods used during assessment. If a vulnerability is not exploitable, this field should include specific details on why the component or service is not impacted by this vulnerability."
-            },
-            "firstIssued": {
-              "type": "string",
-              "format": "date-time",
-              "title": "First Issued",
-              "description": "The date and time (timestamp) when the analysis was first issued."
-            },
-            "lastUpdated": {
-              "type": "string",
-              "format": "date-time",
-              "title": "Last Updated",
-              "description": "The date and time (timestamp) when the analysis was last updated."
+              "title": "Detail"
             }
           }
         },
         "affects": {
           "type": "array",
           "uniqueItems": true,
+          "additionalItems": false,
           "items": {
-            "type": "object",
             "required": [
               "ref"
             ],
             "additionalProperties": false,
             "properties": {
               "ref": {
-                "anyOf": [
-                  {
-                    "title": "Ref",
-                    "$ref": "#/definitions/refLinkType"
-                  },
-                  {
-                    "title": "BOM-Link Element",
-                    "$ref": "#/definitions/bomLinkElementType"
-                  }
-                ],
-                "title": "Reference",
-                "description": "References a component or service by the objects bom-ref"
+                "$ref": "#/definitions/refType",
+                "title": "Reference"
               },
               "versions": {
                 "type": "array",
                 "title": "Versions",
-                "description": "Zero or more individual versions or range of versions.",
+                "additionalItems": false,
                 "items": {
-                  "type": "object",
                   "oneOf": [
                     {
                       "required": [
@@ -3515,18 +2292,12 @@
                   "additionalProperties": false,
                   "properties": {
                     "version": {
-                      "title": "Version",
-                      "description": "A single version of a component or service.",
                       "$ref": "#/definitions/version"
                     },
                     "range": {
-                      "title": "Version Range",
-                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst",
-                      "$ref": "#/definitions/versionRange"
+                      "$ref": "#/definitions/version"
                     },
                     "status": {
-                      "title": "Status",
-                      "description": "The vulnerability status for the version or range of versions.",
                       "$ref": "#/definitions/affectedStatus",
                       "default": "affected"
                     }
@@ -3535,13 +2306,12 @@
               }
             }
           },
-          "title": "Affects",
-          "description": "The components or services that are affected by the vulnerability."
+          "title": "Affects"
         },
         "properties": {
           "type": "array",
           "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "additionalItems": false,
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -3549,3166 +2319,30 @@
       }
     },
     "affectedStatus": {
-      "description": "The vulnerability status of a given version or range of versions of a product. The statuses 'affected' and 'unaffected' indicate that the version is affected or unaffected by the vulnerability. The status 'unknown' indicates that it is unknown or unspecified whether the given version is affected. There can be many reasons for an 'unknown' status, including that an investigation has not been undertaken or that a vendor has not disclosed the status.",
       "type": "string",
       "enum": [
         "affected",
         "unaffected",
         "unknown"
       ],
-      "additionalProperties": false,
-      "meta:enum": {
-        "affected": "The version is affected by the vulnerability.",
-        "unaffected": "The version is not affected by the vulnerability.",
-        "unknown": "It is unknown (or unspecified) whether the given version is affected."
-      }
+      "additionalProperties": false
     },
     "version": {
-      "description": "A single disjunctive version identifier, for a component or service.",
       "type": "string",
+      "minLength": 1,
       "maxLength": 1024,
-      "minLength": 1,
-      "examples": [
-        "9.0.14",
-        "v1.33.7",
-        "7.0.0-M1",
-        "2.0pre1",
-        "1.0.0-beta1",
-        "0.8.15"
-      ],
       "additionalProperties": false
-    },
-    "versionRange": {
-      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst",
-      "type": "string",
-      "minLength": 1,
-      "maxLength": 4096,
-      "examples": [
-        "vers:cargo/9.0.14",
-        "vers:npm/1.2.3|>=2.0.0|<5.0.0",
-        "vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|1.0|2.0pre1",
-        "vers:tomee/>=1.0.0-beta1|<=1.7.5|>=7.0.0-M1|<=7.0.7|>=7.1.0|<=7.1.2|>=8.0.0-M1|<=8.0.1",
-        "vers:gem/>=2.2.0|!= 2.2.1|<2.3.0"
-      ]
     },
     "range": {
-      "deprecated": true,
-      "description": "Deprecated definition. use definition `versionRange` instead.",
-      "$ref": "#/definitions/versionRange",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024,
       "additionalProperties": false
-    },
-    "annotations": {
-      "type": "object",
-      "title": "Annotations",
-      "description": "A comment, note, explanation, or similar textual content which provides additional context to the object(s) being annotated.",
-      "required": [
-        "subjects",
-        "annotator",
-        "timestamp",
-        "text"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the annotation elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
-        },
-        "subjects": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "anyOf": [
-              {
-                "title": "Ref",
-                "$ref": "#/definitions/refLinkType"
-              },
-              {
-                "title": "BOM-Link Element",
-                "$ref": "#/definitions/bomLinkElementType"
-              }
-            ]
-          },
-          "title": "Subjects",
-          "description": "The object in the BOM identified by its bom-ref. This is often a component or service, but may be any object type supporting bom-refs."
-        },
-        "annotator": {
-          "type": "object",
-          "title": "Annotator",
-          "description": "The organization, person, component, or service which created the textual content of the annotation.",
-          "oneOf": [
-            {
-              "required": [
-                "organization"
-              ]
-            },
-            {
-              "required": [
-                "individual"
-              ]
-            },
-            {
-              "required": [
-                "component"
-              ]
-            },
-            {
-              "required": [
-                "service"
-              ]
-            }
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "organization": {
-              "description": "The organization that created the annotation",
-              "$ref": "#/definitions/organizationalEntity"
-            },
-            "individual": {
-              "description": "The person that created the annotation",
-              "$ref": "#/definitions/organizationalContact"
-            },
-            "component": {
-              "description": "The tool or component that created the annotation",
-              "$ref": "#/definitions/tools_component"
-            },
-            "service": {
-              "description": "The service that created the annotation",
-              "$ref": "#/definitions/service"
-            }
-          }
-        },
-        "timestamp": {
-          "type": "string",
-          "format": "date-time",
-          "title": "Timestamp",
-          "description": "The date and time (timestamp) when the annotation was created."
-        },
-        "text": {
-          "type": "string",
-          "title": "Text",
-          "description": "The textual content of the annotation."
-        },
-        "signature": {
-          "$ref": "#/definitions/signature",
-          "title": "Signature",
-          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
-        }
-      }
-    },
-    "modelCard": {
-      "$comment": "Model card support in CycloneDX is derived from TensorFlow Model Card Toolkit released under the Apache 2.0 license and available from https://github.com/tensorflow/model-card-toolkit/blob/main/model_card_toolkit/schema/v0.0.2/model_card.schema.json. In addition, CycloneDX model card support includes portions of VerifyML, also released under the Apache 2.0 license and available from https://github.com/cylynx/verifyml/blob/main/verifyml/model_card_toolkit/schema/v0.0.4/model_card.schema.json.",
-      "type": "object",
-      "title": "Model Card",
-      "description": "A model card describes the intended uses of a machine learning model and potential limitations, including biases and ethical considerations. Model cards typically contain the training parameters, which datasets were used to train the model, performance metrics, and other relevant data useful for ML transparency. This object SHOULD be specified for any component of type `machine-learning-model` and must not be specified for other component types.",
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the model card elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
-        },
-        "modelParameters": {
-          "type": "object",
-          "title": "Model Parameters",
-          "description": "Hyper-parameters for construction of the model.",
-          "additionalProperties": false,
-          "properties": {
-            "approach": {
-              "type": "object",
-              "title": "Approach",
-              "description": "The overall approach to learning used by the model for problem solving.",
-              "additionalProperties": false,
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "title": "Learning Type",
-                  "description": "Learning types describing the learning problem or hybrid learning problem.",
-                  "enum": [
-                    "supervised",
-                    "unsupervised",
-                    "reinforcement-learning",
-                    "semi-supervised",
-                    "self-supervised"
-                  ],
-                  "meta:enum": {
-                    "supervised": "Supervised machine learning involves training an algorithm on labeled data to predict or classify new data based on the patterns learned from the labeled examples.",
-                    "unsupervised": "Unsupervised machine learning involves training algorithms on unlabeled data to discover patterns, structures, or relationships without explicit guidance, allowing the model to identify inherent structures or clusters within the data.",
-                    "reinforcement-learning": "Reinforcement learning is a type of machine learning where an agent learns to make decisions by interacting with an environment to maximize cumulative rewards, through trial and error.",
-                    "semi-supervised": "Semi-supervised machine learning utilizes a combination of labeled and unlabeled data during training to improve model performance, leveraging the benefits of both supervised and unsupervised learning techniques.",
-                    "self-supervised": "Self-supervised machine learning involves training models to predict parts of the input data from other parts of the same data, without requiring external labels, enabling learning from large amounts of unlabeled data."
-                  }
-                }
-              }
-            },
-            "task": {
-              "type": "string",
-              "title": "Task",
-              "description": "Directly influences the input and/or output. Examples include classification, regression, clustering, etc."
-            },
-            "architectureFamily": {
-              "type": "string",
-              "title": "Architecture Family",
-              "description": "The model architecture family such as transformer network, convolutional neural network, residual neural network, LSTM neural network, etc."
-            },
-            "modelArchitecture": {
-              "type": "string",
-              "title": "Model Architecture",
-              "description": "The specific architecture of the model such as GPT-1, ResNet-50, YOLOv3, etc."
-            },
-            "datasets": {
-              "type": "array",
-              "title": "Datasets",
-              "description": "The datasets used to train and evaluate the model.",
-              "items": {
-                "oneOf": [
-                  {
-                    "title": "Inline Data Information",
-                    "$ref": "#/definitions/componentData"
-                  },
-                  {
-                    "type": "object",
-                    "title": "Data Reference",
-                    "additionalProperties": false,
-                    "properties": {
-                      "ref": {
-                        "anyOf": [
-                          {
-                            "title": "Ref",
-                            "$ref": "#/definitions/refLinkType"
-                          },
-                          {
-                            "title": "BOM-Link Element",
-                            "$ref": "#/definitions/bomLinkElementType"
-                          }
-                        ],
-                        "title": "Reference",
-                        "type": "string",
-                        "description": "References a data component by the components bom-ref attribute"
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            "inputs": {
-              "type": "array",
-              "title": "Inputs",
-              "description": "The input format(s) of the model",
-              "items": {
-                "$ref": "#/definitions/inputOutputMLParameters"
-              }
-            },
-            "outputs": {
-              "type": "array",
-              "title": "Outputs",
-              "description": "The output format(s) from the model",
-              "items": {
-                "$ref": "#/definitions/inputOutputMLParameters"
-              }
-            }
-          }
-        },
-        "quantitativeAnalysis": {
-          "type": "object",
-          "title": "Quantitative Analysis",
-          "description": "A quantitative analysis of the model",
-          "additionalProperties": false,
-          "properties": {
-            "performanceMetrics": {
-              "type": "array",
-              "title": "Performance Metrics",
-              "description": "The model performance metrics being reported. Examples may include accuracy, F1 score, precision, top-3 error rates, MSC, etc.",
-              "items": {
-                "$ref": "#/definitions/performanceMetric"
-              }
-            },
-            "graphics": {
-              "$ref": "#/definitions/graphicsCollection"
-            }
-          }
-        },
-        "considerations": {
-          "type": "object",
-          "title": "Considerations",
-          "description": "What considerations should be taken into account regarding the model's construction, training, and application?",
-          "additionalProperties": false,
-          "properties": {
-            "users": {
-              "type": "array",
-              "title": "Users",
-              "description": "Who are the intended users of the model?",
-              "items": {
-                "type": "string"
-              }
-            },
-            "useCases": {
-              "type": "array",
-              "title": "Use Cases",
-              "description": "What are the intended use cases of the model?",
-              "items": {
-                "type": "string"
-              }
-            },
-            "technicalLimitations": {
-              "type": "array",
-              "title": "Technical Limitations",
-              "description": "What are the known technical limitations of the model? E.g. What kind(s) of data should the model be expected not to perform well on? What are the factors that might degrade model performance?",
-              "items": {
-                "type": "string"
-              }
-            },
-            "performanceTradeoffs": {
-              "type": "array",
-              "title": "Performance Tradeoffs",
-              "description": "What are the known tradeoffs in accuracy/performance of the model?",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ethicalConsiderations": {
-              "type": "array",
-              "title": "Ethical Considerations",
-              "description": "What are the ethical risks involved in the application of this model?",
-              "items": {
-                "$ref": "#/definitions/risk"
-              }
-            },
-            "environmentalConsiderations": {
-              "$ref": "#/definitions/environmentalConsiderations",
-              "title": "Environmental Considerations",
-              "description": "What are the various environmental impacts the corresponding machine learning model has exhibited across its lifecycle?"
-            },
-            "fairnessAssessments": {
-              "type": "array",
-              "title": "Fairness Assessments",
-              "description": "How does the model affect groups at risk of being systematically disadvantaged? What are the harms and benefits to the various affected groups?",
-              "items": {
-                "$ref": "#/definitions/fairnessAssessment"
-              }
-            }
-          }
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "inputOutputMLParameters": {
-      "type": "object",
-      "title": "Input and Output Parameters",
-      "additionalProperties": false,
-      "properties": {
-        "format": {
-          "title": "Input/Output Format",
-          "description": "The data format for input/output to the model.",
-          "type": "string",
-          "examples": [
-            "string",
-            "image",
-            "time-series"
-          ]
-        }
-      }
-    },
-    "componentData": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "bom-ref": {
-          "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the dataset elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
-        },
-        "type": {
-          "type": "string",
-          "title": "Type of Data",
-          "description": "The general theme or subject matter of the data being specified.",
-          "enum": [
-            "source-code",
-            "configuration",
-            "dataset",
-            "definition",
-            "other"
-          ],
-          "meta:enum": {
-            "source-code": "Any type of code, code snippet, or data-as-code.",
-            "configuration": "Parameters or settings that may be used by other components.",
-            "dataset": "A collection of data.",
-            "definition": "Data that can be used to create new instances of what the definition defines.",
-            "other": "Any other type of data that does not fit into existing definitions."
-          }
-        },
-        "name": {
-          "title": "Dataset Name",
-          "description": "The name of the dataset.",
-          "type": "string"
-        },
-        "contents": {
-          "type": "object",
-          "title": "Data Contents",
-          "description": "The contents or references to the contents of the data being described.",
-          "additionalProperties": false,
-          "properties": {
-            "attachment": {
-              "title": "Data Attachment",
-              "description": "An optional way to include textual or encoded data.",
-              "$ref": "#/definitions/attachment"
-            },
-            "url": {
-              "type": "string",
-              "title": "Data URL",
-              "description": "The URL to where the data can be retrieved.",
-              "format": "iri-reference"
-            },
-            "properties": {
-              "type": "array",
-              "title": "Configuration Properties",
-              "description": "Provides the ability to document name-value parameters used for configuration.",
-              "items": {
-                "$ref": "#/definitions/property"
-              }
-            }
-          }
-        },
-        "classification": {
-          "$ref": "#/definitions/dataClassification"
-        },
-        "sensitiveData": {
-          "type": "array",
-          "title": "Sensitive Data",
-          "description": "A description of any sensitive data in a dataset.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "graphics": {
-          "$ref": "#/definitions/graphicsCollection"
-        },
-        "description": {
-          "title": "Dataset Description",
-          "description": "A description of the dataset. Can describe size of dataset, whether it's used for source code, training, testing, or validation, etc.",
-          "type": "string"
-        },
-        "governance": {
-          "title": "Data Governance",
-          "$ref": "#/definitions/dataGovernance"
-        }
-      }
-    },
-    "dataGovernance": {
-      "type": "object",
-      "title": "Data Governance",
-      "description": "Data governance captures information regarding data ownership, stewardship, and custodianship, providing insights into the individuals or entities responsible for managing, overseeing, and safeguarding the data throughout its lifecycle.",
-      "additionalProperties": false,
-      "properties": {
-        "custodians": {
-          "type": "array",
-          "title": "Data Custodians",
-          "description": "Data custodians are responsible for the safe custody, transport, and storage of data.",
-          "items": {
-            "$ref": "#/definitions/dataGovernanceResponsibleParty"
-          }
-        },
-        "stewards": {
-          "type": "array",
-          "title": "Data Stewards",
-          "description": "Data stewards are responsible for data content, context, and associated business rules.",
-          "items": {
-            "$ref": "#/definitions/dataGovernanceResponsibleParty"
-          }
-        },
-        "owners": {
-          "type": "array",
-          "title": "Data Owners",
-          "description": "Data owners are concerned with risk and appropriate access to data.",
-          "items": {
-            "$ref": "#/definitions/dataGovernanceResponsibleParty"
-          }
-        }
-      }
-    },
-    "dataGovernanceResponsibleParty": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "organization": {
-          "title": "Organization",
-          "description": "The organization that is responsible for specific data governance role(s).",
-          "$ref": "#/definitions/organizationalEntity"
-        },
-        "contact": {
-          "title": "Individual",
-          "description": "The individual that is responsible for specific data governance role(s).",
-          "$ref": "#/definitions/organizationalContact"
-        }
-      },
-      "oneOf": [
-        {
-          "required": [
-            "organization"
-          ]
-        },
-        {
-          "required": [
-            "contact"
-          ]
-        }
-      ]
-    },
-    "graphicsCollection": {
-      "type": "object",
-      "title": "Graphics Collection",
-      "description": "A collection of graphics that represent various measurements.",
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "title": "Description",
-          "description": "A description of this collection of graphics.",
-          "type": "string"
-        },
-        "collection": {
-          "title": "Collection",
-          "description": "A collection of graphics.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/graphic"
-          }
-        }
-      }
-    },
-    "graphic": {
-      "type": "object",
-      "title": "Graphic",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "title": "Name",
-          "description": "The name of the graphic.",
-          "type": "string"
-        },
-        "image": {
-          "title": "Graphic Image",
-          "description": "The graphic (vector or raster). Base64 encoding must be specified for binary images.",
-          "$ref": "#/definitions/attachment"
-        }
-      }
-    },
-    "performanceMetric": {
-      "type": "object",
-      "title": "Performance Metric",
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "title": "Type",
-          "description": "The type of performance metric.",
-          "type": "string"
-        },
-        "value": {
-          "title": "Value",
-          "description": "The value of the performance metric.",
-          "type": "string"
-        },
-        "slice": {
-          "title": "Slice",
-          "description": "The name of the slice this metric was computed on. By default, assume this metric is not sliced.",
-          "type": "string"
-        },
-        "confidenceInterval": {
-          "title": "Confidence Interval",
-          "description": "The confidence interval of the metric.",
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "lowerBound": {
-              "title": "Lower Bound",
-              "description": "The lower bound of the confidence interval.",
-              "type": "string"
-            },
-            "upperBound": {
-              "title": "Upper Bound",
-              "description": "The upper bound of the confidence interval.",
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
-    "risk": {
-      "type": "object",
-      "title": "Risk",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "title": "Name",
-          "description": "The name of the risk.",
-          "type": "string"
-        },
-        "mitigationStrategy": {
-          "title": "Mitigation Strategy",
-          "description": "Strategy used to address this risk.",
-          "type": "string"
-        }
-      }
-    },
-    "fairnessAssessment": {
-      "type": "object",
-      "title": "Fairness Assessment",
-      "description": "Information about the benefits and harms of the model to an identified at risk group.",
-      "additionalProperties": false,
-      "properties": {
-        "groupAtRisk": {
-          "type": "string",
-          "title": "Group at Risk",
-          "description": "The groups or individuals at risk of being systematically disadvantaged by the model."
-        },
-        "benefits": {
-          "type": "string",
-          "title": "Benefits",
-          "description": "Expected benefits to the identified groups."
-        },
-        "harms": {
-          "type": "string",
-          "title": "Harms",
-          "description": "Expected harms to the identified groups."
-        },
-        "mitigationStrategy": {
-          "type": "string",
-          "title": "Mitigation Strategy",
-          "description": "With respect to the benefits and harms outlined, please describe any mitigation strategy implemented."
-        }
-      }
-    },
-    "dataClassification": {
-      "type": "string",
-      "title": "Data Classification",
-      "description": "Data classification tags data according to its type, sensitivity, and value if altered, stolen, or destroyed."
-    },
-    "environmentalConsiderations": {
-      "type": "object",
-      "title": "Environmental Considerations",
-      "description": "Describes various environmental impact metrics.",
-      "additionalProperties": false,
-      "properties": {
-        "energyConsumptions": {
-          "title": "Energy Consumptions",
-          "description": "Describes energy consumption information incurred for one or more component lifecycle activities.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/energyConsumption"
-          }
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "energyConsumption": {
-      "title": "Energy consumption",
-      "description": "Describes energy consumption information incurred for the specified lifecycle activity.",
-      "type": "object",
-      "required": [
-        "activity",
-        "energyProviders",
-        "activityEnergyCost"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "activity": {
-          "type": "string",
-          "title": "Activity",
-          "description": "The type of activity that is part of a machine learning model development or operational lifecycle.",
-          "enum": [
-            "design",
-            "data-collection",
-            "data-preparation",
-            "training",
-            "fine-tuning",
-            "validation",
-            "deployment",
-            "inference",
-            "other"
-          ],
-          "meta:enum": {
-            "design": "A model design including problem framing, goal definition and algorithm selection.",
-            "data-collection": "Model data acquisition including search, selection and transfer.",
-            "data-preparation": "Model data preparation including data cleaning, labeling and conversion.",
-            "training": "Model building, training and generalized tuning.",
-            "fine-tuning": "Refining a trained model to produce desired outputs for a given problem space.",
-            "validation": "Model validation including model output evaluation and testing.",
-            "deployment": "Explicit model deployment to a target hosting infrastructure.",
-            "inference": "Generating an output response from a hosted model from a set of inputs.",
-            "other": "A lifecycle activity type whose description does not match currently defined values."
-          }
-        },
-        "energyProviders": {
-          "title": "Energy Providers",
-          "description": "The provider(s) of the energy consumed by the associated model development lifecycle activity.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/energyProvider"
-          }
-        },
-        "activityEnergyCost": {
-          "title": "Activity Energy Cost",
-          "description": "The total energy cost associated with the model lifecycle activity.",
-          "$ref": "#/definitions/energyMeasure"
-        },
-        "co2CostEquivalent": {
-          "title": "CO2 Equivalent Cost",
-          "description": "The CO2 cost (debit) equivalent to the total energy cost.",
-          "$ref": "#/definitions/co2Measure"
-        },
-        "co2CostOffset": {
-          "title": "CO2 Cost Offset",
-          "description": "The CO2 offset (credit) for the CO2 equivalent cost.",
-          "$ref": "#/definitions/co2Measure"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "energyMeasure": {
-      "type": "object",
-      "title": "Energy Measure",
-      "description": "A measure of energy.",
-      "required": [
-        "value",
-        "unit"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "value": {
-          "type": "number",
-          "title": "Value",
-          "description": "Quantity of energy."
-        },
-        "unit": {
-          "type": "string",
-          "enum": [
-            "kWh"
-          ],
-          "title": "Unit",
-          "description": "Unit of energy.",
-          "meta:enum": {
-            "kWh": "Kilowatt-hour (kWh) is the energy delivered by one kilowatt (kW) of power for one hour (h)."
-          }
-        }
-      }
-    },
-    "co2Measure": {
-      "type": "object",
-      "title": "CO2 Measure",
-      "description": "A measure of carbon dioxide (CO2).",
-      "required": [
-        "value",
-        "unit"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "value": {
-          "type": "number",
-          "title": "Value",
-          "description": "Quantity of carbon dioxide (CO2)."
-        },
-        "unit": {
-          "type": "string",
-          "enum": [
-            "tCO2eq"
-          ],
-          "title": "Unit",
-          "description": "Unit of carbon dioxide (CO2).",
-          "meta:enum": {
-            "tCO2eq": "Tonnes (t) of carbon dioxide (CO2) equivalent (eq)."
-          }
-        }
-      }
-    },
-    "energyProvider": {
-      "type": "object",
-      "title": "Energy Provider",
-      "description": "Describes the physical provider of energy used for model development or operations.",
-      "required": [
-        "organization",
-        "energySource",
-        "energyProvided"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the energy provider elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
-          "$ref": "#/definitions/refType"
-        },
-        "description": {
-          "type": "string",
-          "title": "Description",
-          "description": "A description of the energy provider."
-        },
-        "organization": {
-          "type": "object",
-          "title": "Organization",
-          "description": "The organization that provides energy.",
-          "$ref": "#/definitions/organizationalEntity"
-        },
-        "energySource": {
-          "type": "string",
-          "enum": [
-            "coal",
-            "oil",
-            "natural-gas",
-            "nuclear",
-            "wind",
-            "solar",
-            "geothermal",
-            "hydropower",
-            "biofuel",
-            "unknown",
-            "other"
-          ],
-          "meta:enum": {
-            "coal": "Energy produced by types of coal.",
-            "oil": "Petroleum products (primarily crude oil and its derivative fuel oils).",
-            "natural-gas": "Hydrocarbon gas liquids (HGL) that occur as gases at atmospheric pressure and as liquids under higher pressures including Natural gas (C5H12 and heavier), Ethane (C2H6), Propane (C3H8), etc.",
-            "nuclear": "Energy produced from the cores of atoms (i.e., through nuclear fission or fusion).",
-            "wind": "Energy produced from moving air.",
-            "solar": "Energy produced from the sun (i.e., solar radiation).",
-            "geothermal": "Energy produced from heat within the earth.",
-            "hydropower": "Energy produced from flowing water.",
-            "biofuel": "Liquid fuels produced from biomass feedstocks (i.e., organic materials such as plants or animals).",
-            "unknown": "The energy source is unknown.",
-            "other": "An energy source that is not listed."
-          },
-          "title": "Energy Source",
-          "description": "The energy source for the energy provider."
-        },
-        "energyProvided": {
-          "$ref": "#/definitions/energyMeasure",
-          "title": "Energy Provided",
-          "description": "The energy provided by the energy source for an associated activity."
-        },
-        "externalReferences": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/externalReference"
-          },
-          "title": "External References",
-          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
-        }
-      }
-    },
-    "postalAddress": {
-      "type": "object",
-      "title": "Postal address",
-      "description": "An address used to identify a contactable location.",
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the address elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
-          "$ref": "#/definitions/refType"
-        },
-        "country": {
-          "type": "string",
-          "title": "Country",
-          "description": "The country name or the two-letter ISO 3166-1 country code."
-        },
-        "region": {
-          "type": "string",
-          "title": "Region",
-          "description": "The region or state in the country.",
-          "examples": [
-            "Texas"
-          ]
-        },
-        "locality": {
-          "type": "string",
-          "title": "Locality",
-          "description": "The locality or city within the country.",
-          "examples": [
-            "Austin"
-          ]
-        },
-        "postOfficeBoxNumber": {
-          "type": "string",
-          "title": "Post Office Box Number",
-          "description": "The post office box number.",
-          "examples": [
-            "901"
-          ]
-        },
-        "postalCode": {
-          "type": "string",
-          "title": "Postal Code",
-          "description": "The postal code.",
-          "examples": [
-            "78758"
-          ]
-        },
-        "streetAddress": {
-          "type": "string",
-          "title": "Street Address",
-          "description": "The street address.",
-          "examples": [
-            "100 Main Street"
-          ]
-        }
-      }
-    },
-    "formula": {
-      "title": "Formula",
-      "description": "Describes workflows and resources that captures rules and other aspects of how the associated BOM component or service was formed.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the formula elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
-          "$ref": "#/definitions/refType"
-        },
-        "components": {
-          "title": "Components",
-          "description": "Transient components that are used in tasks that constitute one or more of this formula's workflows",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/component"
-          },
-          "uniqueItems": true
-        },
-        "services": {
-          "title": "Services",
-          "description": "Transient services that are used in tasks that constitute one or more of this formula's workflows",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/service"
-          },
-          "uniqueItems": true
-        },
-        "workflows": {
-          "title": "Workflows",
-          "description": "List of workflows that can be declared to accomplish specific orchestrated goals and independently triggered.",
-          "$comment": "Different workflows can be designed to work together to perform end-to-end CI/CD builds and deployments.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/workflow"
-          },
-          "uniqueItems": true
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "workflow": {
-      "title": "Workflow",
-      "description": "A specialized orchestration task.",
-      "$comment": "Workflow are as task themselves and can trigger other workflow tasks.  These relationships can be modeled in the taskDependencies graph.",
-      "type": "object",
-      "required": [
-        "bom-ref",
-        "uid",
-        "taskTypes"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the workflow elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
-          "$ref": "#/definitions/refType"
-        },
-        "uid": {
-          "title": "Unique Identifier (UID)",
-          "description": "The unique identifier for the resource instance within its deployment context.",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the resource instance.",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "description": "A description of the resource instance.",
-          "type": "string"
-        },
-        "resourceReferences": {
-          "title": "Resource references",
-          "description": "References to component or service resources that are used to realize the resource instance.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/resourceReferenceChoice"
-          }
-        },
-        "tasks": {
-          "title": "Tasks",
-          "description": "The tasks that comprise the workflow.",
-          "$comment": "Note that tasks can appear more than once as different instances (by name or UID).",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/task"
-          }
-        },
-        "taskDependencies": {
-          "title": "Task dependency graph",
-          "description": "The graph of dependencies between tasks within the workflow.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/dependency"
-          }
-        },
-        "taskTypes": {
-          "title": "Task types",
-          "description": "Indicates the types of activities performed by the set of workflow tasks.",
-          "$comment": "Currently, these types reflect common CI/CD actions.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/taskType"
-          }
-        },
-        "trigger": {
-          "title": "Trigger",
-          "description": "The trigger that initiated the task.",
-          "$ref": "#/definitions/trigger"
-        },
-        "steps": {
-          "title": "Steps",
-          "description": "The sequence of steps for the task.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/step"
-          },
-          "uniqueItems": true
-        },
-        "inputs": {
-          "title": "Inputs",
-          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
-          "examples": [
-            "a `configuration` file which was declared as a local `component` or `externalReference`"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/inputType"
-          },
-          "uniqueItems": true
-        },
-        "outputs": {
-          "title": "Outputs",
-          "description": "Represents resources and data output from a task at runtime by executor or task commands",
-          "examples": [
-            "a log file or metrics data produced by the task"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/outputType"
-          },
-          "uniqueItems": true
-        },
-        "timeStart": {
-          "title": "Time start",
-          "description": "The date and time (timestamp) when the task started.",
-          "type": "string",
-          "format": "date-time"
-        },
-        "timeEnd": {
-          "title": "Time end",
-          "description": "The date and time (timestamp) when the task ended.",
-          "type": "string",
-          "format": "date-time"
-        },
-        "workspaces": {
-          "title": "Workspaces",
-          "description": "A set of named filesystem or data resource shareable by workflow tasks.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/workspace"
-          }
-        },
-        "runtimeTopology": {
-          "title": "Runtime topology",
-          "description": "A graph of the component runtime topology for workflow's instance.",
-          "$comment": "A description of the runtime component and service topology.  This can describe a partial or complete topology used to host and execute the task (e.g., hardware, operating systems, configurations, etc.),",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/dependency"
-          }
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "task": {
-      "title": "Task",
-      "description": "Describes the inputs, sequence of steps and resources used to accomplish a task and its output.",
-      "$comment": "Tasks are building blocks for constructing assemble CI/CD workflows or pipelines.",
-      "type": "object",
-      "required": [
-        "bom-ref",
-        "uid",
-        "taskTypes"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the task elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
-          "$ref": "#/definitions/refType"
-        },
-        "uid": {
-          "title": "Unique Identifier (UID)",
-          "description": "The unique identifier for the resource instance within its deployment context.",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the resource instance.",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "description": "A description of the resource instance.",
-          "type": "string"
-        },
-        "resourceReferences": {
-          "title": "Resource references",
-          "description": "References to component or service resources that are used to realize the resource instance.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/resourceReferenceChoice"
-          }
-        },
-        "taskTypes": {
-          "title": "Task types",
-          "description": "Indicates the types of activities performed by the set of workflow tasks.",
-          "$comment": "Currently, these types reflect common CI/CD actions.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/taskType"
-          }
-        },
-        "trigger": {
-          "title": "Trigger",
-          "description": "The trigger that initiated the task.",
-          "$ref": "#/definitions/trigger"
-        },
-        "steps": {
-          "title": "Steps",
-          "description": "The sequence of steps for the task.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/step"
-          },
-          "uniqueItems": true
-        },
-        "inputs": {
-          "title": "Inputs",
-          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
-          "examples": [
-            "a `configuration` file which was declared as a local `component` or `externalReference`"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/inputType"
-          },
-          "uniqueItems": true
-        },
-        "outputs": {
-          "title": "Outputs",
-          "description": "Represents resources and data output from a task at runtime by executor or task commands",
-          "examples": [
-            "a log file or metrics data produced by the task"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/outputType"
-          },
-          "uniqueItems": true
-        },
-        "timeStart": {
-          "title": "Time start",
-          "description": "The date and time (timestamp) when the task started.",
-          "type": "string",
-          "format": "date-time"
-        },
-        "timeEnd": {
-          "title": "Time end",
-          "description": "The date and time (timestamp) when the task ended.",
-          "type": "string",
-          "format": "date-time"
-        },
-        "workspaces": {
-          "title": "Workspaces",
-          "description": "A set of named filesystem or data resource shareable by workflow tasks.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/workspace"
-          },
-          "uniqueItems": true
-        },
-        "runtimeTopology": {
-          "title": "Runtime topology",
-          "description": "A graph of the component runtime topology for task's instance.",
-          "$comment": "A description of the runtime component and service topology.  This can describe a partial or complete topology used to host and execute the task (e.g., hardware, operating systems, configurations, etc.),",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/dependency"
-          },
-          "uniqueItems": true
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "step": {
-      "type": "object",
-      "description": "Executes specific commands or tools in order to accomplish its owning task as part of a sequence.",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "title": "Name",
-          "description": "A name for the step.",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "description": "A description of the step.",
-          "type": "string"
-        },
-        "commands": {
-          "title": "Commands",
-          "description": "Ordered list of commands or directives for the step",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/command"
-          }
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "command": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "executed": {
-          "title": "Executed",
-          "description": "A text representation of the executed command.",
-          "type": "string"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "workspace": {
-      "title": "Workspace",
-      "description": "A named filesystem or data resource shareable by workflow tasks.",
-      "type": "object",
-      "required": [
-        "bom-ref",
-        "uid"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the workspace elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
-          "$ref": "#/definitions/refType"
-        },
-        "uid": {
-          "title": "Unique Identifier (UID)",
-          "description": "The unique identifier for the resource instance within its deployment context.",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the resource instance.",
-          "type": "string"
-        },
-        "aliases": {
-          "title": "Aliases",
-          "description": "The names for the workspace as referenced by other workflow tasks. Effectively, a name mapping so other tasks can use their own local name in their steps.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "description": {
-          "title": "Description",
-          "description": "A description of the resource instance.",
-          "type": "string"
-        },
-        "resourceReferences": {
-          "title": "Resource references",
-          "description": "References to component or service resources that are used to realize the resource instance.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/resourceReferenceChoice"
-          }
-        },
-        "accessMode": {
-          "title": "Access mode",
-          "description": "Describes the read-write access control for the workspace relative to the owning resource instance.",
-          "type": "string",
-          "enum": [
-            "read-only",
-            "read-write",
-            "read-write-once",
-            "write-once",
-            "write-only"
-          ]
-        },
-        "mountPath": {
-          "title": "Mount path",
-          "description": "A path to a location on disk where the workspace will be available to the associated task's steps.",
-          "type": "string"
-        },
-        "managedDataType": {
-          "title": "Managed data type",
-          "description": "The name of a domain-specific data type the workspace represents.",
-          "$comment": "This property is for CI/CD frameworks that are able to provide access to structured, managed data at a more granular level than a filesystem.",
-          "examples": [
-            "ConfigMap",
-            "Secret"
-          ],
-          "type": "string"
-        },
-        "volumeRequest": {
-          "title": "Volume request",
-          "description": "Identifies the reference to the request for a specific volume type and parameters.",
-          "examples": [
-            "a kubernetes Persistent Volume Claim (PVC) name"
-          ],
-          "type": "string"
-        },
-        "volume": {
-          "title": "Volume",
-          "description": "Information about the actual volume instance allocated to the workspace.",
-          "$comment": "The actual volume allocated may be different than the request.",
-          "examples": [
-            "see https://kubernetes.io/docs/concepts/storage/persistent-volumes/"
-          ],
-          "$ref": "#/definitions/volume"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "volume": {
-      "title": "Volume",
-      "description": "An identifiable, logical unit of data storage tied to a physical device.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "uid": {
-          "title": "Unique Identifier (UID)",
-          "description": "The unique identifier for the volume instance within its deployment context.",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the volume instance",
-          "type": "string"
-        },
-        "mode": {
-          "title": "Mode",
-          "description": "The mode for the volume instance.",
-          "type": "string",
-          "enum": [
-            "filesystem",
-            "block"
-          ],
-          "default": "filesystem"
-        },
-        "path": {
-          "title": "Path",
-          "description": "The underlying path created from the actual volume.",
-          "type": "string"
-        },
-        "sizeAllocated": {
-          "title": "Size allocated",
-          "description": "The allocated size of the volume accessible to the associated workspace. This should include the scalar size as well as IEC standard unit in either decimal or binary form.",
-          "examples": [
-            "10GB",
-            "2Ti",
-            "1Pi"
-          ],
-          "type": "string"
-        },
-        "persistent": {
-          "title": "Persistent",
-          "description": "Indicates if the volume persists beyond the life of the resource it is associated with.",
-          "type": "boolean"
-        },
-        "remote": {
-          "title": "Remote",
-          "description": "Indicates if the volume is remotely (i.e., network) attached.",
-          "type": "boolean"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "trigger": {
-      "title": "Trigger",
-      "description": "Represents a resource that can conditionally activate (or fire) tasks based upon associated events and their data.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "type",
-        "bom-ref",
-        "uid"
-      ],
-      "properties": {
-        "bom-ref": {
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the trigger elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
-          "$ref": "#/definitions/refType"
-        },
-        "uid": {
-          "title": "Unique Identifier (UID)",
-          "description": "The unique identifier for the resource instance within its deployment context.",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the resource instance.",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "description": "A description of the resource instance.",
-          "type": "string"
-        },
-        "resourceReferences": {
-          "title": "Resource references",
-          "description": "References to component or service resources that are used to realize the resource instance.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/resourceReferenceChoice"
-          }
-        },
-        "type": {
-          "title": "Type",
-          "description": "The source type of event which caused the trigger to fire.",
-          "type": "string",
-          "enum": [
-            "manual",
-            "api",
-            "webhook",
-            "scheduled"
-          ]
-        },
-        "event": {
-          "title": "Event",
-          "description": "The event data that caused the associated trigger to activate.",
-          "$ref": "#/definitions/event"
-        },
-        "conditions": {
-          "type": "array",
-          "title": "Conditions",
-          "description": "A list of conditions used to determine if a trigger should be activated.",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/condition"
-          }
-        },
-        "timeActivated": {
-          "title": "Time activated",
-          "description": "The date and time (timestamp) when the trigger was activated.",
-          "type": "string",
-          "format": "date-time"
-        },
-        "inputs": {
-          "title": "Inputs",
-          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
-          "examples": [
-            "a `configuration` file which was declared as a local `component` or `externalReference`"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/inputType"
-          },
-          "uniqueItems": true
-        },
-        "outputs": {
-          "title": "Outputs",
-          "description": "Represents resources and data output from a task at runtime by executor or task commands",
-          "examples": [
-            "a log file or metrics data produced by the task"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/outputType"
-          },
-          "uniqueItems": true
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "event": {
-      "title": "Event",
-      "description": "Represents something that happened that may trigger a response.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "uid": {
-          "title": "Unique Identifier (UID)",
-          "description": "The unique identifier of the event.",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "description": "A description of the event.",
-          "type": "string"
-        },
-        "timeReceived": {
-          "title": "Time Received",
-          "description": "The date and time (timestamp) when the event was received.",
-          "type": "string",
-          "format": "date-time"
-        },
-        "data": {
-          "title": "Data",
-          "description": "Encoding of the raw event data.",
-          "$ref": "#/definitions/attachment"
-        },
-        "source": {
-          "title": "Source",
-          "description": "References the component or service that was the source of the event",
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "target": {
-          "title": "Target",
-          "description": "References the component or service that was the target of the event",
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "inputType": {
-      "title": "Input type",
-      "description": "Type that represents various input data types and formats.",
-      "type": "object",
-      "oneOf": [
-        {
-          "required": [
-            "resource"
-          ]
-        },
-        {
-          "required": [
-            "parameters"
-          ]
-        },
-        {
-          "required": [
-            "environmentVars"
-          ]
-        },
-        {
-          "required": [
-            "data"
-          ]
-        }
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "source": {
-          "title": "Source",
-          "description": "A reference to the component or service that provided the input to the task (e.g., reference to a service with data flow value of `inbound`)",
-          "examples": [
-            "source code repository",
-            "database"
-          ],
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "target": {
-          "title": "Target",
-          "description": "A reference to the component or service that received or stored the input if not the task itself (e.g., a local, named storage workspace)",
-          "examples": [
-            "workspace",
-            "directory"
-          ],
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "resource": {
-          "title": "Resource",
-          "description": "A reference to an independent resource provided as an input to a task by the workflow runtime.",
-          "examples": [
-            "a reference to a configuration file in a repository (i.e., a bom-ref)",
-            "a reference to a scanning service used in a task (i.e., a bom-ref)"
-          ],
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "parameters": {
-          "title": "Parameters",
-          "description": "Inputs that have the form of parameters with names and values.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/definitions/parameter"
-          }
-        },
-        "environmentVars": {
-          "title": "Environment variables",
-          "description": "Inputs that have the form of parameters with names and values.",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/property"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          }
-        },
-        "data": {
-          "title": "Data",
-          "description": "Inputs that have the form of data.",
-          "$ref": "#/definitions/attachment"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "outputType": {
-      "type": "object",
-      "oneOf": [
-        {
-          "required": [
-            "resource"
-          ]
-        },
-        {
-          "required": [
-            "environmentVars"
-          ]
-        },
-        {
-          "required": [
-            "data"
-          ]
-        }
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "title": "Type",
-          "description": "Describes the type of data output.",
-          "type": "string",
-          "enum": [
-            "artifact",
-            "attestation",
-            "log",
-            "evidence",
-            "metrics",
-            "other"
-          ]
-        },
-        "source": {
-          "title": "Source",
-          "description": "Component or service that generated or provided the output from the task (e.g., a build tool)",
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "target": {
-          "title": "Target",
-          "description": "Component or service that received the output from the task (e.g., reference to an artifactory service with data flow value of `outbound`)",
-          "examples": [
-            "a log file described as an `externalReference` within its target domain."
-          ],
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "resource": {
-          "title": "Resource",
-          "description": "A reference to an independent resource generated as output by the task.",
-          "examples": [
-            "configuration file",
-            "source code",
-            "scanning service"
-          ],
-          "$ref": "#/definitions/resourceReferenceChoice"
-        },
-        "data": {
-          "title": "Data",
-          "description": "Outputs that have the form of data.",
-          "$ref": "#/definitions/attachment"
-        },
-        "environmentVars": {
-          "title": "Environment variables",
-          "description": "Outputs that have the form of environment variables.",
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/property"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "uniqueItems": true
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "resourceReferenceChoice": {
-      "title": "Resource reference choice",
-      "description": "A reference to a locally defined resource (e.g., a bom-ref) or an externally accessible resource.",
-      "$comment": "Enables reference to a resource that participates in a workflow; using either internal (bom-ref) or external (externalReference) types.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "ref": {
-          "title": "BOM Reference",
-          "description": "References an object by its bom-ref attribute",
-          "anyOf": [
-            {
-              "title": "Ref",
-              "$ref": "#/definitions/refLinkType"
-            },
-            {
-              "title": "BOM-Link Element",
-              "$ref": "#/definitions/bomLinkElementType"
-            }
-          ]
-        },
-        "externalReference": {
-          "title": "External reference",
-          "description": "Reference to an externally accessible resource.",
-          "$ref": "#/definitions/externalReference"
-        }
-      },
-      "oneOf": [
-        {
-          "required": [
-            "ref"
-          ]
-        },
-        {
-          "required": [
-            "externalReference"
-          ]
-        }
-      ]
-    },
-    "condition": {
-      "title": "Condition",
-      "description": "A condition that was used to determine a trigger should be activated.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "title": "Description",
-          "description": "Describes the set of conditions which cause the trigger to activate.",
-          "type": "string"
-        },
-        "expression": {
-          "title": "Expression",
-          "description": "The logical expression that was evaluated that determined the trigger should be fired.",
-          "type": "string"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        }
-      }
-    },
-    "taskType": {
-      "type": "string",
-      "enum": [
-        "copy",
-        "clone",
-        "lint",
-        "scan",
-        "merge",
-        "build",
-        "test",
-        "deliver",
-        "deploy",
-        "release",
-        "clean",
-        "other"
-      ],
-      "meta:enum": {
-        "copy": "A task that copies software or data used to accomplish other tasks in the workflow.",
-        "clone": "A task that clones a software repository into the workflow in order to retrieve its source code or data for use in a build step.",
-        "lint": "A task that checks source code for programmatic and stylistic errors.",
-        "scan": "A task that performs a scan against source code, or built or deployed components and services. Scans are typically run to gather or test for security vulnerabilities or policy compliance.",
-        "merge": "A task that merges changes or fixes into source code prior to a build step in the workflow.",
-        "build": "A task that builds the source code, dependencies and/or data into an artifact that can be deployed to and executed on target systems.",
-        "test": "A task that verifies the functionality of a component or service.",
-        "deliver": "A task that delivers a built artifact to one or more target repositories or storage systems.",
-        "deploy": "A task that deploys a built artifact for execution on one or more target systems.",
-        "release": "A task that releases a built, versioned artifact to a target repository or distribution system.",
-        "clean": "A task that cleans unnecessary tools, build artifacts and/or data from workflow storage.",
-        "other": "A workflow task that does not match current task type definitions."
-      }
-    },
-    "parameter": {
-      "title": "Parameter",
-      "description": "A representation of a functional parameter.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "title": "Name",
-          "description": "The name of the parameter.",
-          "type": "string"
-        },
-        "value": {
-          "title": "Value",
-          "description": "The value of the parameter.",
-          "type": "string"
-        },
-        "dataType": {
-          "title": "Data type",
-          "description": "The data type of the parameter.",
-          "type": "string"
-        }
-      }
-    },
-    "componentIdentityEvidence": {
-      "type": "object",
-      "title": "Identity Evidence",
-      "description": "Evidence that substantiates the identity of a component.",
-      "required": [
-        "field"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "field": {
-          "type": "string",
-          "enum": [
-            "group",
-            "name",
-            "version",
-            "purl",
-            "cpe",
-            "omniborId",
-            "swhid",
-            "swid",
-            "hash"
-          ],
-          "title": "Field",
-          "description": "The identity field of the component which the evidence describes."
-        },
-        "confidence": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1,
-          "title": "Confidence",
-          "description": "The overall confidence of the evidence from 0 - 1, where 1 is 100% confidence."
-        },
-        "concludedValue": {
-          "type": "string",
-          "title": "Concluded Value",
-          "description": "The value of the field (cpe, purl, etc) that has been concluded based on the aggregate of all methods (if available)."
-        },
-        "methods": {
-          "type": "array",
-          "title": "Methods",
-          "description": "The methods used to extract and/or analyze the evidence.",
-          "items": {
-            "type": "object",
-            "required": [
-              "technique",
-              "confidence"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "technique": {
-                "title": "Technique",
-                "description": "The technique used in this method of analysis.",
-                "type": "string",
-                "enum": [
-                  "source-code-analysis",
-                  "binary-analysis",
-                  "manifest-analysis",
-                  "ast-fingerprint",
-                  "hash-comparison",
-                  "instrumentation",
-                  "dynamic-analysis",
-                  "filename",
-                  "attestation",
-                  "other"
-                ]
-              },
-              "confidence": {
-                "type": "number",
-                "minimum": 0,
-                "maximum": 1,
-                "title": "Confidence",
-                "description": "The confidence of the evidence from 0 - 1, where 1 is 100% confidence. Confidence is specific to the technique used. Each technique of analysis can have independent confidence."
-              },
-              "value": {
-                "type": "string",
-                "title": "Value",
-                "description": "The value or contents of the evidence."
-              }
-            }
-          }
-        },
-        "tools": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "anyOf": [
-              {
-                "title": "Ref",
-                "$ref": "#/definitions/refLinkType"
-              },
-              {
-                "title": "BOM-Link Element",
-                "$ref": "#/definitions/bomLinkElementType"
-              }
-            ]
-          },
-          "title": "BOM References",
-          "description": "The object in the BOM identified by its bom-ref. This is often a component or service but may be any object type supporting bom-refs. Tools used for analysis should already be defined in the BOM, either in the metadata/tools, components, or formulation."
-        }
-      }
-    },
-    "standard": {
-      "type": "object",
-      "title": "Standard",
-      "description": "A standard may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.",
-      "additionalProperties": false,
-      "properties": {
-        "bom-ref": {
-          "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
-        },
-        "name": {
-          "type": "string",
-          "title": "Name",
-          "description": "The name of the standard. This will often be a shortened, single name of the standard."
-        },
-        "version": {
-          "type": "string",
-          "title": "Version",
-          "description": "The version of the standard."
-        },
-        "description": {
-          "type": "string",
-          "title": "Description",
-          "description": "The description of the standard."
-        },
-        "owner": {
-          "type": "string",
-          "title": "Owner",
-          "description": "The owner of the standard, often the entity responsible for its release."
-        },
-        "requirements": {
-          "type": "array",
-          "title": "Requirements",
-          "description": "The list of requirements comprising the standard.",
-          "items": {
-            "type": "object",
-            "title": "Requirement",
-            "additionalProperties": false,
-            "properties": {
-              "bom-ref": {
-                "$ref": "#/definitions/refType",
-                "title": "BOM Reference",
-                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
-              },
-              "identifier": {
-                "type": "string",
-                "title": "Identifier",
-                "description": "The unique identifier used in the standard to identify a specific requirement. This should match what is in the standard and should not be the requirements bom-ref."
-              },
-              "title": {
-                "type": "string",
-                "title": "Title",
-                "description": "The title of the requirement."
-              },
-              "text": {
-                "type": "string",
-                "title": "Text",
-                "description": "The textual content of the requirement."
-              },
-              "descriptions": {
-                "type": "array",
-                "title": "Descriptions",
-                "description": "The supplemental text that provides additional guidance or context to the requirement, but is not directly part of the requirement.",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "openCre": {
-                "type": "array",
-                "title": "OWASP OpenCRE Identifier(s)",
-                "description": "The Common Requirements Enumeration (CRE) identifier(s). CRE is a structured and standardized framework for uniting security standards and guidelines. CRE links each section of a resource to a shared topic identifier (a Common Requirement). Through this shared topic link, all resources map to each other. Use of CRE promotes clear and unambiguous communication among stakeholders.",
-                "items": {
-                  "type": "string",
-                  "pattern": "^CRE:[0-9]+-[0-9]+$",
-                  "examples": [
-                    "CRE:764-507"
-                  ]
-                }
-              },
-              "parent": {
-                "$ref": "#/definitions/refLinkType",
-                "title": "Parent BOM Reference",
-                "description": "The optional `bom-ref` to a parent requirement. This establishes a hierarchy of requirements. Top-level requirements must not define a parent. Only child requirements should define parents."
-              },
-              "properties": {
-                "type": "array",
-                "title": "Properties",
-                "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-                "items": {
-                  "$ref": "#/definitions/property"
-                }
-              },
-              "externalReferences": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/externalReference"
-                },
-                "title": "External References",
-                "description": "External references provide a way to document systems, sites, and information that may be relevant, but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
-              }
-            }
-          }
-        },
-        "levels": {
-          "type": "array",
-          "title": "Levels",
-          "description": "The list of levels associated with the standard. Some standards have different levels of compliance.",
-          "items": {
-            "type": "object",
-            "title": "Level",
-            "additionalProperties": false,
-            "properties": {
-              "bom-ref": {
-                "$ref": "#/definitions/refType",
-                "title": "BOM Reference",
-                "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM."
-              },
-              "identifier": {
-                "type": "string",
-                "title": "Identifier",
-                "description": "The identifier used in the standard to identify a specific level."
-              },
-              "title": {
-                "type": "string",
-                "title": "Title",
-                "description": "The title of the level."
-              },
-              "description": {
-                "type": "string",
-                "title": "Description",
-                "description": "The description of the level."
-              },
-              "requirements": {
-                "type": "array",
-                "title": "Requirements",
-                "description": "The list of requirement `bom-ref`s that comprise the level.",
-                "items": {
-                  "$ref": "#/definitions/refLinkType"
-                }
-              }
-            }
-          }
-        },
-        "externalReferences": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/externalReference"
-          },
-          "title": "External References",
-          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
-        },
-        "signature": {
-          "$ref": "#/definitions/signature",
-          "title": "Signature",
-          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
-        }
-      }
     },
     "signature": {
       "$ref": "jsf-0.82.schema.json#/definitions/signature",
       "title": "Signature",
-      "additionalProperties": false,
-      "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
-    },
-    "cryptoProperties": {
-      "type": "object",
-      "title": "Cryptographic Properties",
-      "description": "Cryptographic assets have properties that uniquely define them and that make them actionable for further reasoning. As an example, it makes a difference if one knows the algorithm family (e.g. AES) or the specific variant or instantiation (e.g. AES-128-GCM). This is because the security level and the algorithm primitive (authenticated encryption) are only defined by the definition of the algorithm variant. The presence of a weak cryptographic algorithm like SHA1 vs. HMAC-SHA1 also makes a difference.",
-      "additionalProperties": false,
-      "required": [
-        "assetType"
-      ],
-      "properties": {
-        "assetType": {
-          "type": "string",
-          "title": "Asset Type",
-          "description": "Cryptographic assets occur in several forms. Algorithms and protocols are most commonly implemented in specialized cryptographic libraries. They may, however, also be 'hardcoded' in software components. Certificates and related cryptographic material like keys, tokens, secrets or passwords are other cryptographic assets to be modelled.",
-          "enum": [
-            "algorithm",
-            "certificate",
-            "protocol",
-            "related-crypto-material"
-          ],
-          "meta:enum": {
-            "algorithm": "Mathematical function commonly used for data encryption, authentication, and digital signatures.",
-            "certificate": "An electronic document that is used to provide the identity or validate a public key.",
-            "protocol": "A set of rules and guidelines that govern the behavior and communication with each other.",
-            "related-crypto-material": "Other cryptographic assets related to algorithms, certificates, and protocols such as keys and tokens."
-          }
-        },
-        "algorithmProperties": {
-          "type": "object",
-          "title": "Algorithm Properties",
-          "description": "Additional properties specific to a cryptographic algorithm.",
-          "additionalProperties": false,
-          "properties": {
-            "primitive": {
-              "type": "string",
-              "title": "primitive",
-              "description": "Cryptographic building blocks used in higher-level cryptographic systems and protocols. Primitives represent different cryptographic routines: deterministic random bit generators (drbg, e.g. CTR_DRBG from NIST SP800-90A-r1), message authentication codes (mac, e.g. HMAC-SHA-256), blockciphers (e.g. AES), streamciphers (e.g. Salsa20), signatures (e.g. ECDSA), hash functions (e.g. SHA-256), public-key encryption schemes (pke, e.g. RSA), extended output functions (xof, e.g. SHAKE256), key derivation functions (e.g. pbkdf2), key agreement algorithms (e.g. ECDH), key encapsulation mechanisms (e.g. ML-KEM), authenticated encryption (ae, e.g. AES-GCM) and the combination of multiple algorithms (combiner, e.g. SP800-56Cr2).",
-              "enum": [
-                "drbg",
-                "mac",
-                "block-cipher",
-                "stream-cipher",
-                "signature",
-                "hash",
-                "pke",
-                "xof",
-                "kdf",
-                "key-agree",
-                "kem",
-                "ae",
-                "combiner",
-                "other",
-                "unknown"
-              ],
-              "meta:enum": {
-                "drbg": "Deterministic Random Bit Generator (DRBG) is a type of pseudorandom number generator designed to produce a sequence of bits from an initial seed value. DRBGs are commonly used in cryptographic applications where reproducibility of random values is important.",
-                "mac": "In cryptography, a Message Authentication Code (MAC) is information used for authenticating and integrity-checking a message.",
-                "block-cipher": "A block cipher is a symmetric key algorithm that operates on fixed-size blocks of data. It encrypts or decrypts the data in block units, providing confidentiality. Block ciphers are widely used in various cryptographic modes and protocols for secure data transmission.",
-                "stream-cipher": "A stream cipher is a symmetric key cipher where plaintext digits are combined with a pseudorandom cipher digit stream (keystream).",
-                "signature": "In cryptography, a signature is a digital representation of a message or data that proves its origin, identity, and integrity. Digital signatures are generated using cryptographic algorithms and are widely used for authentication and verification in secure communication.",
-                "hash": "A hash function is a mathematical algorithm that takes an input (or 'message') and produces a fixed-size string of characters, which is typically a hash value. Hash functions are commonly used in various cryptographic applications, including data integrity verification and password hashing.",
-                "pke": "Public Key Encryption (PKE) is a type of encryption that uses a pair of public and private keys for secure communication. The public key is used for encryption, while the private key is used for decryption. PKE is a fundamental component of public-key cryptography.",
-                "xof": "An XOF is an extendable output function that can take arbitrary input and creates a stream of output, up to a limit determined by the size of the internal state of the hash function that underlies the XOF.",
-                "kdf": "A Key Derivation Function (KDF) derives key material from another source of entropy while preserving the entropy of the input.",
-                "key-agree": "In cryptography, a key-agreement is a protocol whereby two or more parties agree on a cryptographic key in such a way that both influence the outcome.",
-                "kem": "A Key Encapsulation Mechanism (KEM) algorithm is a mechanism for transporting random keying material to a recipient using the recipient's public key.",
-                "ae": "Authenticated Encryption (AE) is a cryptographic process that provides both confidentiality and data integrity. It ensures that the encrypted data has not been tampered with and comes from a legitimate source. AE is commonly used in secure communication protocols.",
-                "combiner": "A combiner aggregates many candidates for a cryptographic primitive and generates a new candidate for the same primitive.",
-                "other": "Another primitive type.",
-                "unknown": "The primitive is not known."
-              }
-            },
-            "parameterSetIdentifier": {
-              "type": "string",
-              "title": "Parameter Set Identifier",
-              "description": "An identifier for the parameter set of the cryptographic algorithm. Examples: in AES128, '128' identifies the key length in bits, in SHA256, '256' identifies the digest length, '128' in SHAKE128 identifies its maximum security level in bits, and 'SHA2-128s' identifies a parameter set used in SLH-DSA (FIPS205)."
-            },
-            "curve": {
-              "type": "string",
-              "title": "Elliptic Curve",
-              "description": "The specific underlying Elliptic Curve (EC) definition employed which is an indicator of the level of security strength, performance and complexity. Absent an authoritative source of curve names, CycloneDX recommends using curve names as defined at [https://neuromancer.sk/std/](https://neuromancer.sk/std/), the source of which can be found at [https://github.com/J08nY/std-curves](https://github.com/J08nY/std-curves)."
-            },
-            "executionEnvironment": {
-              "type": "string",
-              "title": "Execution Environment",
-              "description": "The target and execution environment in which the algorithm is implemented in.",
-              "enum": [
-                "software-plain-ram",
-                "software-encrypted-ram",
-                "software-tee",
-                "hardware",
-                "other",
-                "unknown"
-              ],
-              "meta:enum": {
-                "software-plain-ram": "A software implementation running in plain unencrypted RAM.",
-                "software-encrypted-ram": "A software implementation running in encrypted RAM.",
-                "software-tee": "A software implementation running in a trusted execution environment.",
-                "hardware": "A hardware implementation.",
-                "other": "Another implementation environment.",
-                "unknown": "The execution environment is not known."
-              }
-            },
-            "implementationPlatform": {
-              "type": "string",
-              "title": "Implementation platform",
-              "description": "The target platform for which the algorithm is implemented. The implementation can be 'generic', running on any platform or for a specific platform.",
-              "enum": [
-                "generic",
-                "x86_32",
-                "x86_64",
-                "armv7-a",
-                "armv7-m",
-                "armv8-a",
-                "armv8-m",
-                "armv9-a",
-                "armv9-m",
-                "s390x",
-                "ppc64",
-                "ppc64le",
-                "other",
-                "unknown"
-              ]
-            },
-            "certificationLevel": {
-              "type": "array",
-              "title": "Certification Level",
-              "description": "The certification that the implementation of the cryptographic algorithm has received, if any. Certifications include revisions and levels of FIPS 140 or Common Criteria of different Extended Assurance Levels (CC-EAL).",
-              "items": {
-                "type": "string",
-                "enum": [
-                  "none",
-                  "fips140-1-l1",
-                  "fips140-1-l2",
-                  "fips140-1-l3",
-                  "fips140-1-l4",
-                  "fips140-2-l1",
-                  "fips140-2-l2",
-                  "fips140-2-l3",
-                  "fips140-2-l4",
-                  "fips140-3-l1",
-                  "fips140-3-l2",
-                  "fips140-3-l3",
-                  "fips140-3-l4",
-                  "cc-eal1",
-                  "cc-eal1+",
-                  "cc-eal2",
-                  "cc-eal2+",
-                  "cc-eal3",
-                  "cc-eal3+",
-                  "cc-eal4",
-                  "cc-eal4+",
-                  "cc-eal5",
-                  "cc-eal5+",
-                  "cc-eal6",
-                  "cc-eal6+",
-                  "cc-eal7",
-                  "cc-eal7+",
-                  "other",
-                  "unknown"
-                ],
-                "meta:enum": {
-                  "none": "No certification obtained",
-                  "fips140-1-l1": "FIPS 140-1 Level 1",
-                  "fips140-1-l2": "FIPS 140-1 Level 2",
-                  "fips140-1-l3": "FIPS 140-1 Level 3",
-                  "fips140-1-l4": "FIPS 140-1 Level 4",
-                  "fips140-2-l1": "FIPS 140-2 Level 1",
-                  "fips140-2-l2": "FIPS 140-2 Level 2",
-                  "fips140-2-l3": "FIPS 140-2 Level 3",
-                  "fips140-2-l4": "FIPS 140-2 Level 4",
-                  "fips140-3-l1": "FIPS 140-3 Level 1",
-                  "fips140-3-l2": "FIPS 140-3 Level 2",
-                  "fips140-3-l3": "FIPS 140-3 Level 3",
-                  "fips140-3-l4": "FIPS 140-3 Level 4",
-                  "cc-eal1": "Common Criteria - Evaluation Assurance Level 1",
-                  "cc-eal1+": "Common Criteria - Evaluation Assurance Level 1 (Augmented)",
-                  "cc-eal2": "Common Criteria - Evaluation Assurance Level 2",
-                  "cc-eal2+": "Common Criteria - Evaluation Assurance Level 2 (Augmented)",
-                  "cc-eal3": "Common Criteria - Evaluation Assurance Level 3",
-                  "cc-eal3+": "Common Criteria - Evaluation Assurance Level 3 (Augmented)",
-                  "cc-eal4": "Common Criteria - Evaluation Assurance Level 4",
-                  "cc-eal4+": "Common Criteria - Evaluation Assurance Level 4 (Augmented)",
-                  "cc-eal5": "Common Criteria - Evaluation Assurance Level 5",
-                  "cc-eal5+": "Common Criteria - Evaluation Assurance Level 5 (Augmented)",
-                  "cc-eal6": "Common Criteria - Evaluation Assurance Level 6",
-                  "cc-eal6+": "Common Criteria - Evaluation Assurance Level 6 (Augmented)",
-                  "cc-eal7": "Common Criteria - Evaluation Assurance Level 7",
-                  "cc-eal7+": "Common Criteria - Evaluation Assurance Level 7 (Augmented)",
-                  "other": "Another certification",
-                  "unknown": "The certification level is not known"
-                }
-              }
-            },
-            "mode": {
-              "type": "string",
-              "title": "Mode",
-              "description": "The mode of operation in which the cryptographic algorithm (block cipher) is used.",
-              "enum": [
-                "cbc",
-                "ecb",
-                "ccm",
-                "gcm",
-                "cfb",
-                "ofb",
-                "ctr",
-                "other",
-                "unknown"
-              ],
-              "meta:enum": {
-                "cbc": "Cipher block chaining",
-                "ecb": "Electronic codebook",
-                "ccm": "Counter with cipher block chaining message authentication code",
-                "gcm": "Galois/counter",
-                "cfb": "Cipher feedback",
-                "ofb": "Output feedback",
-                "ctr": "Counter",
-                "other": "Another mode of operation",
-                "unknown": "The mode of operation is not known"
-              }
-            },
-            "padding": {
-              "type": "string",
-              "title": "Padding",
-              "description": "The padding scheme that is used for the cryptographic algorithm.",
-              "enum": [
-                "pkcs5",
-                "pkcs7",
-                "pkcs1v15",
-                "oaep",
-                "raw",
-                "other",
-                "unknown"
-              ],
-              "meta:enum": {
-                "pkcs5": "Public Key Cryptography Standard: Password-Based Cryptography",
-                "pkcs7": "Public Key Cryptography Standard: Cryptographic Message Syntax",
-                "pkcs1v15": "Public Key Cryptography Standard: RSA Cryptography v1.5",
-                "oaep": "Optimal asymmetric encryption padding",
-                "raw": "Raw",
-                "other": "Another padding scheme",
-                "unknown": "The padding scheme is not known"
-              }
-            },
-            "cryptoFunctions": {
-              "type": "array",
-              "title": "Cryptographic functions",
-              "description": "The cryptographic functions implemented by the cryptographic algorithm.",
-              "items": {
-                "type": "string",
-                "enum": [
-                  "generate",
-                  "keygen",
-                  "encrypt",
-                  "decrypt",
-                  "digest",
-                  "tag",
-                  "keyderive",
-                  "sign",
-                  "verify",
-                  "encapsulate",
-                  "decapsulate",
-                  "other",
-                  "unknown"
-                ]
-              }
-            },
-            "classicalSecurityLevel": {
-              "type": "integer",
-              "title": "classical security level",
-              "description": "The classical security level that a cryptographic algorithm provides (in bits).",
-              "minimum": 0
-            },
-            "nistQuantumSecurityLevel": {
-              "type": "integer",
-              "title": "NIST security strength category",
-              "description": "The NIST security strength category as defined in https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/evaluation-criteria/security-(evaluation-criteria). A value of 0 indicates that none of the categories are met.",
-              "minimum": 0,
-              "maximum": 6
-            }
-          }
-        },
-        "certificateProperties": {
-          "type": "object",
-          "title": "Certificate Properties",
-          "description": "Properties for cryptographic assets of asset type 'certificate'",
-          "additionalProperties": false,
-          "properties": {
-            "subjectName": {
-              "type": "string",
-              "title": "Subject Name",
-              "description": "The subject name for the certificate"
-            },
-            "issuerName": {
-              "type": "string",
-              "title": "Issuer Name",
-              "description": "The issuer name for the certificate"
-            },
-            "notValidBefore": {
-              "type": "string",
-              "format": "date-time",
-              "title": "Not Valid Before",
-              "description": "The date and time according to ISO-8601 standard from which the certificate is valid"
-            },
-            "notValidAfter": {
-              "type": "string",
-              "format": "date-time",
-              "title": "Not Valid After",
-              "description": "The date and time according to ISO-8601 standard from which the certificate is not valid anymore"
-            },
-            "signatureAlgorithmRef": {
-              "$ref": "#/definitions/refType",
-              "title": "Algorithm Reference",
-              "description": "The bom-ref to signature algorithm used by the certificate"
-            },
-            "subjectPublicKeyRef": {
-              "$ref": "#/definitions/refType",
-              "title": "Key reference",
-              "description": "The bom-ref to the public key of the subject"
-            },
-            "certificateFormat": {
-              "type": "string",
-              "title": "Certificate Format",
-              "description": "The format of the certificate",
-              "examples": [
-                "X.509",
-                "PEM",
-                "DER",
-                "CVC"
-              ]
-            },
-            "certificateExtension": {
-              "type": "string",
-              "title": "Certificate File Extension",
-              "description": "The file extension of the certificate",
-              "examples": [
-                "crt",
-                "pem",
-                "cer",
-                "der",
-                "p12"
-              ]
-            }
-          }
-        },
-        "relatedCryptoMaterialProperties": {
-          "type": "object",
-          "title": "Related Cryptographic Material Properties",
-          "description": "Properties for cryptographic assets of asset type: `related-crypto-material`",
-          "additionalProperties": false,
-          "properties": {
-            "type": {
-              "type": "string",
-              "title": "relatedCryptoMaterialType",
-              "description": "The type for the related cryptographic material",
-              "enum": [
-                "private-key",
-                "public-key",
-                "secret-key",
-                "key",
-                "ciphertext",
-                "signature",
-                "digest",
-                "initialization-vector",
-                "nonce",
-                "seed",
-                "salt",
-                "shared-secret",
-                "tag",
-                "additional-data",
-                "password",
-                "credential",
-                "token",
-                "other",
-                "unknown"
-              ],
-              "meta:enum": {
-                "private-key": "The confidential key of a key pair used in asymmetric cryptography.",
-                "public-key": "The non-confidential key of a key pair used in asymmetric cryptography.",
-                "secret-key": "A key used to encrypt and decrypt messages in symmetric cryptography.",
-                "key": "A piece of information, usually an octet string, which, when processed through a cryptographic algorithm, processes cryptographic data.",
-                "ciphertext": "The result of encryption performed on plaintext using an algorithm (or cipher).",
-                "signature": "A cryptographic value that is calculated from the data and a key known only by the signer.",
-                "digest": "The output of the hash function.",
-                "initialization-vector": "A fixed-size random or pseudo-random value used as an input parameter for cryptographic algorithms.",
-                "nonce": "A random or pseudo-random number that can only be used once in a cryptographic communication.",
-                "seed": "The input to a pseudo-random number generator. Different seeds generate different pseudo-random sequences.",
-                "salt": "A value used in a cryptographic process, usually to ensure that the results of computations for one instance cannot be reused by an attacker.",
-                "shared-secret": "A piece of data known only to the parties involved, in a secure communication.",
-                "tag": "A message authentication code (MAC), sometimes known as an authentication tag, is a short piece of information used for authenticating and integrity-checking a message.",
-                "additional-data": "An unspecified collection of data with relevance to cryptographic activity.",
-                "password": "A secret word, phrase, or sequence of characters used during authentication or authorization.",
-                "credential": "Establishes the identity of a party to communication, usually in the form of cryptographic keys or passwords.",
-                "token": "An object encapsulating a security identity.",
-                "other": "Another type of cryptographic asset.",
-                "unknown": "The type of cryptographic asset is not known."
-              }
-            },
-            "id": {
-              "type": "string",
-              "title": "ID",
-              "description": "The optional unique identifier for the related cryptographic material."
-            },
-            "state": {
-              "type": "string",
-              "title": "State",
-              "description": "The key state as defined by NIST SP 800-57.",
-              "enum": [
-                "pre-activation",
-                "active",
-                "suspended",
-                "deactivated",
-                "compromised",
-                "destroyed"
-              ]
-            },
-            "algorithmRef": {
-              "$ref": "#/definitions/refType",
-              "title": "Algorithm Reference",
-              "description": "The bom-ref to the algorithm used to generate the related cryptographic material."
-            },
-            "creationDate": {
-              "type": "string",
-              "format": "date-time",
-              "title": "Creation Date",
-              "description": "The date and time (timestamp) when the related cryptographic material was created."
-            },
-            "activationDate": {
-              "type": "string",
-              "format": "date-time",
-              "title": "Activation Date",
-              "description": "The date and time (timestamp) when the related cryptographic material was activated."
-            },
-            "updateDate": {
-              "type": "string",
-              "format": "date-time",
-              "title": "Update Date",
-              "description": "The date and time (timestamp) when the related cryptographic material was updated."
-            },
-            "expirationDate": {
-              "type": "string",
-              "format": "date-time",
-              "title": "Expiration Date",
-              "description": "The date and time (timestamp) when the related cryptographic material expires."
-            },
-            "value": {
-              "type": "string",
-              "title": "Value",
-              "description": "The associated value of the cryptographic material."
-            },
-            "size": {
-              "type": "integer",
-              "title": "Size",
-              "description": "The size of the cryptographic asset (in bits)."
-            },
-            "format": {
-              "type": "string",
-              "title": "Format",
-              "description": "The format of the related cryptographic material (e.g. P8, PEM, DER)."
-            },
-            "securedBy": {
-              "$ref": "#/definitions/securedBy",
-              "title": "Secured By",
-              "description": "The mechanism by which the cryptographic asset is secured by."
-            }
-          }
-        },
-        "protocolProperties": {
-          "type": "object",
-          "title": "Protocol Properties",
-          "description": "Properties specific to cryptographic assets of type: `protocol`.",
-          "additionalProperties": false,
-          "properties": {
-            "type": {
-              "type": "string",
-              "title": "Type",
-              "description": "The concrete protocol type.",
-              "enum": [
-                "tls",
-                "ssh",
-                "ipsec",
-                "ike",
-                "sstp",
-                "wpa",
-                "other",
-                "unknown"
-              ],
-              "meta:enum": {
-                "tls": "Transport Layer Security",
-                "ssh": "Secure Shell",
-                "ipsec": "Internet Protocol Security",
-                "ike": "Internet Key Exchange",
-                "sstp": "Secure Socket Tunneling Protocol",
-                "wpa": "Wi-Fi Protected Access",
-                "other": "Another protocol type",
-                "unknown": "The protocol type is not known"
-              }
-            },
-            "version": {
-              "type": "string",
-              "title": "Protocol Version",
-              "description": "The version of the protocol.",
-              "examples": [
-                "1.0",
-                "1.2",
-                "1.99"
-              ]
-            },
-            "cipherSuites": {
-              "type": "array",
-              "title": "Cipher Suites",
-              "description": "A list of cipher suites related to the protocol.",
-              "items": {
-                "$ref": "#/definitions/cipherSuite",
-                "title": "Cipher Suite"
-              }
-            },
-            "ikev2TransformTypes": {
-              "type": "object",
-              "title": "IKEv2 Transform Types",
-              "description": "The IKEv2 transform types supported (types 1-4), defined in [RFC 7296 section 3.3.2](https://www.ietf.org/rfc/rfc7296.html#section-3.3.2), and additional properties.",
-              "additionalProperties": false,
-              "properties": {
-                "encr": {
-                  "$ref": "#/definitions/cryptoRefArray",
-                  "title": "Encryption Algorithm (ENCR)",
-                  "description": "Transform Type 1: encryption algorithms"
-                },
-                "prf": {
-                  "$ref": "#/definitions/cryptoRefArray",
-                  "title": "Pseudorandom Function (PRF)",
-                  "description": "Transform Type 2: pseudorandom functions"
-                },
-                "integ": {
-                  "$ref": "#/definitions/cryptoRefArray",
-                  "title": "Integrity Algorithm (INTEG)",
-                  "description": "Transform Type 3: integrity algorithms"
-                },
-                "ke": {
-                  "$ref": "#/definitions/cryptoRefArray",
-                  "title": "Key Exchange Method (KE)",
-                  "description": "Transform Type 4: Key Exchange Method (KE) per [RFC 9370](https://www.ietf.org/rfc/rfc9370.html), formerly called Diffie-Hellman Group (D-H)."
-                },
-                "esn": {
-                  "type": "boolean",
-                  "title": "Extended Sequence Numbers (ESN)",
-                  "description": "Specifies if an Extended Sequence Number (ESN) is used."
-                },
-                "auth": {
-                  "$ref": "#/definitions/cryptoRefArray",
-                  "title": "IKEv2 Authentication method",
-                  "description": "IKEv2 Authentication method"
-                }
-              }
-            },
-            "cryptoRefArray": {
-              "$ref": "#/definitions/cryptoRefArray",
-              "title": "Cryptographic References",
-              "description": "A list of protocol-related cryptographic assets"
-            }
-          }
-        },
-        "oid": {
-          "type": "string",
-          "title": "OID",
-          "description": "The object identifier (OID) of the cryptographic asset."
-        }
-      }
-    },
-    "cipherSuite": {
-      "type": "object",
-      "title": "Cipher Suite",
-      "description": "Object representing a cipher suite",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "type": "string",
-          "title": "Common Name",
-          "description": "A common name for the cipher suite.",
-          "examples": [
-            "TLS_DHE_RSA_WITH_AES_128_CCM"
-          ]
-        },
-        "algorithms": {
-          "type": "array",
-          "title": "Related Algorithms",
-          "description": "A list of algorithms related to the cipher suite.",
-          "items": {
-            "$ref": "#/definitions/refType",
-            "title": "Algorithm reference",
-            "description": "The bom-ref to algorithm cryptographic asset."
-          }
-        },
-        "identifiers": {
-          "type": "array",
-          "title": "Cipher Suite Identifiers",
-          "description": "A list of common identifiers for the cipher suite.",
-          "items": {
-            "type": "string",
-            "title": "identifier",
-            "description": "Cipher suite identifier",
-            "examples": [
-              "0xC0",
-              "0x9E"
-            ]
-          }
-        }
-      }
-    },
-    "cryptoRefArray": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/refType"
-      }
-    },
-    "securedBy": {
-      "type": "object",
-      "title": "Secured By",
-      "description": "Specifies the mechanism by which the cryptographic asset is secured by",
-      "additionalProperties": false,
-      "properties": {
-        "mechanism": {
-          "type": "string",
-          "title": "Mechanism",
-          "description": "Specifies the mechanism by which the cryptographic asset is secured by.",
-          "examples": [
-            "HSM",
-            "TPM",
-            "SGX",
-            "Software",
-            "None"
-          ]
-        },
-        "algorithmRef": {
-          "$ref": "#/definitions/refType",
-          "title": "Algorithm Reference",
-          "description": "The bom-ref to the algorithm."
-        }
-      }
-    },
-    "tags": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "title": "Tags",
-      "description": "Textual strings that aid in discovery, search, and retrieval of the associated object. Tags often serve as a way to group or categorize similar or related objects by various attributes.",
-      "examples": [
-        "json-parser",
-        "object-persistence",
-        "text-to-image",
-        "translation",
-        "object-detection"
-      ]
-    },
-    "tools_component": {
-      "type": "object",
-      "title": "Component",
-      "required": [
-        "type",
-        "name"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "application",
-            "framework",
-            "library",
-            "container",
-            "platform",
-            "operating-system",
-            "device",
-            "device-driver",
-            "firmware",
-            "file",
-            "machine-learning-model",
-            "data",
-            "cryptographic-asset"
-          ],
-          "meta:enum": {
-            "application": "A software application. Refer to [https://en.wikipedia.org/wiki/Application_software](https://en.wikipedia.org/wiki/Application_software) for information about applications.",
-            "framework": "A software framework. Refer to [https://en.wikipedia.org/wiki/Software_framework](https://en.wikipedia.org/wiki/Software_framework) for information on how frameworks vary slightly from libraries.",
-            "library": "A software library. Refer to [https://en.wikipedia.org/wiki/Library_(computing)](https://en.wikipedia.org/wiki/Library_(computing)) for information about libraries. All third-party and open source reusable components will likely be a library. If the library also has key features of a framework, then it should be classified as a framework. If not, or is unknown, then specifying library is recommended.",
-            "container": "A packaging and/or runtime format, not specific to any particular technology, which isolates software inside the container from software outside of a container through virtualization technology. Refer to [https://en.wikipedia.org/wiki/OS-level_virtualization](https://en.wikipedia.org/wiki/OS-level_virtualization).",
-            "platform": "A runtime environment which interprets or executes software. This may include runtimes such as those that execute bytecode or low-code/no-code application platforms.",
-            "operating-system": "A software operating system without regard to deployment model (i.e. installed on physical hardware, virtual machine, image, etc) Refer to [https://en.wikipedia.org/wiki/Operating_system](https://en.wikipedia.org/wiki/Operating_system).",
-            "device": "A hardware device such as a processor or chip-set. A hardware device containing firmware SHOULD include a component for the physical hardware itself and another component of type 'firmware' or 'operating-system' (whichever is relevant), describing information about the software running on the device. See also the list of [known device properties](https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/device.md).",
-            "device-driver": "A special type of software that operates or controls a particular type of device. Refer to [https://en.wikipedia.org/wiki/Device_driver](https://en.wikipedia.org/wiki/Device_driver).",
-            "firmware": "A special type of software that provides low-level control over a device's hardware. Refer to [https://en.wikipedia.org/wiki/Firmware](https://en.wikipedia.org/wiki/Firmware).",
-            "file": "A computer file. Refer to [https://en.wikipedia.org/wiki/Computer_file](https://en.wikipedia.org/wiki/Computer_file) for information about files.",
-            "machine-learning-model": "A model based on training data that can make predictions or decisions without being explicitly programmed to do so.",
-            "data": "A collection of discrete values that convey information.",
-            "cryptographic-asset": "A cryptographic asset including algorithms, protocols, certificates, keys, tokens, and secrets."
-          },
-          "title": "Component Type",
-          "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component.",
-          "examples": [
-            "library"
-          ]
-        },
-        "mime-type": {
-          "type": "string",
-          "title": "Mime-Type",
-          "description": "The optional mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented, such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
-          "examples": [
-            "image/jpeg"
-          ],
-          "pattern": "^[-+a-z0-9.]+/[-+a-z0-9.]+$"
-        },
-        "bom-ref": {
-          "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
-        },
-        "supplier": {
-          "title": "Component Supplier",
-          "description": " The organization that supplied the component. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
-          "$ref": "#/definitions/organizationalEntity"
-        },
-        "manufacturer": {
-          "title": "Component Manufacturer",
-          "description": "The organization that created the component.\nManufacturer is common in components created through automated processes. Components created through manual means may have `@.authors` instead.",
-          "$ref": "#/definitions/organizationalEntity"
-        },
-        "authors": {
-          "type": "array",
-          "title": "Component Authors",
-          "description": "The person(s) who created the component.\nAuthors are common in components created through manual processes. Components created through automated means may have `@.manufacturer` instead.",
-          "items": {
-            "$ref": "#/definitions/organizationalContact"
-          }
-        },
-        "author": {
-          "deprecated": true,
-          "type": "string",
-          "title": "Component Author (legacy)",
-          "description": "[Deprecated] This will be removed in a future version. Use `@.authors` or `@.manufacturer` instead.\nThe person(s) or organization(s) that authored the component",
-          "examples": [
-            "Acme Inc"
-          ]
-        },
-        "publisher": {
-          "type": "string",
-          "title": "Component Publisher",
-          "description": "The person(s) or organization(s) that published the component",
-          "examples": [
-            "Acme Inc"
-          ]
-        },
-        "group": {
-          "type": "string",
-          "title": "Component Group",
-          "description": "The grouping name or identifier. This will often be a shortened, single name of the company or project that produced the component, or the source package or domain name. Whitespace and special characters should be avoided. Examples include: apache, org.apache.commons, and apache.org.",
-          "examples": [
-            "com.acme"
-          ]
-        },
-        "name": {
-          "type": "string",
-          "title": "Component Name",
-          "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
-          "examples": [
-            "tomcat-catalina"
-          ]
-        },
-        "version": {
-          "$ref": "#/definitions/version",
-          "title": "Component Version",
-          "description": "The component version. The version should ideally comply with semantic versioning but is not enforced."
-        },
-        "description": {
-          "type": "string",
-          "title": "Component Description",
-          "description": "Specifies a description for the component"
-        },
-        "scope": {
-          "type": "string",
-          "enum": [
-            "required",
-            "optional",
-            "excluded"
-          ],
-          "meta:enum": {
-            "required": "The component is required for runtime",
-            "optional": "The component is optional at runtime. Optional components are components that are not capable of being called due to them not being installed or otherwise accessible by any means. Components that are installed but due to configuration or other restrictions are prohibited from being called must be scoped as 'required'.",
-            "excluded": "Components that are excluded provide the ability to document component usage for test and other non-runtime purposes. Excluded components are not reachable within a call graph at runtime."
-          },
-          "title": "Component Scope",
-          "description": "Specifies the scope of the component. If scope is not specified, 'required' scope SHOULD be assumed by the consumer of the BOM.",
-          "default": "required"
-        },
-        "hashes": {
-          "type": "array",
-          "title": "Component Hashes",
-          "description": "The hashes of the component.",
-          "items": {
-            "$ref": "#/definitions/hash"
-          }
-        },
-        "licenses": {
-          "$ref": "#/definitions/licenseChoice",
-          "title": "Component License(s)"
-        },
-        "copyright": {
-          "type": "string",
-          "title": "Component Copyright",
-          "description": "A copyright notice informing users of the underlying claims to copyright ownership in a published work.",
-          "examples": [
-            "Acme Inc"
-          ]
-        },
-        "cpe": {
-          "type": "string",
-          "title": "Common Platform Enumeration (CPE)",
-          "description": "Asserts the identity of the component using CPE. The CPE must conform to the CPE 2.2 or 2.3 specification. See [https://nvd.nist.gov/products/cpe](https://nvd.nist.gov/products/cpe). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
-          "examples": [
-            "cpe:2.3:a:acme:component_framework:-:*:*:*:*:*:*:*"
-          ]
-        },
-        "purl": {
-          "type": "string",
-          "title": "Package URL (purl)",
-          "description": "Asserts the identity of the component using package-url (purl). The purl, if specified, must be valid and conform to the specification defined at: [https://github.com/package-url/purl-spec](https://github.com/package-url/purl-spec). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
-          "examples": [
-            "pkg:maven/com.acme/tomcat-catalina@9.0.14?packaging=jar"
-          ]
-        },
-        "omniborId": {
-          "type": "array",
-          "title": "OmniBOR Artifact Identifier (gitoid)",
-          "description": "Asserts the identity of the component using the OmniBOR Artifact ID. The OmniBOR, if specified, must be valid and conform to the specification defined at: [https://www.iana.org/assignments/uri-schemes/prov/gitoid](https://www.iana.org/assignments/uri-schemes/prov/gitoid). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
-          "items": {
-            "type": "string"
-          },
-          "examples": [
-            "gitoid:blob:sha1:a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-            "gitoid:blob:sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
-          ]
-        },
-        "swhid": {
-          "type": "array",
-          "title": "SoftWare Heritage Identifier",
-          "description": "Asserts the identity of the component using the Software Heritage persistent identifier (SWHID). The SWHID, if specified, must be valid and conform to the specification defined at: [https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html](https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
-          "items": {
-            "type": "string"
-          },
-          "examples": [
-            "swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2"
-          ]
-        },
-        "swid": {
-          "$ref": "#/definitions/swid",
-          "title": "SWID Tag",
-          "description": "Asserts the identity of the component using [ISO-IEC 19770-2 Software Identification (SWID) Tags](https://www.iso.org/standard/65666.html). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity."
-        },
-        "modified": {
-          "type": "boolean",
-          "title": "Component Modified From Original",
-          "description": "[Deprecated] This will be removed in a future version. Use the pedigree element instead to supply information on exactly how the component was modified. A boolean value indicating if the component has been modified from the original. A value of true indicates the component is a derivative of the original. A value of false indicates the component has not been modified from the original."
-        },
-        "pedigree": {
-          "type": "object",
-          "title": "Component Pedigree",
-          "description": "Component pedigree is a way to document complex supply chain scenarios where components are created, distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to document variants where the exact relation may not be known.",
-          "additionalProperties": false,
-          "properties": {
-            "ancestors": {
-              "type": "array",
-              "title": "Ancestors",
-              "description": "Describes zero or more components in which a component is derived from. This is commonly used to describe forks from existing projects where the forked version contains a ancestor node containing the original component it was forked from. For example, Component A is the original component. Component B is the component being used and documented in the BOM. However, Component B contains a pedigree node with a single ancestor documenting Component A - the original component from which Component B is derived from.",
-              "items": {
-                "$ref": "#/definitions/component"
-              }
-            },
-            "descendants": {
-              "type": "array",
-              "title": "Descendants",
-              "description": "Descendants are the exact opposite of ancestors. This provides a way to document all forks (and their forks) of an original or root component.",
-              "items": {
-                "$ref": "#/definitions/component"
-              }
-            },
-            "variants": {
-              "type": "array",
-              "title": "Variants",
-              "description": "Variants describe relations where the relationship between the components is not known. For example, if Component A contains nearly identical code to Component B. They are both related, but it is unclear if one is derived from the other, or if they share a common ancestor.",
-              "items": {
-                "$ref": "#/definitions/component"
-              }
-            },
-            "commits": {
-              "type": "array",
-              "title": "Commits",
-              "description": "A list of zero or more commits which provide a trail describing how the component deviates from an ancestor, descendant, or variant.",
-              "items": {
-                "$ref": "#/definitions/commit"
-              }
-            },
-            "patches": {
-              "type": "array",
-              "title": "Patches",
-              "description": ">A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complementary to commits or may be used in place of commits.",
-              "items": {
-                "$ref": "#/definitions/patch"
-              }
-            },
-            "notes": {
-              "type": "string",
-              "title": "Notes",
-              "description": "Notes, observations, and other non-structured commentary describing the components pedigree."
-            }
-          }
-        },
-        "externalReferences": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/externalReference"
-          },
-          "title": "External References",
-          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
-        },
-        "components": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/component"
-          },
-          "uniqueItems": true,
-          "title": "Components",
-          "description": "A list of software and hardware components included in the parent component. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system &#8594; subsystem &#8594; parts assembly in physical supply chains."
-        },
-        "evidence": {
-          "$ref": "#/definitions/componentEvidence",
-          "title": "Evidence",
-          "description": "Provides the ability to document evidence collected through various forms of extraction or analysis."
-        },
-        "releaseNotes": {
-          "$ref": "#/definitions/releaseNotes",
-          "title": "Release notes",
-          "description": "Specifies optional release notes."
-        },
-        "modelCard": {
-          "$ref": "#/definitions/modelCard",
-          "title": "AI/ML Model Card"
-        },
-        "data": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/componentData"
-          },
-          "title": "Data",
-          "description": "This object SHOULD be specified for any component of type `data` and must not be specified for other component types."
-        },
-        "cryptoProperties": {
-          "$ref": "#/definitions/cryptoProperties",
-          "title": "Cryptographic Properties"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
-          "items": {
-            "$ref": "#/definitions/property"
-          }
-        },
-        "tags": {
-          "$ref": "#/definitions/tags",
-          "title": "Tags"
-        },
-        "signature": {
-          "$ref": "#/definitions/signature",
-          "title": "Signature",
-          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
-        }
-      }
+      "additionalProperties": false
     }
   }
 }

--- a/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
@@ -2026,7 +2026,7 @@
                 "bom-ref": {
                   "$ref": "#/definitions/refType",
                   "title": "BOM Reference",
-                  "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+                  "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
                 }
               }
             }

--- a/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
@@ -4,6 +4,30 @@
   "type": "object",
   "title": "CycloneDX Bill of Materials Standard",
   "$comment": "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
+  "if": {
+    "required": [
+      "components"
+    ]
+  },
+  "then": {
+    "required": [
+      "bomFormat",
+      "specVersion",
+      "version",
+      "metadata",
+      "compositions",
+      "dependencies"
+    ]
+  },
+  "else": {
+    "required": [
+      "bomFormat",
+      "specVersion",
+      "version",
+      "metadata",
+      "compositions"
+    ]
+  },
   "additionalProperties": false,
   "properties": {
     "$schema": {
@@ -22,13 +46,13 @@
       "title": "CycloneDX Specification Version",
       "description": "The version of the CycloneDX specification the BOM conforms to.",
       "examples": [
-        "1.6.1"
+        "1.6"
       ]
     },
     "serialNumber": {
       "type": "string",
       "title": "BOM Serial Number",
-      "description": "Every BOM generated SHOULD have a unique serial number, even if the contents of the BOM have not changed over time. If specified, the serial number must conform to [RFC 4122](https://www.ietf.org/rfc/rfc4122.html). Use of serial numbers is recommended.",
+      "description": "Every BOM generated SHOULD have a unique serial number, even if the contents of the BOM have not changed over time. If specified, the serial number must conform to RFC-4122. Use of serial numbers is recommended.",
       "examples": [
         "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
       ],
@@ -580,6 +604,7 @@
     "refType": {
       "description": "Identifier for referable and therefore interlinkable elements.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
       "type": "string",
+      "additionalProperties": false,
       "minLength": 1,
       "$comment": "TODO (breaking change): add a format constraint that prevents the value from staring with 'urn:cdx:'"
     },
@@ -703,10 +728,7 @@
                 "components": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "required": [
-                      "type"
-                    ]
+                    "$ref": "#/definitions/tools_component"
                   },
                   "uniqueItems": true,
                   "title": "Components",
@@ -715,7 +737,7 @@
                 "services": {
                   "type": "array",
                   "items": {
-                    "type": "object"
+                    "$ref": "#/definitions/service"
                   },
                   "uniqueItems": true,
                   "title": "Services",
@@ -763,13 +785,8 @@
           "$ref": "#/definitions/organizationalEntity"
         },
         "licenses": {
-          "title": "BOM License(s)",
-          "description": "The license information for the BOM document.\nThis may be different from the license(s) of the component(s) that the BOM describes.",
-          "minItems": 1,
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/licenseChoice"
-          }
+          "$ref": "#/definitions/licenseChoice",
+          "title": "Component License(s)"
         },
         "properties": {
           "type": "array",
@@ -838,11 +855,11 @@
         "name": {
           "type": "string",
           "title": "Organization Name",
+          "minLength": 1,
           "description": "The name of the organization",
           "examples": [
             "Example Inc."
-          ],
-          "minLength": 1
+          ]
         },
         "address": {
           "$ref": "#/definitions/postalAddress",
@@ -988,6 +1005,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
+          "minLength": 1,
           "description": "An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "supplier": {
@@ -1036,15 +1054,16 @@
         "name": {
           "type": "string",
           "title": "Component Name",
+          "minLength": 1,
           "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
           "examples": [
             "tomcat-catalina"
-          ],
-          "minLength": 1
+          ]
         },
         "version": {
           "$ref": "#/definitions/version",
           "title": "Component Version",
+          "minLength": 1,
           "description": "The component version. The version should ideally comply with semantic versioning but is not enforced."
         },
         "description": {
@@ -1077,12 +1096,8 @@
           }
         },
         "licenses": {
-          "title": "Component License(s)",
-          "minItems": 1,
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/licenseChoice"
-          }
+          "$ref": "#/definitions/licenseChoice",
+          "title": "Component License(s)"
         },
         "copyright": {
           "type": "string",
@@ -1122,7 +1137,7 @@
         },
         "swhid": {
           "type": "array",
-          "title": "Software Heritage Identifier",
+          "title": "SoftWare Heritage Identifier",
           "description": "Asserts the identity of the component using the Software Heritage persistent identifier (SWHID). The SWHID, if specified, must be valid and conform to the specification defined at: [https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html](https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
           "items": {
             "type": "string"
@@ -1295,7 +1310,7 @@
         ]
       },
       "else": {
-        "$comment": "These requirements only apply to components which DO NOT reference an external SBOM.",
+        "$comment": "These requirements only apply to components which DO not reference an external SBOM.",
         "allOf": [
           {
             "required": [
@@ -1640,8 +1655,8 @@
         "content": {
           "type": "string",
           "title": "Attachment Text",
-          "description": "The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text.",
-          "minLength": 1
+          "minLength": 1,
+          "description": "The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text."
         }
       }
     },
@@ -1679,7 +1694,8 @@
         "BLAKE2b-384",
         "BLAKE2b-512",
         "BLAKE3"
-      ]
+      ],
+      "additionalProperties": false
     },
     "hash-content": {
       "type": "string",
@@ -1688,7 +1704,8 @@
       "examples": [
         "3942447fac867ae5cdb3229b658f4d48"
       ],
-      "pattern": "^([a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$"
+      "pattern": "^([a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$",
+      "additionalProperties": false
     },
     "license": {
       "type": "object",
@@ -1724,11 +1741,11 @@
         "name": {
           "type": "string",
           "title": "License Name",
+          "minLength": 1,
           "description": "The name of the license. This may include the name of a commercial or proprietary license or an open source license that may not be defined by SPDX.",
           "examples": [
             "Acme Software License"
-          ],
-          "minLength": 1
+          ]
         },
         "acknowledgement": {
           "$ref": "#/definitions/licenseAcknowledgementEnumeration"
@@ -1913,28 +1930,29 @@
               "description": "The timestamp indicating when the current license expires (if applicable)."
             }
           },
-          "required": [
-            "licenseTypes"
-          ],
-          "if": {
-            "properties": {
-              "licenseTypes": {
-                "contains": {
-                  "not": {
-                    "const": "appliance"
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "licenseTypes": {
+                    "contains": {
+                      "const": "appliance"
+                    }
                   }
-                }
+                },
+                "required": [
+                  "licenseTypes"
+                ]
+              },
+              "then": {},
+              "else": {
+                "required": [
+                  "licenseTypes",
+                  "licensor"
+                ]
               }
-            },
-            "required": [
-              "licenseTypes"
-            ]
-          },
-          "then": {
-            "required": [
-              "licensor"
-            ]
-          }
+            }
+          ]
         },
         "properties": {
           "type": "array",
@@ -1966,32 +1984,63 @@
       }
     },
     "licenseChoice": {
-      "type": "object",
-      "title": "License(s)",
-      "additionalProperties": false,
-      "properties": {
-        "license": {
-          "$ref": "#/definitions/license"
-        },
-        "expression": {
-          "type": "string",
-          "minLength": 1,
-          "title": "SPDX License Expression",
-          "examples": [
-            "Apache-2.0 AND (MIT OR GPL-2.0-only)",
-            "GPL-3.0-only WITH Classpath-exception-2.0"
-          ]
-        }
-      },
+      "title": "License Choice",
+      "description": "EITHER (list of SPDX licenses and/or named licenses) OR (tuple of one SPDX License Expression)",
+      "type": "array",
+      "minItems": 1,
       "oneOf": [
         {
-          "required": [
-            "license"
-          ]
+          "title": "Multiple licenses",
+          "description": "A list of SPDX licenses and/or named licenses.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "License",
+            "required": [
+              "license"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "license": {
+                "$ref": "#/definitions/license"
+              }
+            }
+          }
         },
         {
-          "required": [
-            "expression"
+          "title": "SPDX License Expression",
+          "description": "A tuple of exactly one SPDX License Expression.",
+          "type": "array",
+          "additionalItems": false,
+          "minItems": 1,
+          "maxItems": 1,
+          "items": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "SPDX License Expression",
+                  "examples": [
+                    "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+                    "GPL-3.0-only WITH Classpath-exception-2.0"
+                  ]
+                },
+                "acknowledgement": {
+                  "$ref": "#/definitions/licenseAcknowledgementEnumeration"
+                },
+                "bom-ref": {
+                  "$ref": "#/definitions/refType",
+                  "title": "BOM Reference",
+                  "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM."
+                }
+              }
+            }
           ]
         }
       ]
@@ -2207,7 +2256,8 @@
             {
               "title": "URL",
               "type": "string",
-              "format": "iri-reference"
+              "format": "iri-reference",
+              "minLength": 1
             },
             {
               "title": "BOM-Link",
@@ -2215,8 +2265,7 @@
             }
           ],
           "title": "URL",
-          "description": "The URI (URL or URN) to the external reference. External references are URIs and therefore can accept any URL scheme including https ([RFC-7230](https://www.ietf.org/rfc/rfc7230.txt)), mailto ([RFC-2368](https://www.ietf.org/rfc/rfc2368.txt)), tel ([RFC-3966](https://www.ietf.org/rfc/rfc3966.txt)), and dns ([RFC-4501](https://www.ietf.org/rfc/rfc4501.txt)). External references may also include formally registered URNs such as [CycloneDX BOM-Link](https://cyclonedx.org/capabilities/bomlink/) to reference CycloneDX BOMs or any object within a BOM. BOM-Link transforms applicable external references into relationships that can be expressed in a BOM or across BOMs.",
-          "minLength": 1
+          "description": "The URI (URL or URN) to the external reference. External references are URIs and therefore can accept any URL scheme including https ([RFC-7230](https://www.ietf.org/rfc/rfc7230.txt)), mailto ([RFC-2368](https://www.ietf.org/rfc/rfc2368.txt)), tel ([RFC-3966](https://www.ietf.org/rfc/rfc3966.txt)), and dns ([RFC-4501](https://www.ietf.org/rfc/rfc4501.txt)). External references may also include formally registered URNs such as [CycloneDX BOM-Link](https://cyclonedx.org/capabilities/bomlink/) to reference CycloneDX BOMs or any object within a BOM. BOM-Link transforms applicable external references into relationships that can be expressed in a BOM or across BOMs."
         },
         "comment": {
           "type": "string",
@@ -2373,7 +2422,7 @@
         "bom-ref": {
           "$ref": "#/definitions/refType",
           "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the service elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
         },
         "provider": {
           "title": "Provider",
@@ -2442,11 +2491,8 @@
           "description": "Specifies information about the data including the directional flow of data and the data classification."
         },
         "licenses": {
-          "title": "Service License(s)",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/licenseChoice"
-          }
+          "$ref": "#/definitions/licenseChoice",
+          "title": "Service License(s)"
         },
         "externalReferences": {
           "type": "array",
@@ -2579,6 +2625,7 @@
         "unknown": "The directional flow of data is not known."
       },
       "title": "Data flow direction",
+      "additionalProperties": false,
       "description": "Specifies the flow direction of the data. Direction is relative to the service."
     },
     "copyright": {
@@ -2605,7 +2652,7 @@
       "properties": {
         "identity": {
           "title": "Identity Evidence",
-          "description": "Evidence that substantiates the identity of a component. The identity may be an object or an array of identity objects. Support for specifying identity as a single object was introduced in CycloneDX v1.5. Arrays were introduced in v1.6. It is recommended that all implementations use arrays, even if only one identity object is specified.",
+          "description": "Evidence that substantiates the identity of a component. The identify may be an object or an array of identity objects. Support for specifying identity as a single object was introduced in CycloneDX v1.5. Arrays were introduced in v1.6. It is recommended that all implementations use arrays, even if only one identity object is specified.",
           "oneOf": [
             {
               "type": "array",
@@ -2729,11 +2776,8 @@
           }
         },
         "licenses": {
-          "title": "License Evidence",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/licenseChoice"
-          }
+          "$ref": "#/definitions/licenseChoice",
+          "title": "License Evidence"
         },
         "copyright": {
           "type": "array",
@@ -2822,6 +2866,7 @@
         "unknown",
         "not_specified"
       ],
+      "additionalProperties": false,
       "meta:enum": {
         "complete": "The relationship is complete. No further relationships including constituent components, services, or dependencies are known to exist.",
         "incomplete": "The relationship is incomplete. Additional relationships exist and may include constituent components, services, or dependencies.",
@@ -2860,7 +2905,8 @@
       "type": "string",
       "pattern": "^([a-z]{2})(-[A-Z]{2})?$",
       "title": "Locale",
-      "description": "Defines a syntax for representing two character language code (ISO-639) followed by an optional two character country code. The language code must be lower case. If the country code is specified, the country code must be upper case. The language code and country code must be separated by a minus sign. Examples: en, en-US, fr, fr-CA"
+      "description": "Defines a syntax for representing two character language code (ISO-639) followed by an optional two character country code. The language code must be lower case. If the country code is specified, the country code must be upper case. The language code and country code must be separated by a minus sign. Examples: en, en-US, fr, fr-CA",
+      "additionalProperties": false
     },
     "releaseType": {
       "type": "string",
@@ -2999,7 +3045,8 @@
       "type": "integer",
       "minimum": 1,
       "title": "CWE",
-      "description": "Integer representation of a Common Weaknesses Enumerations (CWE). For example 399 (of https://cwe.mitre.org/data/definitions/399.html)"
+      "description": "Integer representation of a Common Weaknesses Enumerations (CWE). For example 399 (of https://cwe.mitre.org/data/definitions/399.html)",
+      "additionalProperties": false
     },
     "severity": {
       "type": "string",
@@ -3014,6 +3061,7 @@
         "none",
         "unknown"
       ],
+      "additionalProperties": false,
       "meta:enum": {
         "critical": "Critical severity",
         "high": "High severity",
@@ -3037,6 +3085,7 @@
         "SSVC",
         "other"
       ],
+      "additionalProperties": false,
       "meta:enum": {
         "CVSSv2": "Common Vulnerability Scoring System v2.0",
         "CVSSv3": "Common Vulnerability Scoring System v3.0",
@@ -3083,6 +3132,7 @@
         "protected_at_perimeter",
         "protected_by_mitigating_control"
       ],
+      "additionalProperties": false,
       "meta:enum": {
         "code_not_present": "The code has been removed or tree-shaked.",
         "code_not_reachable": "The vulnerable code is not invoked at runtime.",
@@ -3344,7 +3394,7 @@
                 "components": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/component"
+                    "$ref": "#/definitions/tools_component"
                   },
                   "uniqueItems": true,
                   "title": "Components",
@@ -3510,6 +3560,7 @@
         "unaffected",
         "unknown"
       ],
+      "additionalProperties": false,
       "meta:enum": {
         "affected": "The version is affected by the vulnerability.",
         "unaffected": "The version is not affected by the vulnerability.",
@@ -3520,6 +3571,7 @@
       "description": "A single disjunctive version identifier, for a component or service.",
       "type": "string",
       "maxLength": 1024,
+      "minLength": 1,
       "examples": [
         "9.0.14",
         "v1.33.7",
@@ -3528,7 +3580,7 @@
         "1.0.0-beta1",
         "0.8.15"
       ],
-      "minLength": 1
+      "additionalProperties": false
     },
     "versionRange": {
       "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/purl-spec/VERSION-RANGE-SPEC.rst",
@@ -3546,7 +3598,8 @@
     "range": {
       "deprecated": true,
       "description": "Deprecated definition. use definition `versionRange` instead.",
-      "$ref": "#/definitions/versionRange"
+      "$ref": "#/definitions/versionRange",
+      "additionalProperties": false
     },
     "annotations": {
       "type": "object",
@@ -3621,7 +3674,7 @@
             },
             "component": {
               "description": "The tool or component that created the annotation",
-              "$ref": "#/definitions/component"
+              "$ref": "#/definitions/tools_component"
             },
             "service": {
               "description": "The service that created the annotation",
@@ -4958,7 +5011,6 @@
         "properties": {
           "type": "array",
           "title": "Properties",
-          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
           "items": {
             "$ref": "#/definitions/property"
           }
@@ -5683,6 +5735,7 @@
     "signature": {
       "$ref": "jsf-0.82.schema.json#/definitions/signature",
       "title": "Signature",
+      "additionalProperties": false,
       "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
     },
     "cryptoProperties": {
@@ -6338,30 +6391,328 @@
         "translation",
         "object-detection"
       ]
+    },
+    "tools_component": {
+      "type": "object",
+      "title": "Component",
+      "required": [
+        "type",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "application",
+            "framework",
+            "library",
+            "container",
+            "platform",
+            "operating-system",
+            "device",
+            "device-driver",
+            "firmware",
+            "file",
+            "machine-learning-model",
+            "data",
+            "cryptographic-asset"
+          ],
+          "meta:enum": {
+            "application": "A software application. Refer to [https://en.wikipedia.org/wiki/Application_software](https://en.wikipedia.org/wiki/Application_software) for information about applications.",
+            "framework": "A software framework. Refer to [https://en.wikipedia.org/wiki/Software_framework](https://en.wikipedia.org/wiki/Software_framework) for information on how frameworks vary slightly from libraries.",
+            "library": "A software library. Refer to [https://en.wikipedia.org/wiki/Library_(computing)](https://en.wikipedia.org/wiki/Library_(computing)) for information about libraries. All third-party and open source reusable components will likely be a library. If the library also has key features of a framework, then it should be classified as a framework. If not, or is unknown, then specifying library is recommended.",
+            "container": "A packaging and/or runtime format, not specific to any particular technology, which isolates software inside the container from software outside of a container through virtualization technology. Refer to [https://en.wikipedia.org/wiki/OS-level_virtualization](https://en.wikipedia.org/wiki/OS-level_virtualization).",
+            "platform": "A runtime environment which interprets or executes software. This may include runtimes such as those that execute bytecode or low-code/no-code application platforms.",
+            "operating-system": "A software operating system without regard to deployment model (i.e. installed on physical hardware, virtual machine, image, etc) Refer to [https://en.wikipedia.org/wiki/Operating_system](https://en.wikipedia.org/wiki/Operating_system).",
+            "device": "A hardware device such as a processor or chip-set. A hardware device containing firmware SHOULD include a component for the physical hardware itself and another component of type 'firmware' or 'operating-system' (whichever is relevant), describing information about the software running on the device. See also the list of [known device properties](https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/device.md).",
+            "device-driver": "A special type of software that operates or controls a particular type of device. Refer to [https://en.wikipedia.org/wiki/Device_driver](https://en.wikipedia.org/wiki/Device_driver).",
+            "firmware": "A special type of software that provides low-level control over a device's hardware. Refer to [https://en.wikipedia.org/wiki/Firmware](https://en.wikipedia.org/wiki/Firmware).",
+            "file": "A computer file. Refer to [https://en.wikipedia.org/wiki/Computer_file](https://en.wikipedia.org/wiki/Computer_file) for information about files.",
+            "machine-learning-model": "A model based on training data that can make predictions or decisions without being explicitly programmed to do so.",
+            "data": "A collection of discrete values that convey information.",
+            "cryptographic-asset": "A cryptographic asset including algorithms, protocols, certificates, keys, tokens, and secrets."
+          },
+          "title": "Component Type",
+          "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component.",
+          "examples": [
+            "library"
+          ]
+        },
+        "mime-type": {
+          "type": "string",
+          "title": "Mime-Type",
+          "description": "The optional mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented, such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
+          "examples": [
+            "image/jpeg"
+          ],
+          "pattern": "^[-+a-z0-9.]+/[-+a-z0-9.]+$"
+        },
+        "bom-ref": {
+          "$ref": "#/definitions/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "supplier": {
+          "title": "Component Supplier",
+          "description": " The organization that supplied the component. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "manufacturer": {
+          "title": "Component Manufacturer",
+          "description": "The organization that created the component.\nManufacturer is common in components created through automated processes. Components created through manual means may have `@.authors` instead.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "authors": {
+          "type": "array",
+          "title": "Component Authors",
+          "description": "The person(s) who created the component.\nAuthors are common in components created through manual processes. Components created through automated means may have `@.manufacturer` instead.",
+          "items": {
+            "$ref": "#/definitions/organizationalContact"
+          }
+        },
+        "author": {
+          "deprecated": true,
+          "type": "string",
+          "title": "Component Author (legacy)",
+          "description": "[Deprecated] This will be removed in a future version. Use `@.authors` or `@.manufacturer` instead.\nThe person(s) or organization(s) that authored the component",
+          "examples": [
+            "Acme Inc"
+          ]
+        },
+        "publisher": {
+          "type": "string",
+          "title": "Component Publisher",
+          "description": "The person(s) or organization(s) that published the component",
+          "examples": [
+            "Acme Inc"
+          ]
+        },
+        "group": {
+          "type": "string",
+          "title": "Component Group",
+          "description": "The grouping name or identifier. This will often be a shortened, single name of the company or project that produced the component, or the source package or domain name. Whitespace and special characters should be avoided. Examples include: apache, org.apache.commons, and apache.org.",
+          "examples": [
+            "com.acme"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "title": "Component Name",
+          "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
+          "examples": [
+            "tomcat-catalina"
+          ]
+        },
+        "version": {
+          "$ref": "#/definitions/version",
+          "title": "Component Version",
+          "description": "The component version. The version should ideally comply with semantic versioning but is not enforced."
+        },
+        "description": {
+          "type": "string",
+          "title": "Component Description",
+          "description": "Specifies a description for the component"
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "required",
+            "optional",
+            "excluded"
+          ],
+          "meta:enum": {
+            "required": "The component is required for runtime",
+            "optional": "The component is optional at runtime. Optional components are components that are not capable of being called due to them not being installed or otherwise accessible by any means. Components that are installed but due to configuration or other restrictions are prohibited from being called must be scoped as 'required'.",
+            "excluded": "Components that are excluded provide the ability to document component usage for test and other non-runtime purposes. Excluded components are not reachable within a call graph at runtime."
+          },
+          "title": "Component Scope",
+          "description": "Specifies the scope of the component. If scope is not specified, 'required' scope SHOULD be assumed by the consumer of the BOM.",
+          "default": "required"
+        },
+        "hashes": {
+          "type": "array",
+          "title": "Component Hashes",
+          "description": "The hashes of the component.",
+          "items": {
+            "$ref": "#/definitions/hash"
+          }
+        },
+        "licenses": {
+          "$ref": "#/definitions/licenseChoice",
+          "title": "Component License(s)"
+        },
+        "copyright": {
+          "type": "string",
+          "title": "Component Copyright",
+          "description": "A copyright notice informing users of the underlying claims to copyright ownership in a published work.",
+          "examples": [
+            "Acme Inc"
+          ]
+        },
+        "cpe": {
+          "type": "string",
+          "title": "Common Platform Enumeration (CPE)",
+          "description": "Asserts the identity of the component using CPE. The CPE must conform to the CPE 2.2 or 2.3 specification. See [https://nvd.nist.gov/products/cpe](https://nvd.nist.gov/products/cpe). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "examples": [
+            "cpe:2.3:a:acme:component_framework:-:*:*:*:*:*:*:*"
+          ]
+        },
+        "purl": {
+          "type": "string",
+          "title": "Package URL (purl)",
+          "description": "Asserts the identity of the component using package-url (purl). The purl, if specified, must be valid and conform to the specification defined at: [https://github.com/package-url/purl-spec](https://github.com/package-url/purl-spec). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "examples": [
+            "pkg:maven/com.acme/tomcat-catalina@9.0.14?packaging=jar"
+          ]
+        },
+        "omniborId": {
+          "type": "array",
+          "title": "OmniBOR Artifact Identifier (gitoid)",
+          "description": "Asserts the identity of the component using the OmniBOR Artifact ID. The OmniBOR, if specified, must be valid and conform to the specification defined at: [https://www.iana.org/assignments/uri-schemes/prov/gitoid](https://www.iana.org/assignments/uri-schemes/prov/gitoid). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            "gitoid:blob:sha1:a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+            "gitoid:blob:sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+          ]
+        },
+        "swhid": {
+          "type": "array",
+          "title": "SoftWare Heritage Identifier",
+          "description": "Asserts the identity of the component using the Software Heritage persistent identifier (SWHID). The SWHID, if specified, must be valid and conform to the specification defined at: [https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html](https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            "swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2"
+          ]
+        },
+        "swid": {
+          "$ref": "#/definitions/swid",
+          "title": "SWID Tag",
+          "description": "Asserts the identity of the component using [ISO-IEC 19770-2 Software Identification (SWID) Tags](https://www.iso.org/standard/65666.html). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity."
+        },
+        "modified": {
+          "type": "boolean",
+          "title": "Component Modified From Original",
+          "description": "[Deprecated] This will be removed in a future version. Use the pedigree element instead to supply information on exactly how the component was modified. A boolean value indicating if the component has been modified from the original. A value of true indicates the component is a derivative of the original. A value of false indicates the component has not been modified from the original."
+        },
+        "pedigree": {
+          "type": "object",
+          "title": "Component Pedigree",
+          "description": "Component pedigree is a way to document complex supply chain scenarios where components are created, distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to document variants where the exact relation may not be known.",
+          "additionalProperties": false,
+          "properties": {
+            "ancestors": {
+              "type": "array",
+              "title": "Ancestors",
+              "description": "Describes zero or more components in which a component is derived from. This is commonly used to describe forks from existing projects where the forked version contains a ancestor node containing the original component it was forked from. For example, Component A is the original component. Component B is the component being used and documented in the BOM. However, Component B contains a pedigree node with a single ancestor documenting Component A - the original component from which Component B is derived from.",
+              "items": {
+                "$ref": "#/definitions/component"
+              }
+            },
+            "descendants": {
+              "type": "array",
+              "title": "Descendants",
+              "description": "Descendants are the exact opposite of ancestors. This provides a way to document all forks (and their forks) of an original or root component.",
+              "items": {
+                "$ref": "#/definitions/component"
+              }
+            },
+            "variants": {
+              "type": "array",
+              "title": "Variants",
+              "description": "Variants describe relations where the relationship between the components is not known. For example, if Component A contains nearly identical code to Component B. They are both related, but it is unclear if one is derived from the other, or if they share a common ancestor.",
+              "items": {
+                "$ref": "#/definitions/component"
+              }
+            },
+            "commits": {
+              "type": "array",
+              "title": "Commits",
+              "description": "A list of zero or more commits which provide a trail describing how the component deviates from an ancestor, descendant, or variant.",
+              "items": {
+                "$ref": "#/definitions/commit"
+              }
+            },
+            "patches": {
+              "type": "array",
+              "title": "Patches",
+              "description": ">A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complementary to commits or may be used in place of commits.",
+              "items": {
+                "$ref": "#/definitions/patch"
+              }
+            },
+            "notes": {
+              "type": "string",
+              "title": "Notes",
+              "description": "Notes, observations, and other non-structured commentary describing the components pedigree."
+            }
+          }
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/externalReference"
+          },
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+        },
+        "components": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/component"
+          },
+          "uniqueItems": true,
+          "title": "Components",
+          "description": "A list of software and hardware components included in the parent component. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system &#8594; subsystem &#8594; parts assembly in physical supply chains."
+        },
+        "evidence": {
+          "$ref": "#/definitions/componentEvidence",
+          "title": "Evidence",
+          "description": "Provides the ability to document evidence collected through various forms of extraction or analysis."
+        },
+        "releaseNotes": {
+          "$ref": "#/definitions/releaseNotes",
+          "title": "Release notes",
+          "description": "Specifies optional release notes."
+        },
+        "modelCard": {
+          "$ref": "#/definitions/modelCard",
+          "title": "AI/ML Model Card"
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/componentData"
+          },
+          "title": "Data",
+          "description": "This object SHOULD be specified for any component of type `data` and must not be specified for other component types."
+        },
+        "cryptoProperties": {
+          "$ref": "#/definitions/cryptoProperties",
+          "title": "Cryptographic Properties"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/definitions/property"
+          }
+        },
+        "tags": {
+          "$ref": "#/definitions/tags",
+          "title": "Tags"
+        },
+        "signature": {
+          "$ref": "#/definitions/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
     }
-  },
-  "if": {
-    "required": [
-      "components"
-    ]
-  },
-  "then": {
-    "required": [
-      "bomFormat",
-      "specVersion",
-      "version",
-      "metadata",
-      "compositions",
-      "dependencies"
-    ]
-  },
-  "else": {
-    "required": [
-      "bomFormat",
-      "specVersion",
-      "version",
-      "metadata",
-      "compositions"
-    ]
   }
 }

--- a/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
+++ b/cdxev/auxiliary/schema/bom-1.6-custom.schema.json
@@ -785,12 +785,15 @@
           "$ref": "#/definitions/organizationalEntity"
         },
         "licenses": {
-          "additionalItems": false,
-          "items": {
-            "$ref": "#/definitions/licenseChoice"
-          },
-          "title": "Component License(s)",
-          "minItems": 1
+          "allOf": [
+            {
+              "$ref": "#/definitions/licenseChoice"
+            },
+            {
+              "minItems": 1
+            }
+          ],
+          "title": "Component License(s)"
         },
         "properties": {
           "type": "array",
@@ -1100,13 +1103,15 @@
           }
         },
         "licenses": {
-          "type": "array",
-          "additionalItems": false,
-          "items": {
-            "$ref": "#/definitions/licenseChoice"
-          },
-          "title": "Component License(s)",
-          "minItems": 1
+          "allOf": [
+            {
+              "$ref": "#/definitions/licenseChoice"
+            },
+            {
+              "minItems": 1
+            }
+          ],
+          "title": "Component License(s)"
         },
         "copyright": {
           "type": "string",
@@ -1993,44 +1998,48 @@
       }
     },
     "licenseChoice": {
-      "type": "object",
-      "title": "License(s)",
-      "additionalProperties": false,
-      "properties": {
-        "license": {
-          "$ref": "#/definitions/license"
-        },
-        "expression": {
-          "type": "string",
-          "minLength": 1,
-          "title": "SPDX License Expression",
-          "description": "A valid SPDX license expression.\nRefer to https://spdx.org/specifications for syntax requirements",
-          "examples": [
-            "Apache-2.0 AND (MIT OR GPL-2.0-only)",
-            "GPL-3.0-only WITH Classpath-exception-2.0"
-          ]
-        },
-        "acknowledgement": {
-          "$ref": "#/definitions/licenseAcknowledgementEnumeration"
-        },
-        "bom-ref": {
-          "$ref": "#/definitions/refType",
-          "title": "BOM Reference",
-          "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+      "title": "License Choice",
+      "description": "EITHER (list of SPDX licenses and/or named licenses) OR (tuple of one SPDX License Expression)",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "oneOf": [
+          {
+            "required": [
+              "license"
+            ]
+          },
+          {
+            "required": [
+              "expression"
+            ]
+          }
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "license": {
+            "$ref": "#/definitions/license"
+          },
+          "expression": {
+            "type": "string",
+            "title": "SPDX License Expression",
+            "description": "A valid SPDX license expression.\nRefer to https://spdx.org/specifications for syntax requirements",
+            "minLength": 1,
+            "examples": [
+              "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+              "GPL-3.0-only WITH Classpath-exception-2.0"
+            ]
+          },
+          "acknowledgement": {
+            "$ref": "#/definitions/licenseAcknowledgementEnumeration"
+          },
+          "bom-ref": {
+            "$ref": "#/definitions/refType",
+            "title": "BOM Reference",
+            "description": "An optional identifier which can be used to reference the license elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+          }
         }
-      },
-      "oneOf": [
-        {
-          "required": [
-            "license"
-          ]
-        },
-        {
-          "required": [
-            "expression"
-          ]
-        }
-      ]
+      }
     },
     "commit": {
       "type": "object",

--- a/cdxev/validator/validate.py
+++ b/cdxev/validator/validate.py
@@ -179,7 +179,8 @@ def validate_sbom(  # noqa: C901
                                 + "used license ID "
                                 + leaf.args[0].split()[0]
                                 + " is not a valid SPDX ID. "
-                                "Please use either the field 'name' or provide a valid ID."
+                                "Please use either the field 'name' and 'text' or "
+                                "provide a valid ID."
                             )
                         elif "non-empty" in leaf.message:
                             errors.append(

--- a/cdxev/validator/validate.py
+++ b/cdxev/validator/validate.py
@@ -149,7 +149,7 @@ def validate_sbom(  # noqa: C901
             except AttributeError:
                 error_path = error.json_path + " has the mistake: "
             if error.context is not None and len(error.context) > 0:
-                if error.validator in ("oneOf", "anyOf") and "licenses" in error.json_path:
+                if error.validator == "oneOf" and "licenses" in error.json_path:
                     # When licenseChoice (array oneOf) fails, the actual errors are nested in
                     # the context of the branch that was closest to passing. Walk the context
                     # tree to find the most relevant leaf errors to surface.
@@ -172,13 +172,8 @@ def validate_sbom(  # noqa: C901
                                 seen_messages.add(leaf.message)
                                 all_leaves.append(leaf)
 
-                    if not all_leaves:
-                        all_leaves = collect_leaf_errors(error.context[0])
-
                     for leaf in all_leaves:
-                        if (
-                            "license.id" in leaf.json_path or "license.id" in error.json_path
-                        ) and ("is not one of" in leaf.message):
+                        if "license.id" in leaf.json_path and "is not one of" in leaf.message:
                             errors.append(
                                 error_path
                                 + "used license ID "

--- a/cdxev/validator/validate.py
+++ b/cdxev/validator/validate.py
@@ -97,10 +97,9 @@ def validate_sbom(  # noqa: C901
         )
         for error in sorted(v.iter_errors(sbom), key=str):
             try:
-                if (
-                    error.validator == "required"
-                    and error.validator_value == ["this_is_an_externally_described_component"]
-                ):
+                if error.validator == "required" and error.validator_value == [
+                    "this_is_an_externally_described_component"
+                ]:
                     # This requirement in the schema allows us to produce warnings.
                     comp = t.cast(dict, error.instance)
                     if "bom-ref" in comp:
@@ -150,22 +149,70 @@ def validate_sbom(  # noqa: C901
             except AttributeError:
                 error_path = error.json_path + " has the mistake: "
             if error.context is not None and len(error.context) > 0:
-                error_message = ""
-                for i in range(len(error.context)):
-                    error_field = re.search(r"'\w+'|(is too short)", error.context[i].message)
-                    if (error_field is None) or (error_field.group(0) == "is too short"):
-                        validation_field = "'" + error.context[i].json_path.split(".")[-1] + "'"
-                    else:
-                        validation_field = error_field.group(0)
-                    if i < (len(error.context) - 1):
-                        if error_message == "":
-                            error_message += validation_field
+                if error.validator in ("oneOf", "anyOf") and "licenses" in error.json_path:
+                    # When licenseChoice (array oneOf) fails, the actual errors are nested in
+                    # the context of the branch that was closest to passing. Walk the context
+                    # tree to find the most relevant leaf errors to surface.
+                    def collect_leaf_errors(
+                        err: jsonschema.exceptions.ValidationError,
+                    ) -> list[jsonschema.exceptions.ValidationError]:
+                        if err.context:
+                            leaves = []
+                            for sub in err.context:
+                                leaves.extend(collect_leaf_errors(sub))
+                            return leaves
+                        return [err]
+
+                    # Collect all leaf errors from all branches (deduplicated by message)
+                    all_leaves: list[jsonschema.exceptions.ValidationError] = []
+                    seen_messages: set[str] = set()
+                    for ctx_error in error.context:
+                        for leaf in collect_leaf_errors(ctx_error):
+                            if leaf.message not in seen_messages:
+                                seen_messages.add(leaf.message)
+                                all_leaves.append(leaf)
+
+                    if not all_leaves:
+                        all_leaves = collect_leaf_errors(error.context[0])
+
+                    for leaf in all_leaves:
+                        if (
+                            "license.id" in leaf.json_path or "license.id" in error.json_path
+                        ) and ("is not one of" in leaf.message):
+                            errors.append(
+                                error_path
+                                + "used license ID "
+                                + leaf.args[0].split()[0]
+                                + " is not a valid SPDX ID. "
+                                "Please use either the field 'name' or provide a valid ID."
+                            )
+                        elif "non-empty" in leaf.message:
+                            errors.append(
+                                f"{error_path}'{leaf.absolute_path[-1]}' should not be empty"
+                            )
+                        elif leaf.validator == "pattern":
+                            errors.append(error_path + leaf.message.replace("\\", ""))
                         else:
-                            error_message += ", " + validation_field
-                    else:
-                        error_message += " or " + validation_field
-                error_message += " is a required property"
-                errors.append(error_path + error_message)
+                            errors.append(error_path + leaf.message)
+                else:
+                    error_message = ""
+                    for i in range(len(error.context)):
+                        error_field = re.search(r"'\w+'|(is too short)", error.context[i].message)
+                        if (error_field is None) or (error_field.group(0) == "is too short"):
+                            validation_field = (
+                                "'" + error.context[i].json_path.split(".")[-1] + "'"
+                            )
+                        else:
+                            validation_field = error_field.group(0)
+                        if i < (len(error.context) - 1):
+                            if error_message == "":
+                                error_message += validation_field
+                            else:
+                                error_message += ", " + validation_field
+                        else:
+                            error_message += " or " + validation_field
+                    error_message += " is a required property"
+                    errors.append(error_path + error_message)
             else:
                 if ("license.id" in error.json_path) and ("is not one of" in error.message):
                     # if mistake is a wrong SPDX ID omit printing every single option


### PR DESCRIPTION
This PR implements the same updates to the `licenses` definition from CycloneDX 1.5 and 1.6 in the custom schema.

From what I could tell, the only modification we made as part of our custom requirements was the `minLength` property on the `expression` property. I've made sure to keep that around.