### PR TITLE
fix: make merge results consistent when no components field is present

### DIFF
--- a/cdxev/auxiliary/sbomFunctions.py
+++ b/cdxev/auxiliary/sbomFunctions.py
@@ -179,6 +179,22 @@ def get_bom_refs_from_dependencies(dependencies: Sequence[dict]) -> list[str]:
     return list_of_bom_refs
 
 
+def get_bom_refs_from_dependencies_dependson(dependencies: Sequence[dict]) -> list[str]:
+    """
+    Function that gets a list of dependencies and returns a list with their sboms
+
+    Input:
+    dependencies: List with dict of dependencies
+
+    Output:
+    bom_refs: List of Strings, containing the bom-refs of the dependencies
+    """
+    list_of_bom_refs = []
+    for dependency in dependencies:
+        list_of_bom_refs += dependency.get("dependsOn", [])
+    return list_of_bom_refs
+
+
 def extract_components(list_of_components: Sequence[dict]) -> Sequence[dict]:
     extracted_components = []
     for component in list_of_components:
@@ -765,3 +781,38 @@ def merge_affects_versions(
                     original_affect_versions.append(version)
         if not ref_is_in:
             original_affects.append(affect)
+
+def add_merged_metadata_component_to_dependencies(merged_sbom: dict, added_sbom: dict) -> None:
+
+    added_sbom_ref = (
+        added_sbom.get("metadata", {}).get("component", {}).get("bom-ref", "")
+    )
+    merged_sbom_ref = (
+        merged_sbom.get("metadata", {}).get("component", {}).get("bom-ref", "")
+    )
+
+    if merged_sbom_ref not in get_bom_refs_from_dependencies(merged_sbom.get("dependencies", [])):
+
+        product_dependancy = {
+            "ref": merged_sbom_ref,
+            "dependsOn": [added_sbom_ref],
+        }
+        if merged_sbom.get("dependencies", []):
+            merged_sbom["dependencies"].append(product_dependancy)
+        else:
+            merged_sbom["dependencies"] = [product_dependancy]
+
+    else:
+        product_dependancy = get_dependency_by_ref(merged_sbom_ref, merged_sbom.get("dependencies", []))
+        first_level_dependson = product_dependancy.get("dependsOn", [])
+
+        if added_sbom_ref not in get_bom_refs_from_dependencies_dependson(merged_sbom.get("dependencies", [])):
+            first_level_dependson.append(added_sbom_ref)
+
+
+def get_bom_ref_from_components(list_of_components: list[dict]) -> list[str]:
+    list_of_bom_refs = []
+    all_components = extract_components(list_of_components)
+    for component in all_components:
+        list_of_bom_refs.append(component.get("bom-ref", ""))
+    return list_of_bom_refs

--- a/cdxev/merge.py
+++ b/cdxev/merge.py
@@ -100,6 +100,11 @@ def merge_components(
     """
     list_of_merged_components: t.List[dict] = governing_sbom.get("components", [])
     list_of_added_components = sbom_to_be_merged.get("components", [])
+    if sbom_to_be_merged.get("metadata", {}).get("component", {}):
+        component_from_metadata = sbom_to_be_merged.get("metadata", {}).get(
+            "component", {}
+        )
+        list_of_added_components.append(component_from_metadata)
 
     present_component_identities: dict[ComponentIdentity, dict] = {}
     for component in extract_components(governing_sbom.get("components", [])):
@@ -228,9 +233,6 @@ def merge_2_sboms(
         )
 
     merged_sbom = original_sbom
-    component_from_metadata = sbom_to_be_merged.get("metadata", {}).get("component", {})
-    components_of_sbom_to_be_merged = sbom_to_be_merged.get("components", [])
-    components_of_sbom_to_be_merged.append(component_from_metadata)
     list_of_original_dependencies = original_sbom.get("dependencies", [])
     list_of_new_dependencies = sbom_to_be_merged.get("dependencies", [])
     list_of_original_vulnerabilities = original_sbom.get("vulnerabilities", [])
@@ -259,7 +261,7 @@ def merge_2_sboms(
         )
         merged_sbom["vulnerabilities"] = list_of_merged_vulnerabilities
 
-    if original_sbom.get("components", []) and sbom_to_be_merged.get("components", []):
+    if list_of_merged_components:
         merged_sbom["components"] = list_of_merged_components
 
     if original_sbom.get("dependencies", []) and sbom_to_be_merged.get(

--- a/cdxev/merge.py
+++ b/cdxev/merge.py
@@ -16,6 +16,8 @@ from cdxev.auxiliary.sbomFunctions import (
     make_bom_refs_unique,
     merge_affects_versions,
     unify_bom_refs,
+    add_merged_metadata_component_to_dependencies,
+    get_bom_ref_from_components
 )
 from cdxev.log import LogMessage
 
@@ -104,7 +106,16 @@ def merge_components(
         component_from_metadata = sbom_to_be_merged.get("metadata", {}).get(
             "component", {}
         )
-        list_of_added_components.append(component_from_metadata)
+        list_of_bom_ref = get_bom_ref_from_components(list_of_merged_components)
+        list_of_bom_ref.append(governing_sbom.get("metadata", {}).get("component", {}).get("bom-ref", ""))
+        if not component_from_metadata.get("bom-ref", 1) in list_of_bom_ref:
+            list_of_merged_components.append(component_from_metadata)
+        elif hierarchical:
+            # The added SBOM's root component already exists in the governing SBOM.
+            # In hierarchical mode, route its sub-components to be nested under it.
+            wrapper = dict(component_from_metadata)
+            wrapper["components"] = list_of_added_components
+            list_of_added_components = [wrapper]
 
     present_component_identities: dict[ComponentIdentity, dict] = {}
     for component in extract_components(governing_sbom.get("components", [])):
@@ -264,7 +275,7 @@ def merge_2_sboms(
     if list_of_merged_components:
         merged_sbom["components"] = list_of_merged_components
 
-    if original_sbom.get("dependencies", []) and sbom_to_be_merged.get(
+    if original_sbom.get("dependencies", []) or sbom_to_be_merged.get(
         "dependencies", []
     ):
         merged_sbom["dependencies"] = merged_dependencies
@@ -274,6 +285,10 @@ def merge_2_sboms(
             merged_sbom.get("compositions", []),
             sbom_to_be_merged.get("compositions", []),
         )
+
+
+    if merged_sbom.get("metadata", {}).get("component", {}) and merged_sbom.get("components", []):
+        add_merged_metadata_component_to_dependencies(merged_sbom, sbom_to_be_merged)
 
     return merged_sbom
 

--- a/tests/auxiliary/test_merge_sboms/sections_for_test_sbom.json
+++ b/tests/auxiliary/test_merge_sboms/sections_for_test_sbom.json
@@ -6645,5 +6645,54 @@
         }
       ]
     }
+  },
+  "test_merge_metadata_component": {
+    "sbom_1": {
+      "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+      "bomFormat": "CycloneDX",
+      "specVersion": "1.6",
+      "metadata": {
+        "component": {
+          "bom-ref": "app",
+          "type": "application",
+          "name": "Acme Application",
+          "version": "1.0.0"
+        }
+      }
+    },
+    "sbom_2": {
+      "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+      "bomFormat": "CycloneDX",
+      "specVersion": "1.6",
+      "metadata": {
+        "component": {
+          "bom-ref": "second",
+          "type": "application",
+          "name": "Second app",
+          "version": "1.0.0"
+        }
+      }
+    },
+    "expected": {
+      "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+      "bomFormat": "CycloneDX",
+      "specVersion": "1.6",
+      "metadata": {
+        "component": {
+          "bom-ref": "app",
+          "type": "application",
+          "name": "Acme Application",
+          "version": "1.0.0"
+        }
+      },
+      "components": [
+        {
+          "bom-ref": "second",
+          "type": "application",
+          "name": "Second app",
+          "version": "1.0.0"
+        }
+      ]
+    }
   }
 }

--- a/tests/auxiliary/test_merge_sboms/sections_for_test_sbom.json
+++ b/tests/auxiliary/test_merge_sboms/sections_for_test_sbom.json
@@ -6692,7 +6692,15 @@
           "name": "Second app",
           "version": "1.0.0"
         }
-      ]
+      ],
+      "dependencies": [
+        {
+            "ref": "app",
+            "dependsOn": [
+                "second"
+            ]
+        }
+    ]
     }
   }
 }

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -98,7 +98,6 @@ class TestMergeSboms(unittest.TestCase):
         expected = sections["expected"]
 
         actual = merge.merge([sbom_1, sbom_2])
-        print(actual)
         self.assertEqual(actual, expected)
 
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -91,6 +91,16 @@ class TestMergeSboms(unittest.TestCase):
         sbom_merged.pop("compositions")
         self.assertTrue(helper.compare_sboms(merged_sbom, sbom_merged))
 
+    def test_merge_metadata_component(self) -> None:
+        sections = helper.load_sections_for_test_sbom()["test_merge_metadata_component"]
+        sbom_1 = sections["sbom_1"]
+        sbom_2 = sections["sbom_2"]
+        expected = sections["expected"]
+
+        actual = merge.merge([sbom_1, sbom_2])
+        print(actual)
+        self.assertEqual(actual, expected)
+
 
 class TestMergeSeveralSboms(unittest.TestCase):
     def test_merge_3_sboms(self) -> None:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -98,7 +98,67 @@ class TestMergeSboms(unittest.TestCase):
         expected = sections["expected"]
 
         actual = merge.merge([sbom_1, sbom_2])
+
         self.assertEqual(actual, expected)
+
+    def test_merge_in_empty_sbom(self) -> None:
+        sections = helper.load_sections_for_test_sbom()["merge_vulnerabilities_tests"][
+            "test_merge_vulnerabilities"
+        ]
+        added_sbom = sections["merge.input_1"]
+        governing_sbom = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.3",
+            "version": 1,
+            "metadata": {
+                "timestamp": "2022-10-17T19:59:12",
+                "authors": [
+                    {
+                        "name": "automated"
+                    }
+                ],
+                "component": {
+                    "type": "library",
+                    "bom-ref": "Main_program",
+                    "supplier": {
+                        "name": "Company Legal"
+                    },
+                    "group": "com.company.governing",
+                    "name": "Main_program",
+                    "version": "T5.0.3.96",
+                    "licenses": [
+                        {
+                            "license": {
+                                "name": "company internal"
+                            }
+                        }
+                    ],
+                    "copyright": "Company Legal 2022, all rights reserved"
+                }
+            },
+            "components": [
+                {
+                    "type": "application",
+                    "bom-ref": "governing_program",
+                    "supplier": {
+                        "name": "Company Legal"
+                    },
+                    "group": "com.company.governing",
+                    "name": "governing_program",
+                    "version": "T5.0.3.96",
+                    "licenses": [
+                        {
+                            "license": {
+                                "name": "company internal"
+                            }
+                        }
+                    ],
+                    "copyright": "Company Legal 2022, all rights reserved"
+                }
+            ]
+        }
+        merged_sbom = merge.merge([governing_sbom, added_sbom], hierarchical=True)
+        self.assertEqual(len(merged_sbom["components"]), 1)
 
 
 class TestMergeSeveralSboms(unittest.TestCase):
@@ -108,7 +168,6 @@ class TestMergeSeveralSboms(unittest.TestCase):
         sub_sub_program = helper.load_additional_sbom_dict()["sub_sub_program"]
         goal_sbom = helper.load_additional_sbom_dict()["merge_government_sub_sub_sub"]
         merged_bom = merge.merge([governing_program, sub_program, sub_sub_program])
-
         self.assertTrue(helper.compare_sboms(merged_bom, goal_sbom))
 
     def test_merge_4_sboms(self) -> None:

--- a/tests/test_sbom_functions.py
+++ b/tests/test_sbom_functions.py
@@ -859,5 +859,30 @@ class TestVulnerabilities(unittest.TestCase):
         )
 
 
+class TestDependencyFunctions(unittest.TestCase):
+    def test_add_merged_metadata_component_to_dependencies(self) -> None:
+        metadata_component = {"bom-ref": "metadata_component"}
+        metadata = {"component": metadata_component}
+        metadata_component_added = {"bom-ref": "metadata_component_added"}
+        metadata_added = {"component": metadata_component_added}
+        dependencies = [
+            {
+                "ref": "metadata_component",
+                "dependsOn": ["component_1", "component 2"]
+            }
+        ]
+        sbom_added = {"metadata": metadata_added}
+        sbom_merged = {"metadata": metadata, "dependencies": dependencies}
+
+        sbF.add_merged_metadata_component_to_dependencies(sbom_merged, sbom_added)
+
+        self.assertTrue("metadata_component_added" in sbom_merged["dependencies"][0]["dependsOn"])
+
+        sbom_merged = {"metadata": metadata}
+        sbF.add_merged_metadata_component_to_dependencies(sbom_merged, sbom_added)
+
+        self.assertTrue("metadata_component_added" in sbom_merged["dependencies"][0]["dependsOn"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
closes #412 