### PR TITLE
fix: uniformly define encoding for all file handling

### DIFF
--- a/cdxev/__main__.py
+++ b/cdxev/__main__.py
@@ -100,7 +100,7 @@ def read_sbom(sbom_file: Path, file_type: Optional[str] = None) -> Tuple[dict, s
 def load_json(path: Path) -> t.Any:
     """Loads a JSON file into a dictionary."""
     try:
-        with path.open(encoding="utf-8-sig") as file:
+        with path.open(encoding="utf_8_sig") as file:
             return json.load(file)
     except json.JSONDecodeError as ex:
         raise InputFileError("Invalid JSON", None, ex.lineno) from ex
@@ -969,7 +969,7 @@ def invoke_set(args: argparse.Namespace) -> int:
 
         updates = []
         try:
-            with open(args.from_file) as from_file:
+            with open(args.from_file, encoding="utf_8_sig") as from_file:
                 updates = json.load(from_file)
         except json.JSONDecodeError as ex:
             raise InputFileError(

--- a/cdxev/amend/operations.py
+++ b/cdxev/amend/operations.py
@@ -305,7 +305,7 @@ class LicenseNameToId(Operation):
         license_mapping_file = (
             importlib.resources.files(__spec__.parent) / "license_name_spdx_id_map.json"  # type: ignore[arg-type]  # noqa: E501
         )
-        license_mapping_json = license_mapping_file.read_text(encoding="utf-8-sig")
+        license_mapping_json = license_mapping_file.read_text(encoding="utf_8_sig")
         license_mapping = json.loads(license_mapping_json)
         for mapping in license_mapping:
             for name in mapping["names"]:

--- a/cdxev/auxiliary/io_processing.py
+++ b/cdxev/auxiliary/io_processing.py
@@ -44,7 +44,7 @@ def write_sbom(sbom: dict, destination: t.Optional[Path], update_metadata: bool 
         file = sys.stdout
     else:
         destination = create_destination_path(destination, sbom, generate_filename)
-        file = destination.open("w")
+        file = destination.open("w", encoding="utf_8")
 
     json.dump(sbom, file, indent=4)
 
@@ -146,7 +146,7 @@ def write_list(
         file = sys.stdout
     else:
         destination = create_destination_path(destination, sbom, create_list_file_filename)
-        file = destination.open("w")
+        file = destination.open("w", encoding="utf_8")
     file.write(list_file)
 
 

--- a/cdxev/build_public_bom.py
+++ b/cdxev/build_public_bom.py
@@ -282,7 +282,7 @@ def build_public_bom(
 
 
 def create_internal_validator(path_to_schema: Path) -> Draft7Validator:
-    with path_to_schema.open() as schema_f:
+    with path_to_schema.open(encoding="utf_8_sig") as schema_f:
         schema_internal = json.load(schema_f)
     validator_for_being_internal = Draft7Validator(schema_internal, format_checker=FormatChecker())
     validator_for_being_internal.check_schema(schema_internal)

--- a/cdxev/validator/customreports.py
+++ b/cdxev/validator/customreports.py
@@ -92,7 +92,7 @@ class WarningsNgReporter(logging.Handler):
         s = json.dumps(self.buffer, indent=4)
         try:
             if isinstance(self.target, pathlib.Path):
-                self.target.write_text(s)
+                self.target.write_text(s, encoding="utf_8")
             else:
                 self.target.write(s)
         finally:
@@ -169,7 +169,7 @@ class GitLabCQReporter(logging.Handler):
         s = json.dumps(self.buffer, indent=4)
         try:
             if isinstance(self.target, pathlib.Path):
-                self.target.write_text(s)
+                self.target.write_text(s, encoding="utf_8")
             else:
                 self.target.write(s)
         finally:

--- a/cdxev/validator/helper.py
+++ b/cdxev/validator/helper.py
@@ -30,7 +30,7 @@ def open_schema(
                     "Schema not loaded",
                     "Path does not exist or is not a file: " + str(schema_path),
                 )
-            with schema_path.open() as fp:
+            with schema_path.open(encoding="utf_8_sig") as fp:
                 return json.load(fp)  # type:ignore [no-any-return]
     except OSError as e:
         raise AppError("Schema not loaded", str(e)) from e
@@ -54,7 +54,7 @@ def _get_builtin_schema(schema_type: str, spec_version: str) -> dict:
             f"No built-in schema found for CycloneDX version {spec_version} and "
             f"schema type '{schema_type}'.",
         )
-    schema_json = schema_file.read_text()
+    schema_json = schema_file.read_text(encoding="utf_8_sig")
     schema = json.loads(schema_json)
     if isinstance(schema, dict):
         return schema
@@ -67,7 +67,7 @@ def _get_builtin_schema(schema_type: str, spec_version: str) -> dict:
 
 def load_spdx_schema() -> dict:
     path_to_embedded_schema = resources.files("cdxev.auxiliary.schema") / "spdx.schema.json"
-    with path_to_embedded_schema.open() as f:
+    with path_to_embedded_schema.open(encoding="utf_8_sig") as f:
         schema = json.load(f)
         if isinstance(schema, dict):
             return schema

--- a/tests/auxiliary/helper.py
+++ b/tests/auxiliary/helper.py
@@ -103,7 +103,7 @@ def get_ratings_dict() -> dict:
     with open(
         path_to_folder_with_test_sboms + "ratings_lists_for_tests.json",
         "r",
-        encoding="utf-8-sig",
+        encoding="utf_8_sig",
     ) as my_file:
         return json.load(my_file)
 
@@ -112,7 +112,7 @@ def get_dictionary_with_stuff() -> dict:
     with open(
         path_to_folder_with_test_sboms + "sections_for_test_sbom.json",
         "r",
-        encoding="utf-8-sig",
+        encoding="utf_8_sig",
     ) as my_file:
         return json.load(my_file)
 
@@ -121,7 +121,7 @@ def load_governing_program() -> dict:
     with open(
         path_to_folder_with_test_sboms + "governing_program.json",
         "r",
-        encoding="utf-8-sig",
+        encoding="utf_8_sig",
     ) as my_file:
         sbom = json.load(my_file)
     return sbom
@@ -131,7 +131,7 @@ def load_sections_for_test_sbom() -> dict:
     with open(
         path_to_folder_with_test_sboms + "sections_for_test_sbom.json",
         "r",
-        encoding="utf-8-sig",
+        encoding="utf_8_sig",
     ) as my_file:
         sbom = json.load(my_file)
     return sbom
@@ -141,7 +141,7 @@ def load_governing_program_merged_sub_program() -> dict:
     with open(
         path_to_folder_with_test_sboms + "merged_sbom.json",
         "r",
-        encoding="utf-8-sig",
+        encoding="utf_8_sig",
     ) as my_file:
         sbom = json.load(my_file)
     return sbom
@@ -151,7 +151,7 @@ def load_sub_program() -> dict:
     with open(
         path_to_folder_with_test_sboms + "sub_program.json",
         "r",
-        encoding="utf-8-sig",
+        encoding="utf_8_sig",
     ) as my_file:
         sbom = json.load(my_file)
     return sbom
@@ -161,7 +161,7 @@ def load_additional_sbom_dict() -> dict:
     with open(
         path_to_folder_with_test_sboms + "additional_sboms.json",
         "r",
-        encoding="utf-8-sig",
+        encoding="utf_8_sig",
     ) as my_file:
         sbom = json.load(my_file)
     return sbom

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -60,7 +60,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
             if not errors_file.is_file():
                 continue
 
-            with errors_file.open() as f:
+            with errors_file.open(encoding="utf_8_sig") as f:
                 expected_errors[sbom] = json.load(f)
 
         metafunc.parametrize(

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -11,14 +11,14 @@ from cdxev.__main__ import main
 
 
 def load_sbom(path: Path) -> dict:
-    with path.open() as f:
+    with path.open(encoding="utf_8_sig") as f:
         sbom = json.load(f)
     delete_non_reproducible(sbom)
     return sbom
 
 
 def load_list(path: Path) -> dict:
-    with path.open() as f:
+    with path.open(encoding="utf_8_sig") as f:
         list = f.read()
     return list
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -356,7 +356,7 @@ class TestListCommand:
     def data(self, data_dir: Path, request: pytest.FixtureRequest) -> DataFixture:
         input_path = data_dir / request.param["input"]
         expected_path = data_dir / request.param["expected"]
-        with open(expected_path, "r") as file:
+        with open(expected_path, "r", encoding="utf_8_sig") as file:
             expected_json = json.load(file)
 
         return self.DataFixture(
@@ -377,7 +377,9 @@ class TestListCommand:
         assert exit_code == Status.OK
 
         # Verify that output matches what is expected
-        with open("tests/integration/data/list_command/list_licenses.csv", "r") as file:
+        with open(
+            "tests/integration/data/list_command/list_licenses.csv", "r", encoding="utf_8_sig"
+        ) as file:
             file_contents = file.read()
         assert actual == file_contents
 
@@ -394,7 +396,9 @@ class TestListCommand:
         assert exit_code == Status.OK
 
         # Verify that output matches what is expected
-        with open("tests/integration/data/list_command/list_components.csv", "r") as file:
+        with open(
+            "tests/integration/data/list_command/list_components.csv", "r", encoding="utf_8_sig"
+        ) as file:
             file_contents = file.read()
         assert actual == file_contents
 
@@ -411,7 +415,9 @@ class TestListCommand:
         assert exit_code == Status.OK
 
         # Verify that output matches what is expected
-        with open("tests/integration/data/list_command/list_licenses.txt", "r") as file:
+        with open(
+            "tests/integration/data/list_command/list_licenses.txt", "r", encoding="utf_8_sig"
+        ) as file:
             file_contents = file.read()
         assert actual == file_contents
 
@@ -428,7 +434,9 @@ class TestListCommand:
         assert exit_code == Status.OK
 
         # Verify that output matches what is expected
-        with open("tests/integration/data/list_command/list_components.txt", "r") as file:
+        with open(
+            "tests/integration/data/list_command/list_components.txt", "r", encoding="utf_8_sig"
+        ) as file:
             file_contents = file.read()
         assert actual == file_contents
 
@@ -1100,7 +1108,7 @@ class TestValidate:
 
         # Assert that the report file exists and has the expected structure
         assert report_path.is_file()
-        with open(report_path) as f:
+        with open(report_path, encoding="utf_8_sig") as f:
             report = json.load(f)
         assert "issues" in report
         assert len(report["issues"]) == 1
@@ -1122,7 +1130,7 @@ class TestValidate:
 
         # Assert that the report file exists and has the expected structure
         assert report_path.is_file()
-        with open(report_path) as f:
+        with open(report_path, encoding="utf_8_sig") as f:
             report = json.load(f)
         assert len(report) == 1
         assert "check_name" in report[0]
@@ -1276,7 +1284,7 @@ class TestVex:
         expected_vex = load_sbom(expected_path)
         expected_search = load_sbom(expected_search_path)
         expected_trim = load_sbom(expected_trim_path)
-        with expected_list_path.open() as file:
+        with expected_list_path.open(encoding="utf_8_sig") as file:
             expected_list = file.read()
 
         return self.DataFixture(

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -26,7 +26,7 @@ class AmendTestCase(unittest.TestCase):
     operation: Operation
 
     def setUp(self) -> None:
-        with open(path_to_folder_with_test_sboms + "test.cdx.json", encoding="utf_8") as file:
+        with open(path_to_folder_with_test_sboms + "test.cdx.json", encoding="utf_8_sig") as file:
             self.sbom_fixture = json.load(file)
 
     def test_no_metadata_component_doesnt_raise(self) -> None:

--- a/tests/test_build_public_bom.py
+++ b/tests/test_build_public_bom.py
@@ -56,20 +56,20 @@ path_to_documentation_schema_4 = Path(os.path.abspath(relative_path_to_documenta
 
 
 def get_sbom(pathsbom: str) -> dict:
-    with open(pathsbom, "r") as read_file:
+    with open(pathsbom, "r", encoding="utf_8_sig") as read_file:
         sbom = json.load(read_file)
     return sbom
 
 
 def dumpsbom(sbom: dict, name: str = "watchsbom.json") -> None:
-    with open(name, "w") as write_file:
+    with open(name, "w", encoding="utf_8") as write_file:
         json.dump(sbom, write_file, indent=4)
 
 
 class TestCreateInternalValidator(unittest.TestCase):
     def test_valid_schema(self) -> None:
         validator = b_p_b.create_internal_validator(path_to_example_schema_1)
-        with path_to_example_schema_1.open() as schema_f:
+        with path_to_example_schema_1.open(encoding="utf_8_sig") as schema_f:
             schema_internal = json.load(schema_f)
         self.assertTrue(validator.is_valid(schema_internal))
 

--- a/tests/test_io_processing.py
+++ b/tests/test_io_processing.py
@@ -255,7 +255,7 @@ class OutputToFileTestCase(unittest.TestCase):
         path = pathlib.Path("output.json")
 
         out.write_sbom(sbom, path, False)
-        output = path.read_text()
+        output = path.read_text(encoding="utf_8_sig")
 
         self.assertEqual(expected, output)
 
@@ -266,7 +266,7 @@ class OutputToFileTestCase(unittest.TestCase):
         path = pathlib.Path("doesnotexist") / "output.json"
 
         out.write_sbom(sbom, path, False)
-        output = path.read_text()
+        output = path.read_text(encoding="utf_8_sig")
 
         self.assertEqual(expected, output)
 
@@ -281,5 +281,5 @@ class OutputToFileTestCase(unittest.TestCase):
 
         self.assertTrue(expected_file_path.is_file())
 
-        output = expected_file_path.read_text()
+        output = expected_file_path.read_text(encoding="utf_8_sig")
         self.assertEqual(expected, output)

--- a/tests/test_list_command.py
+++ b/tests/test_list_command.py
@@ -10,7 +10,7 @@ path_to_sbom = (
 
 
 def get_test_sbom(path_sbom: str = path_to_sbom) -> dict:
-    with open(path_sbom, "r") as read_file:
+    with open(path_sbom, "r", encoding="utf_8_sig") as read_file:
         sbom = json.load(read_file)
     return sbom
 

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -42,7 +42,7 @@ class SetTestCase(unittest.TestCase):
     sample_coordinates = {"name": "mylibrary", "group": "acme", "version": "0.2.4"}
 
     def setUp(self) -> None:
-        with open("tests/auxiliary/test_set_sboms/test.cdx.json", encoding="utf_8") as file:
+        with open("tests/auxiliary/test_set_sboms/test.cdx.json", encoding="utf_8_sig") as file:
             self.sbom_fixture = json.load(file)
 
     def test_add_property(self) -> None:
@@ -557,7 +557,7 @@ class TestVersionRange(unittest.TestCase):
                 "tests/auxiliary/test_set_sboms/Acme_Application_"
                 "9.1.1_ec7781220ec7781220ec778122012345_20220217T101458.cdx.json"
             ),
-            encoding="utf_8",
+            encoding="utf_8_sig",
         ) as file:
             self.sbom_fixture = json.load(file)
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -63,7 +63,7 @@ def validate_test(
 
 
 def get_test_sbom(path_bom: str = path_to_sbom) -> dict:
-    with open(path_bom, "r") as read_file:
+    with open(path_bom, "r", encoding="utf_8_sig") as read_file:
         sbom = json.load(read_file)
     return sbom
 

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -10,7 +10,7 @@ path_to_test_folder = "tests/auxiliary/test_vex/"
 
 
 def load_file(file_path: Path) -> dict:
-    with open(path_to_test_folder + file_path, "r", encoding="utf-8-sig") as my_file:
+    with open(path_to_test_folder + file_path, "r", encoding="utf_8_sig") as my_file:
         vex_file = json.load(my_file)
     return vex_file
 
@@ -209,7 +209,7 @@ class TestVulnerabilityFunctions(unittest.TestCase):
         self.assertEqual(len(result["vulnerabilities"]), 1)
 
     def test_vex_extract_command(self):
-        with open(path_to_test_folder + "embedded_vex.json", "r", encoding="utf-8-sig") as my_file:
+        with open(path_to_test_folder + "embedded_vex.json", "r", encoding="utf_8_sig") as my_file:
             embedded_vex = json.load(my_file)
         result = vex.vex("extract", embedded_vex, "", "", "", "")
         self.assertEqual(result["vulnerabilities"], embedded_vex["vulnerabilities"])


### PR DESCRIPTION
Currently, the app writes output for some commands without specifying a character encoding. This makes Python resort to the system-default encoding (at least on my Windows 11 machine that's CP1512, not Unicode). When presented with Unicode data, this crashed the app on output.
I stumbled over this problem when the *list* command crashed for my SBOM.

This PR uniformly defines the following encodings for all file I/O:
* `utf_8_sig` for reading
* `utf_8` for writing

It also replaces previous mentions of `utf-8-sig` and `utf-8` (with dashes instead of underscores) with the canonical names with underscores.