### PR TITLE
fix: adapt vulnerability identities when merging several SBOMs

### DIFF
--- a/cdxev/auxiliary/identity.py
+++ b/cdxev/auxiliary/identity.py
@@ -277,9 +277,15 @@ class VulnerabilityIdentity:
             raise TypeError(f"Can not compare {type(other)} with VulnerabilityIdentity")
         return self.one_of_ids_is_in(other.aliases)
 
+    def __hash__(self) -> int:
+        # __eq__ is hierarchical and non-transitive: two identities may compare equal via
+        # different shared aliases, so no alias-derived hash can satisfy the contract
+        # "equal objects have equal hashes."
+        # A constant hash keeps dict/set semantics correct, though operations degrade to O(n).
+        return 0
+
     def __str__(self) -> str:
-        if id not in self.aliases:  # type: ignore[comparison-overlap]
-            string = self.id
+        string = self.id or (self.aliases[0] if self.aliases else "")
         for ref in self.aliases:
             if ref not in string:
                 string += "_|_" + ref

--- a/cdxev/auxiliary/sbom_functions.py
+++ b/cdxev/auxiliary/sbom_functions.py
@@ -480,19 +480,48 @@ def collect_affects_of_vulnerabilities(
     if list_of_original_vulnerabilities:
         for n in range(len(list_of_original_vulnerabilities)):
             # use json string of vulnerability in case the vulnerability does not contain any id
-            id = identities[json.dumps(list_of_original_vulnerabilities[n], sort_keys=True)]
+            id = get_identity_for_vulnerability(list_of_original_vulnerabilities[n], identities)
             affects = deepcopy(list_of_original_vulnerabilities[n].get("affects", []))
             if id.string() not in collected_affects.keys():
                 for k in range(n + 1, len(list_of_original_vulnerabilities)):
-                    new_id = identities[
-                        json.dumps(list_of_original_vulnerabilities[k], sort_keys=True)
-                    ]
+                    new_id = get_identity_for_vulnerability(
+                        list_of_original_vulnerabilities[k], identities
+                    )
 
                     if id == new_id:
                         affects += list_of_original_vulnerabilities[k].get("affects", [])
 
                 collected_affects[id.string()] = affects
     return collected_affects
+
+
+def get_identity_for_vulnerability(
+    vulnerability: dict,
+    identities: dict[str, VulnerabilityIdentity],
+) -> VulnerabilityIdentity:
+    """
+    Return a vulnerability identity for the given vulnerability object.
+
+    The lookup first tries the JSON-serialized vulnerability key used by
+    get_identities_for_vulnerabilities(). If no direct key is found (for example,
+    after vulnerabilities were merged and their affects lists changed), it falls
+    back to alias-based identity matching and caches the result.
+    """
+    vulnerability_string = json.dumps(vulnerability, sort_keys=True)
+    identity = identities.get(vulnerability_string)
+    if identity is not None:
+        return identity
+
+    aliases = VulnerabilityIdentity.get_ids_from_vulnerability(vulnerability)
+    for identity in identities.values():
+        if identity.one_of_ids_is_in(aliases):
+            identities[vulnerability_string] = identity
+            return identity
+
+    # No matching identity exists yet (e.g. empty IDs); create and cache one.
+    created_identity = VulnerabilityIdentity(aliases[0] if aliases else "", aliases)
+    identities[vulnerability_string] = created_identity
+    return created_identity
 
 
 def compare_version_range(first_range: str, second_range: str) -> bool:

--- a/cdxev/auxiliary/sbom_functions.py
+++ b/cdxev/auxiliary/sbom_functions.py
@@ -479,10 +479,12 @@ def collect_affects_of_vulnerabilities(
     collected_affects: dict[str, list[dict]] = {}
     if list_of_original_vulnerabilities:
         for n in range(len(list_of_original_vulnerabilities)):
-            # use json string of vulnerability in case the vulnerability does not contain any id
+            # Key by identity string for id/alias vulnerabilities, and by vulnerability JSON only
+            # when that identity string is empty to avoid collisions for distinct empty-id entries.
             id = get_identity_for_vulnerability(list_of_original_vulnerabilities[n], identities)
+            affects_key = _affects_key_for(id, list_of_original_vulnerabilities[n])
             affects = deepcopy(list_of_original_vulnerabilities[n].get("affects", []))
-            if id.string() not in collected_affects.keys():
+            if affects_key not in collected_affects.keys():
                 for k in range(n + 1, len(list_of_original_vulnerabilities)):
                     new_id = get_identity_for_vulnerability(
                         list_of_original_vulnerabilities[k], identities
@@ -491,8 +493,21 @@ def collect_affects_of_vulnerabilities(
                     if id == new_id:
                         affects += list_of_original_vulnerabilities[k].get("affects", [])
 
-                collected_affects[id.string()] = affects
+                collected_affects[affects_key] = affects
     return collected_affects
+
+
+def _affects_key_for(identity: VulnerabilityIdentity, vulnerability: dict) -> str:
+    """Stable key for collected affects entries.
+
+    Vulnerabilities with id/alias information are keyed by identity string so related
+    vulnerability objects share one affects bucket. Empty-id vulnerabilities would all have an
+    empty identity string, so they are keyed by their JSON representation to avoid collisions.
+    """
+    key = identity.string()
+    if key:
+        return key
+    return json.dumps(vulnerability, sort_keys=True)
 
 
 def get_identity_for_vulnerability(
@@ -506,6 +521,8 @@ def get_identity_for_vulnerability(
     get_identities_for_vulnerabilities(). If no direct key is found (for example,
     after vulnerabilities were merged and their affects lists changed), it falls
     back to alias-based identity matching and caches the result.
+    The alias fallback is O(n) over identities per cache miss, and misses can recur as affects
+    mutate across successive merges because the cache key is the current vulnerability JSON.
     """
     vulnerability_string = json.dumps(vulnerability, sort_keys=True)
     identity = identities.get(vulnerability_string)

--- a/cdxev/merge.py
+++ b/cdxev/merge.py
@@ -6,6 +6,7 @@ import typing as t
 
 from cdxev.auxiliary.identity import ComponentIdentity, VulnerabilityIdentity
 from cdxev.auxiliary.sbom_functions import (
+    _affects_key_for,
     CycloneDXVersion,
     SpecVersion,
     add_merged_metadata_component_to_dependencies,
@@ -843,7 +844,12 @@ def merge_vulnerabilities(
                     # ranges must be checked as a whole
 
                     new_affects = extract_new_affects(
-                        collected_affects[id_object_original_vulnerability.string()],
+                        collected_affects[
+                            _affects_key_for(
+                                id_object_original_vulnerability,
+                                original_vulnerability,
+                            )
+                        ],
                         new_vulnerability.get("affects", []),
                         original_vulnerability.get("id", ""),
                         keep_version_overlap=True,
@@ -873,7 +879,12 @@ def merge_vulnerabilities(
             # is equal to one with the entry "<=3.0.0" but for this the ranges must be checked
             # as a whole
             new_affects = extract_new_affects(
-                collected_affects[id_object_original_vulnerability.string()],
+                collected_affects[
+                    _affects_key_for(
+                        id_object_original_vulnerability,
+                        original_vulnerability,
+                    )
+                ],
                 new_vulnerability.get("affects", []),
                 original_vulnerability.get("id", ""),
                 different_analysis=True,

--- a/cdxev/merge.py
+++ b/cdxev/merge.py
@@ -6,9 +6,9 @@ import typing as t
 
 from cdxev.auxiliary.identity import ComponentIdentity, VulnerabilityIdentity
 from cdxev.auxiliary.sbom_functions import (
-    _affects_key_for,
     CycloneDXVersion,
     SpecVersion,
+    _affects_key_for,
     add_merged_metadata_component_to_dependencies,
     collect_affects_of_vulnerabilities,
     extract_components,

--- a/cdxev/merge.py
+++ b/cdxev/merge.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import copy
-import json
 import logging
 import typing as t
 
@@ -16,6 +15,7 @@ from cdxev.auxiliary.sbom_functions import (
     get_bom_refs_from_dependencies,
     get_dependency_by_ref,
     get_identities_for_vulnerabilities,
+    get_identity_for_vulnerability,
     make_bom_refs_unique,
     merge_affects_versions,
     unify_bom_refs,
@@ -786,11 +786,13 @@ def merge_vulnerabilities(
     for original_vulnerability in list_of_original_vulnerabilities:
         is_in = False
         same_affects_state = False
-        id_str_original_vulnerability = json.dumps(original_vulnerability, sort_keys=True)
-        id_object_original_vulnerability = vulnerability_identities[id_str_original_vulnerability]
+        id_object_original_vulnerability = get_identity_for_vulnerability(
+            original_vulnerability, vulnerability_identities
+        )
         for new_vulnerability in list_of_new_vulnerabilities:
-            id_str_new_vulnerability = json.dumps(new_vulnerability, sort_keys=True)
-            id_object_new_vulnerability = vulnerability_identities[id_str_new_vulnerability]
+            id_object_new_vulnerability = get_identity_for_vulnerability(
+                new_vulnerability, vulnerability_identities
+            )
             if id_object_new_vulnerability == id_object_original_vulnerability:
                 is_in = True
                 if original_vulnerability.get("analysis", {}).get(
@@ -810,16 +812,16 @@ def merge_vulnerabilities(
         # all provided vulnerabilities are analysed during intitialization and a registry with
         # the respective references is created, the vulnerabilities are then mapped according to
         # this registry
-        id_str_new_vulnerability = json.dumps(new_vulnerability, sort_keys=True)
-        id_object_new_vulnerability = vulnerability_identities[id_str_new_vulnerability]
+        id_object_new_vulnerability = get_identity_for_vulnerability(
+            new_vulnerability, vulnerability_identities
+        )
 
         # The loop is over the original vulnerabilities and not the merged ones to avoid
         # data losses in the case of duplicate entries in new_vulnerabilities
         for original_vulnerability in list_of_original_vulnerabilities:
-            id_str_original_vulnerability = json.dumps(original_vulnerability, sort_keys=True)
-            id_object_original_vulnerability = vulnerability_identities[
-                id_str_original_vulnerability
-            ]
+            id_object_original_vulnerability = get_identity_for_vulnerability(
+                original_vulnerability, vulnerability_identities
+            )
             # objects describe the same vulnerability
             if id_object_new_vulnerability == id_object_original_vulnerability:
                 is_in = True

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1929,7 +1929,7 @@ class TestMergeSeveralSboms(unittest.TestCase):
             "vulnerabilities": [
                 {
                     "id": "CVE-STATE",
-                    "analysis": {"state": "affected"},
+                    "analysis": {"state": "exploitable"},
                     "affects": [{"ref": "state-2", "versions": [{"status": "affected"}]}],
                 }
             ],

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1724,6 +1724,246 @@ class TestMergeSeveralSboms(unittest.TestCase):
             {"vtep_application", "vtep_bootloader", "vtep_bootselector"},
         )
 
+    def test_merge_3_sboms_alias_only_match(self) -> None:
+        sbom_1 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-A",
+                    "references": [{"id": "GHSA-shared"}],
+                    "analysis": {"state": "not_affected"},
+                    "affects": [{"ref": "comp-a", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+        sbom_2 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-B",
+                    "references": [{"id": "GHSA-shared"}],
+                    "analysis": {"state": "not_affected"},
+                    "affects": [{"ref": "comp-b", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+        sbom_3 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-C",
+                    "references": [{"id": "GHSA-shared"}],
+                    "analysis": {"state": "not_affected"},
+                    "affects": [{"ref": "comp-c", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+
+        merged_bom = merge.merge([sbom_1, sbom_2, sbom_3])
+        vulnerabilities = merged_bom.get("vulnerabilities", [])
+
+        self.assertEqual(len(vulnerabilities), 1)
+        refs = {affected.get("ref") for affected in vulnerabilities[0].get("affects", [])}
+        self.assertSetEqual(refs, {"comp-a", "comp-b", "comp-c"})
+
+    def test_merge_3_sboms_distinct_vulns_not_over_merged(self) -> None:
+        sbom_1 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-1",
+                    "analysis": {"state": "not_affected"},
+                    "affects": [{"ref": "comp-1", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+        sbom_2 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-2",
+                    "analysis": {"state": "not_affected"},
+                    "affects": [{"ref": "comp-2", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+        sbom_3 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-3",
+                    "analysis": {"state": "not_affected"},
+                    "affects": [{"ref": "comp-3", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+
+        merged_bom = merge.merge([sbom_1, sbom_2, sbom_3])
+        vulnerabilities = merged_bom.get("vulnerabilities", [])
+
+        self.assertEqual(len(vulnerabilities), 3)
+        refs = {
+            affected.get("ref")
+            for vulnerability in vulnerabilities
+            for affected in vulnerability.get("affects", [])
+        }
+        self.assertSetEqual(refs, {"comp-1", "comp-2", "comp-3"})
+
+    def test_merge_3_sboms_empty_id_vulns_preserve_affects(self) -> None:
+        sbom_1 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "analysis": {"state": "not_affected"},
+                    "affects": [{"ref": "empty-1", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+        sbom_2 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "analysis": {"state": "not_affected"},
+                    "affects": [{"ref": "empty-2", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+        sbom_3 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "analysis": {"state": "not_affected"},
+                    "affects": [{"ref": "empty-3", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+
+        merged_bom = merge.merge([sbom_1, sbom_2, sbom_3])
+        vulnerabilities = merged_bom.get("vulnerabilities", [])
+
+        self.assertEqual(len(vulnerabilities), 3)
+        refs = {
+            affected.get("ref")
+            for vulnerability in vulnerabilities
+            for affected in vulnerability.get("affects", [])
+        }
+        self.assertSetEqual(refs, {"empty-1", "empty-2", "empty-3"})
+
+    def test_merge_4_sboms_intermediate_mutation(self) -> None:
+        sbom_1 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-2023-1111",
+                    "analysis": {"state": "not_affected"},
+                    "affects": [{"ref": "comp-1", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+        sbom_2 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-2023-1111",
+                    "analysis": {"state": "not_affected"},
+                    "affects": [{"ref": "comp-2", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+        sbom_3 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-2023-1111",
+                    "analysis": {"state": "not_affected"},
+                    "affects": [{"ref": "comp-3", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+        sbom_4 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-2023-1111",
+                    "analysis": {"state": "not_affected"},
+                    "affects": [{"ref": "comp-4", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+
+        merged_bom = merge.merge([sbom_1, sbom_2, sbom_3, sbom_4])
+        vulnerabilities = merged_bom.get("vulnerabilities", [])
+
+        self.assertEqual(len(vulnerabilities), 1)
+        refs = {affected.get("ref") for affected in vulnerabilities[0].get("affects", [])}
+        self.assertSetEqual(refs, {"comp-1", "comp-2", "comp-3", "comp-4"})
+
+    def test_merge_3_sboms_differing_analysis_state(self) -> None:
+        sbom_1 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-STATE",
+                    "analysis": {"state": "not_affected"},
+                    "affects": [{"ref": "state-1", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+        sbom_2 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-STATE",
+                    "analysis": {"state": "affected"},
+                    "affects": [{"ref": "state-2", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+        sbom_3 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-STATE",
+                    "analysis": {"state": "exploitable"},
+                    "affects": [{"ref": "state-3", "versions": [{"status": "affected"}]}],
+                }
+            ],
+        }
+
+        merged_bom = merge.merge([sbom_1, sbom_2, sbom_3])
+        vulnerabilities = merged_bom.get("vulnerabilities", [])
+
+        self.assertEqual(len(vulnerabilities), 3)
+        refs_by_state = {
+            vulnerability.get("analysis", {}).get("state", ""):
+            {affected.get("ref") for affected in vulnerability.get("affects", [])}
+            for vulnerability in vulnerabilities
+        }
+        self.assertDictEqual(
+            refs_by_state,
+            {
+                "not_affected": {"state-1"},
+                "affected": {"state-2"},
+                "exploitable": {"state-3"},
+            },
+        )
+
     def _load_reference_sbom(self, spec_version: str) -> dict:
         with open(
             "tests/auxiliary/test_validate_sboms/"

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1951,8 +1951,9 @@ class TestMergeSeveralSboms(unittest.TestCase):
 
         self.assertEqual(len(vulnerabilities), 3)
         refs_by_state = {
-            vulnerability.get("analysis", {}).get("state", ""):
-            {affected.get("ref") for affected in vulnerability.get("affects", [])}
+            vulnerability.get("analysis", {}).get("state", ""): {
+                affected.get("ref") for affected in vulnerability.get("affects", [])
+            }
             for vulnerability in vulnerabilities
         }
         self.assertDictEqual(

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1929,7 +1929,7 @@ class TestMergeSeveralSboms(unittest.TestCase):
             "vulnerabilities": [
                 {
                     "id": "CVE-STATE",
-                    "analysis": {"state": "exploitable"},
+                    "analysis": {"state": "false_positive"},
                     "affects": [{"ref": "state-2", "versions": [{"status": "affected"}]}],
                 }
             ],
@@ -1959,7 +1959,7 @@ class TestMergeSeveralSboms(unittest.TestCase):
             refs_by_state,
             {
                 "not_affected": {"state-1"},
-                "affected": {"state-2"},
+                "false_positive": {"state-2"},
                 "exploitable": {"state-3"},
             },
         )

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1662,6 +1662,68 @@ class TestMergeToolsBomRefUniqueness(unittest.TestCase):
 
 
 class TestMergeSeveralSboms(unittest.TestCase):
+    def test_merge_3_sboms_vulnerability_identity_after_intermediate_merge(self) -> None:
+        sbom_1 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-2023-7158",
+                    "analysis": {"state": "not_affected"},
+                    "affects": [
+                        {
+                            "ref": "vtep_application",
+                            "versions": [{"status": "unaffected", "version": "1.10.0"}],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        sbom_2 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-2023-7158",
+                    "analysis": {"state": "not_affected"},
+                    "affects": [
+                        {
+                            "ref": "vtep_bootloader",
+                            "versions": [{"status": "unaffected", "version": "5.1.0"}],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        sbom_3 = {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "vulnerabilities": [
+                {
+                    "id": "CVE-2023-7158",
+                    "analysis": {"state": "not_affected"},
+                    "affects": [
+                        {
+                            "ref": "vtep_bootselector",
+                            "versions": [{"status": "unaffected", "version": "1.0.0"}],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        merged_bom = merge.merge([sbom_1, sbom_2, sbom_3])
+        vulnerabilities = merged_bom.get("vulnerabilities", [])
+
+        self.assertEqual(len(vulnerabilities), 1)
+        refs = {affected.get("ref") for affected in vulnerabilities[0].get("affects", [])}
+        self.assertSetEqual(
+            refs,
+            {"vtep_application", "vtep_bootloader", "vtep_bootselector"},
+        )
+
     def _load_reference_sbom(self, spec_version: str) -> dict:
         with open(
             "tests/auxiliary/test_validate_sboms/"


### PR DESCRIPTION
When merging several SBOMs the references used in affects of a vulnerability can be overwrittten. Since the identities are determined in the beginning, this can lead to a crash.