### PR TITLE
fix: add missing license expression file

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -29,6 +29,7 @@ export PYTHONPATH="$FUZZ_DIR:${PYTHONPATH:-}"
 DATA_ARGS=(
   "--add-data=$REPO_DIR/cdxev/amend/license_name_spdx_id_map.json:cdxev/amend"
   "--add-data=$REPO_DIR/cdxev/auxiliary/schema:cdxev/auxiliary/schema"
+  "--collect-data=license_expression"
   "--copy-metadata=cyclonedx-editor-validator"
 )
 


### PR DESCRIPTION
Our fuzzing did not work anymore, which was, according to the logs, because of the missing file for license expression/ref from scancode db